### PR TITLE
Add a timed context manager to statsd.

### DIFF
--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -169,6 +169,40 @@ class TestDogStatsd(object):
         t.assert_equal('timed.test', name)
         self.assert_almost_equal(0.5, float(value), 0.1)
 
+    def test_timed_context(self):
+        with self.statsd.timed_context('timed_context.test'):
+            time.sleep(0.5)
+
+        packet = self.recv()
+        name_value, type_ = packet.split('|')
+        name, value = name_value.split(':')
+
+        t.assert_equal('ms', type_)
+        t.assert_equal('timed_context.test', name)
+        self.assert_almost_equal(0.5, float(value), 0.1)
+
+    def test_timed_context_exception(self):
+        """Test that an exception bubbles out of the context manager."""
+        class ContextException(Exception):
+            pass
+
+        def func(self):
+            with self.statsd.timed_context('timed_context.test.exception'):
+                time.sleep(0.5)
+                raise ContextException()
+
+        # Ensure the exception was raised.
+        t.assert_raises(ContextException, func, self)
+
+        # Ensure the timing was recorded.
+        packet = self.recv()
+        name_value, type_ = packet.split('|')
+        name, value = name_value.split(':')
+
+        t.assert_equal('ms', type_)
+        t.assert_equal('timed_context.test.exception', name)
+        self.assert_almost_equal(0.5, float(value), 0.1)
+
     def test_batched(self):
         self.statsd.open_buffer()
         self.statsd.gauge('page.views', 123)

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -170,7 +170,7 @@ class TestDogStatsd(object):
         self.assert_almost_equal(0.5, float(value), 0.1)
 
     def test_timed_context(self):
-        with self.statsd.timed_context('timed_context.test'):
+        with self.statsd.timed('timed_context.test'):
             time.sleep(0.5)
 
         packet = self.recv()
@@ -187,7 +187,7 @@ class TestDogStatsd(object):
             pass
 
         def func(self):
-            with self.statsd.timed_context('timed_context.test.exception'):
+            with self.statsd.timed('timed_context.test.exception'):
                 time.sleep(0.5)
                 raise ContextException()
 


### PR DESCRIPTION
This enables a context manager in statsd so you can easily time a set of code without saving the start time, etc. manually:

```python
    with statsd.timed_context('user.query.time', sample_rate=0.5):
        # Do what you need to ...
        pass

    # Is equivalent to ...
    start = time.time()
    try:
        get_user(user_id)
    finally:
        statsd.timing('user.query.time', time.time() - start)
```

Two tests are also added for this code.

Fixes #25

Please let me know if you want anything changed, etc. I'd love to see this in the next release!