### PR TITLE
Clarify monitor muting endpoints

### DIFF
--- a/datadog/api/base.py
+++ b/datadog/api/base.py
@@ -121,7 +121,7 @@ class HTTPClient(object):
                 cls._timeout_counter += 1
                 raise HttpTimeout('%s %s timed out after %d seconds.' % (method, url, _timeout))
             except requests.exceptions.HTTPError as e:
-                if e.response.status_code == 404 or e.response.status_code == 400:
+                if e.response.status_code in (400, 403, 404):
                     pass
                 else:
                     raise

--- a/datadog/api/monitors.py
+++ b/datadog/api/monitors.py
@@ -72,6 +72,9 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
         :param scope: scope to apply the unmute
         :type scope: string
 
+        :param all_scopes: if True, clears mute settings for all scopes
+        :type all_scopes: boolean
+
         :returns: JSON response from HTTP request
         """
         return super(Monitor, cls)._trigger_class_action('POST', 'unmute', id, **params)
@@ -79,7 +82,7 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
     @classmethod
     def mute_all(cls):
         """
-        Mute all monitors.
+        Globally mute monitors.
 
         :returns: JSON response from HTTP request
         """
@@ -88,7 +91,7 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
     @classmethod
     def unmute_all(cls):
         """
-        Unmute all monitors.
+        Cancel global monitor mute setting (does not remove mute settings for individual monitors).
 
         :returns: JSON response from HTTP request
         """

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -66,6 +66,8 @@ class MonitorClient(object):
         unmute_parser.add_argument('monitor_id', help="monitor to unmute")
         unmute_parser.add_argument('--scope', help="scope to unmute (must be muted), "
                                    "e.g. role:db", default=[])
+        unmute_parser.add_argument('--all_scopes', help="clear muting across all scopes",
+                                   action='store_true')
         unmute_parser.set_defaults(func=cls._unmute)
 
     @classmethod
@@ -196,8 +198,10 @@ class MonitorClient(object):
     @classmethod
     def _unmute(cls, args):
         api._timeout = args.timeout
-        # TODO CHECK
-        res = api.Monitor.unmute(args.monitor_id, scope=args.scope)
-        if res is not None:
-            report_warnings(res)
-            report_errors(res)
+        res = api.Monitor.unmute(args.monitor_id, scope=args.scope, all_scopes=args.all_scopes)
+        report_warnings(res)
+        report_errors(res)
+        if format == 'pretty':
+            print(cls._pretty_json(res))
+        else:
+            print(json.dumps(res))

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -46,23 +46,25 @@ class MonitorClient(object):
         delete_parser.add_argument('monitor_id', help="monitor to delete")
         delete_parser.set_defaults(func=cls._delete)
 
-        mute_all_parser = verb_parsers.add_parser('mute_all', help="Mute all monitors")
+        mute_all_parser = verb_parsers.add_parser('mute_all', help="Globally mute "
+                                                  "monitors (downtime over *)")
         mute_all_parser.set_defaults(func=cls._mute_all)
 
-        unmute_all_parser = verb_parsers.add_parser('unmute_all', help="Unmute all monitors")
+        unmute_all_parser = verb_parsers.add_parser('unmute_all', help="Globally unmute "
+                                                    "monitors (cancel downtime over *)")
         unmute_all_parser.set_defaults(func=cls._unmute_all)
 
         mute_parser = verb_parsers.add_parser('mute', help="Mute a monitor")
         mute_parser.add_argument('monitor_id', help="monitor to mute")
         mute_parser.add_argument('--scope', help="scope to apply the mute to,"
-                                 " e.g. role:db", default=[])
+                                 " e.g. role:db (optional)", default=[])
         mute_parser.add_argument('--end', help="POSIX timestamp for when"
-                                 " the mute should end", default=None)
+                                 " the mute should end (optional)", default=None)
         mute_parser.set_defaults(func=cls._mute)
 
         unmute_parser = verb_parsers.add_parser('unmute', help="Unmute a monitor")
         unmute_parser.add_argument('monitor_id', help="monitor to unmute")
-        unmute_parser.add_argument('--scope', help="scope to apply the mute to, "
+        unmute_parser.add_argument('--scope', help="scope to unmute (must be muted), "
                                    "e.g. role:db", default=[])
         unmute_parser.set_defaults(func=cls._unmute)
 

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -356,10 +356,8 @@ class TestDatadog(unittest.TestCase):
         dog.Metric.send(metric="test.metric", points=1.0)
         dog.Metric.send(metric="test.metric", points=(time.time(), 1.0))
 
+    @attr('monitor')
     def test_monitors(self):
-        # Stop testing 'silenced' parameter
-        # Depending on the enabled flag (i.e. API release), 'silenced' can be a boolean or a dictionnary
-
         query = "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100"
 
         monitor_id = dog.Monitor.create(query=query, type="metric alert")['id']
@@ -370,13 +368,15 @@ class TestDatadog(unittest.TestCase):
 
         options = {
             "notify_no_data": True,
-            "no_data_timeframe": 20
+            "no_data_timeframe": 20,
+            "silenced": {"*": None}
         }
-        dog.Monitor.update(monitor_id, query=query, silenced=True, options=options, timeout_h=1)
+        dog.Monitor.update(monitor_id, query=query, options=options, timeout_h=1)
         monitor = dog.Monitor.get(monitor_id)
         assert monitor['query'] == query, monitor['query']
         assert monitor['options']['notify_no_data'] == True, monitor['options']['notify_no_data']
-        assert monitor['options']['no_data_timeframe'] == 20, monitor['options']['notify_no_data']
+        assert monitor['options']['no_data_timeframe'] == 20, monitor['options']['no_data_timeframe']
+        assert monitor['options']['silenced'] == {"*": None}, monitor['options']['silenced']
 
         dog.Monitor.delete(monitor_id)
         try:
@@ -667,6 +667,17 @@ class TestDatadog(unittest.TestCase):
         monitor = dog.Monitor.get(monitor_id)
         eq(monitor['options']['silenced'], {})
 
+        options = {
+            "silenced": {"host:abcd1234": None, "host:abcd1235": None}
+        }
+        dog.Monitor.update(monitor_id, query=query, options=options)
+        monitor = dog.Monitor.get(monitor_id)
+        eq(monitor['options']['silenced'], options['silenced'])
+
+        dog.Monitor.unmute(monitor_id, all_scopes=True)
+        monitor = dog.Monitor.get(monitor_id)
+        eq(monitor['options']['silenced'], {})
+
         dog.Monitor.delete(monitor_id)
 
     @attr('monitor')
@@ -731,7 +742,7 @@ class TestDatadog(unittest.TestCase):
         eq(mute['action'], "Muted")
         eq(mute['end'], end2)
 
-        unmute = dog.Host.unmute(hostname)
+        dog.Host.unmute(hostname)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Adjust dogshell descriptions to distinguish between mute_all/unmute_all and mute/unmute
- Add new monitor unmute arg (`all_scopes`) to allow clearing all mute settings for a given monitor
- Update monitor mute tests
- Include additional information in 403 response exceptions