### PR TITLE
Fix Metric.send() to play nice with multiple metrics

### DIFF
--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -53,7 +53,8 @@ class Metric(SearchableAPIResource, SendableAPIResource):
                 for metric in metrics:
                     if isinstance(metric, dict):
                         metric['points'] = cls._process_points(metric['points'])
-                metrics_dict = {"series": metrics[0]}
+                #metrics_dict = {"series": metrics[0]}
+                metrics_dict = {"series": metrics}
             else:
                 single_metric['points'] = cls._process_points(single_metric['points'])
                 metrics = [single_metric]

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -53,7 +53,6 @@ class Metric(SearchableAPIResource, SendableAPIResource):
                 for metric in metrics:
                     if isinstance(metric, dict):
                         metric['points'] = cls._process_points(metric['points'])
-                #metrics_dict = {"series": metrics[0]}
                 metrics_dict = {"series": metrics}
             else:
                 single_metric['points'] = cls._process_points(single_metric['points'])

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -205,3 +205,36 @@ class TestResources(DatadogAPIWithInitialization):
         Metric.query(start="val1", end="val2")
         self.request_called_with('GET', "host/api/v1/query",
                                  params={'from': "val1", 'to': "val2"})
+
+    def test_metric_submit_multiple(self):
+        """"""
+        from copy import deepcopy
+        import json
+        from time import time
+
+        now = time()
+
+        data = [dict(metric='metric.1', points=13),
+                dict(metric='metric.2', points=19)]
+
+        Metric.send(*deepcopy(data))
+        #Metric.send(deepcopy(data))
+
+        args, kwargs = self.request_mock.request.call_args
+        sent_data = json.loads(kwargs['data'])
+        #print(args)
+        #print(kwargs)
+        #print(sent_data)
+
+        for i, metric in enumerate(sent_data['series']):
+            print(metric)
+            assert set(metric.keys()) == set(['metric', 'points', 'host'])
+
+            assert metric['metric'] == data[i]['metric']
+            assert metric['host'] == api._host_name
+
+            assert isinstance(metric['points'], list) and len(metric['points']) == 1 # there's array of 1 point
+            assert len(metric['points'][0]) == 2 # it consists of a [time, value] pair
+            assert metric['points'][0][1] == data[i]['points'] # its value == value we sent
+            assert now - 1 < metric['points'][0][0] < now + 1 # it's time not so far from current time
+

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -206,8 +206,7 @@ class TestResources(DatadogAPIWithInitialization):
         self.request_called_with('GET', "host/api/v1/query",
                                  params={'from': "val1", 'to': "val2"})
 
-    def test_metric_submit_multiple(self):
-        """"""
+    def test_metric_submit_multiple_points_is_single_value(self):
         from copy import deepcopy
         import json
         from time import time
@@ -218,23 +217,22 @@ class TestResources(DatadogAPIWithInitialization):
                 dict(metric='metric.2', points=19)]
 
         Metric.send(*deepcopy(data))
-        #Metric.send(deepcopy(data))
 
         args, kwargs = self.request_mock.request.call_args
         sent_data = json.loads(kwargs['data'])
-        #print(args)
-        #print(kwargs)
-        #print(sent_data)
 
         for i, metric in enumerate(sent_data['series']):
-            print(metric)
             assert set(metric.keys()) == set(['metric', 'points', 'host'])
 
             assert metric['metric'] == data[i]['metric']
             assert metric['host'] == api._host_name
 
-            assert isinstance(metric['points'], list) and len(metric['points']) == 1 # there's array of 1 point
-            assert len(metric['points'][0]) == 2 # it consists of a [time, value] pair
-            assert metric['points'][0][1] == data[i]['points'] # its value == value we sent
-            assert now - 1 < metric['points'][0][0] < now + 1 # it's time not so far from current time
+            # points is a list of 1 point
+            assert isinstance(metric['points'], list) and len(metric['points']) == 1
+            # it consists of a [time, value] pair
+            assert len(metric['points'][0]) == 2
+            # its value == value we sent
+            assert metric['points'][0][1] == data[i]['points']
+            # it's time not so far from current time
+            assert now - 1 < metric['points'][0][0] < now + 1
 


### PR DESCRIPTION
In short, method signature and usage (http://docs.datadoghq.com/api/#metrics) is different and misguiding. Also, it will send the wrong data if user pass list of metrics with `points` as a single value. Below is a detailed explanation.

Here's a Metric.send() method without docstrings:
```python
    @classmethod
    def send(cls, *metrics, **single_metric):
        try:
            if metrics:
                for metric in metrics:
                    if isinstance(metric, dict):
                        metric['points'] = cls._process_points(metric['points'])
                metrics_dict = {"series": metrics[0]}
            else:
                single_metric['points'] = cls._process_points(single_metric['points'])
                metrics = [single_metric]
                metrics_dict = {"series": metrics}

        except KeyError:
            raise KeyError("'points' parameter is required")

        return super(Metric, cls).send(attach_host_name=True, **metrics_dict)
```
There're few issues with it:

1. Method signature says it accepts arbitrary number of metrics, but api docs says it should be used with a single list, not multiple positional args. It really misguiding users.

2. If you pass a list of metrics as a single positional argument, `metrics` will be a list of a sinle list (`[[your metrics here]]`). Let's see what happens next.
`for metric in metrics` will take a list of metrics and compare it with a dict - indeed, list is not a dict, so no calls to cls._process_points(). It will absolutely not change `metrics` in any way. Since `points` must be a list of lists of timestamp and a value `[[timestamp, value]]`, wrong data will be sent. Though datadog api will say `202 Accepted`, it will not not accept any data at all.

3. We can pass metrics as arbitrary args (`Metric.send(*metrics)`), and it will call `_process_points()` and transform data in the right way. But then it will take only first metric (it will be a dict), and since `series` must be a list, not a dict, we will get an error. And that's what I changed - 1 line of code.