### PR TITLE
update requests library, per CVE-2015-2296

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 install_reqs = [
     "decorator>=3.3.2",
-    "requests>=0.8.8",
+    "requests>=2.6.0",
 ]
 if sys.version_info[0] == 2:
     # simplejson is not python3 compatible


### PR DESCRIPTION
Versions prior to 2.6.0 are vulnerable to a specific session hijack
attack. While we do not use cookies when interacting with the Datadog
API, it is good practice to keep up with security patches like this.

More info: http://www.openwall.com/lists/oss-security/2015/03/14/4