### PR TITLE
[core] API parameters from environment variables

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -55,8 +55,8 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     :type statsd_port: port
     """
     # Configure api
-    api._api_key = api_key
-    api._application_key = app_key
+    api._api_key = api_key if api_key is not None else os.environ.get('DATADOG_API_KEY')
+    api._application_key = app_key if app_key is not None else os.environ.get('DATADOG_APP_KEY')
     api._host_name = host_name if host_name is not None else get_hostname()
     api._api_host = api_host if api_host is not None else \
         os.environ.get('DATADOG_HOST', 'https://app.datadoghq.com')


### PR DESCRIPTION
Allows users to set their API and application keys via `DATADOG_API_KEY ` and `DATADOG_APP_KEY ` like we do for the API host with `DATADOG_HOST `.

Fix https://github.com/DataDog/dogapi/issues/133