### PR TITLE
v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+0.6.0 / 2015.05.27
+==================
+* [FEATURE] Add `message` parameter support to host muting commands, [#51][]
+* [BUGFIX] Always fall back when unable to determine hostname from `datadog.conf`, [#53][]
+
 0.5.0 / 2015.05.19
 ==================
 * [FEATURE] Add support for metric query API, [#45][]
@@ -64,5 +69,7 @@ See [#8][], thanks [@benweatherman][]
 [#43]: https://github.com/DataDog/datadogpy/issues/43
 [#45]: https://github.com/DataDog/datadogpy/issues/45
 [#47]: https://github.com/DataDog/datadogpy/issues/47
+[#51]: https://github.com/DataDog/datadogpy/issues/51
+[#53]: https://github.com/DataDog/datadogpy/issues/53
 [@benweatherman]: https://github.com/benweatherman
 [@miketheman]: https://github.com/miketheman

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if [sys.version_info[0], sys.version_info[1]] < [2, 7]:
 
 setup(
     name="datadog",
-    version="0.5.0",
+    version="0.6.0",
     install_requires=install_reqs,
     tests_require=["tox", "nose", "mock", "six", "pillow"],
     packages=[


### PR DESCRIPTION
* [FEATURE] Add `message` parameter support to host muting commands, [#51][]
* [BUGFIX] Always fall back when unable to determine hostname from `datadog.conf`, [#53][]
[#51]: https://github.com/DataDog/datadogpy/issues/51
[#53]: https://github.com/DataDog/datadogpy/issues/53