### PR TITLE
[test] force mock to version 1.0.1 for py26 compat

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands = nosetests ./tests/unit/
 deps =
 	nose
 	six
-	mock
+	mock==1.0.1
 setenv =
     PYTHONPATH = {toxinidir}
 


### PR DESCRIPTION
'mock' version 1.0.1 is the last version compatible with Python 2.6.