### PR TITLE
Add option for SSL verification with Requests library

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -32,7 +32,7 @@ else:
 
 
 def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
-               proxies=None, statsd_host=None, statsd_port=None):
+               proxies=None, statsd_host=None, statsd_port=None, cacert=True):
     """
     Initialize and configure Datadog.api and Datadog.statsd modules
 
@@ -53,6 +53,11 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
 
     :param statsd_port: Port of DogStatsd server or statsd daemon
     :type statsd_port: port
+
+    :param cacert: Path to local certificate file used to verify SSL
+    certificates. Can also be set to True (default) to use the systems
+    certificate store, or False to skip SSL verification
+    :type cacert: path or boolean
     """
     # Configure api
     api._api_key = api_key if api_key is not None else os.environ.get('DATADOG_API_KEY')
@@ -61,6 +66,7 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     api._api_host = api_host if api_host is not None else \
         os.environ.get('DATADOG_HOST', 'https://app.datadoghq.com')
     api._proxies = proxies
+    api._cacert = cacert
 
     # Given statsd_host and statsd_port, overrides statsd instance
     if statsd_host and statsd_port:

--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -6,6 +6,7 @@ _application_key = None
 _api_version = 'v1'
 _api_host = None
 _host_name = None
+_cacert = True
 
 # HTTP(S) settings
 _proxies = None

--- a/datadog/api/base.py
+++ b/datadog/api/base.py
@@ -61,7 +61,8 @@ class HTTPClient(object):
 
             # Import API, User and HTTP settings
             from datadog.api import _api_key, _application_key, _api_host, \
-                _swallow, _host_name, _proxies, _max_retries, _timeout
+                _swallow, _host_name, _proxies, _max_retries, _timeout, \
+                _cacert
 
             # Check keys and add then to params
             if _api_key is None:
@@ -112,7 +113,8 @@ class HTTPClient(object):
                     params=params,
                     data=body,
                     timeout=_timeout,
-                    proxies=_proxies)
+                    proxies=_proxies,
+                    verify=_cacert)
 
                 result.raise_for_status()
             except requests.ConnectionError as e:


### PR DESCRIPTION
In my production environment the server was missing root certificates to verify datadogs SSL cert which made the datadog api to fail with a No such file or directory error.
Added the option to use the verify parameter in requests to configure a ca certificates file or to disable verification.