### PR TITLE
Yann/rebase send multiple metrics

### DIFF
--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -24,7 +24,7 @@ class Metric(SearchableAPIResource, SendableAPIResource):
         return points
 
     @classmethod
-    def send(cls, *metrics, **single_metric):
+    def send(cls, metrics=None, **single_metric):
         """
         Submit a metric or a list of metrics to the metric API
 

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -53,7 +53,7 @@ class Metric(SearchableAPIResource, SendableAPIResource):
                 for metric in metrics:
                     if isinstance(metric, dict):
                         metric['points'] = cls._process_points(metric['points'])
-                metrics_dict = {"series": metrics[0]}
+                metrics_dict = {"series": metrics}
             else:
                 single_metric['points'] = cls._process_points(single_metric['points'])
                 metrics = [single_metric]

--- a/tests/unit/api/helper.py
+++ b/tests/unit/api/helper.py
@@ -70,6 +70,13 @@ class DatadogAPITestCase(unittest.TestCase):
         self.request_mock = request_class_mock.return_value
         self.request_mock.request = Mock(return_value=MockReponse())
 
+    def get_request_data(self):
+        """
+
+        """
+        _, kwargs = self.request_mock.request.call_args
+        return json.loads(kwargs['data'])
+
     def request_called_with(self, method, url, data=None, params=None):
         (req_method, req_url), others = self.request_mock.request.call_args
         assert method == req_method, req_method

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -205,3 +205,34 @@ class TestResources(DatadogAPIWithInitialization):
         Metric.query(start="val1", end="val2")
         self.request_called_with('GET', "host/api/v1/query",
                                  params={'from': "val1", 'to': "val2"})
+
+    def test_metric_submit_multiple_points_is_single_value(self):
+        from copy import deepcopy
+        import json
+        from time import time
+
+        now = time()
+
+        data = [dict(metric='metric.1', points=13),
+                dict(metric='metric.2', points=19)]
+
+        Metric.send(*deepcopy(data))
+
+        args, kwargs = self.request_mock.request.call_args
+        sent_data = json.loads(kwargs['data'])
+
+        for i, metric in enumerate(sent_data['series']):
+            assert set(metric.keys()) == set(['metric', 'points', 'host'])
+
+            assert metric['metric'] == data[i]['metric']
+            assert metric['host'] == api._host_name
+
+            # points is a list of 1 point
+            assert isinstance(metric['points'], list) and len(metric['points']) == 1
+            # it consists of a [time, value] pair
+            assert len(metric['points'][0]) == 2
+            # its value == value we sent
+            assert metric['points'][0][1] == data[i]['points']
+            # it's time not so far from current time
+            assert now - 1 < metric['points'][0][0] < now + 1
+

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -1,7 +1,9 @@
 # stdlib
+from copy import deepcopy
 from functools import wraps
 import os
 import tempfile
+from time import time
 
 # 3p
 import mock
@@ -194,9 +196,41 @@ class TestResources(DatadogAPIWithInitialization):
         self.request_called_with('POST', "host/api/v1/actionname/" + str(actionable_object_id),
                                  data={'mydata': "val"})
 
+
+class TestMetricResource(DatadogAPIWithInitialization):
+
+    def submit_and_assess_metric_payload(self, serie):
+        """
+        Helper to assess the metric payload format.
+        """
+        now = time()
+
+        if isinstance(serie, dict):
+            Metric.send(**deepcopy(serie))
+            serie = [serie]
+        else:
+            Metric.send(deepcopy(serie))
+
+        payload = self.get_request_data()
+
+        for i, metric in enumerate(payload['series']):
+            assert set(metric.keys()) == set(['metric', 'points', 'host'])
+
+            assert metric['metric'] == serie[i]['metric']
+            assert metric['host'] == api._host_name
+
+            # points is a list of 1 point
+            assert isinstance(metric['points'], list) and len(metric['points']) == 1
+            # it consists of a [time, value] pair
+            assert len(metric['points'][0]) == 2
+            # its value == value we sent
+            assert metric['points'][0][1] == serie[i]['points']
+            # it's time not so far from current time
+            assert now - 1 < metric['points'][0][0] < now + 1
+
     def test_metric_submit_query_switch(self):
         """
-        Specific to Metric subpackages: endpoints are different for submission and queries
+        Endpoints are different for submission and queries.
         """
         Metric.send(points="val")
         self.request_called_with('POST', "host/api/v1/series",
@@ -206,33 +240,15 @@ class TestResources(DatadogAPIWithInitialization):
         self.request_called_with('GET', "host/api/v1/query",
                                  params={'from': "val1", 'to': "val2"})
 
-    def test_metric_submit_multiple_points_is_single_value(self):
-        from copy import deepcopy
-        import json
-        from time import time
+    def test_points_submission(self):
+        """
+        Assess the data payload format, when submitting a single or multiple points.
+        """
+        # Single point
+        serie = dict(metric='metric.1', points=13)
+        self.submit_and_assess_metric_payload(serie)
 
-        now = time()
-
-        data = [dict(metric='metric.1', points=13),
-                dict(metric='metric.2', points=19)]
-
-        Metric.send(*deepcopy(data))
-
-        args, kwargs = self.request_mock.request.call_args
-        sent_data = json.loads(kwargs['data'])
-
-        for i, metric in enumerate(sent_data['series']):
-            assert set(metric.keys()) == set(['metric', 'points', 'host'])
-
-            assert metric['metric'] == data[i]['metric']
-            assert metric['host'] == api._host_name
-
-            # points is a list of 1 point
-            assert isinstance(metric['points'], list) and len(metric['points']) == 1
-            # it consists of a [time, value] pair
-            assert len(metric['points'][0]) == 2
-            # its value == value we sent
-            assert metric['points'][0][1] == data[i]['points']
-            # it's time not so far from current time
-            assert now - 1 < metric['points'][0][0] < now + 1
-
+        # Multiple point
+        serie = [dict(metric='metric.1', points=13),
+                 dict(metric='metric.2', points=19)]
+        self.submit_and_assess_metric_payload(serie)


### PR DESCRIPTION
Rebase of https://github.com/DataDog/datadogpy/pull/56.

Added my two cents to comply with the syntax demoed in the documentation examples (http://docs.datadoghq.com/api/#metrics), i.e. pass a list of metrics as a single positional argument.