### PR TITLE
Make the metric optional for the timed decorator.

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -133,7 +133,7 @@ class DogStatsd(object):
         the context OR in a function call.
         """
 
-        def __init__(self, statsd, metric, tags=None, sample_rate=1):
+        def __init__(self, statsd, metric=None, tags=None, sample_rate=1):
             self.statsd = statsd
             self.metric = metric
             self.tags = tags
@@ -141,6 +141,10 @@ class DogStatsd(object):
 
         def __call__(self, func):
             """Decorator which returns the elapsed time of the function call."""
+            # Default to the function name if metric was not provided.
+            if not self.metric:
+                self.metric = '%s.%s' % (func.__module__, func.__name__)
+
             @wraps(func)
             def wrapped(*args, **kwargs):
                 with self:
@@ -148,6 +152,8 @@ class DogStatsd(object):
             return wrapped
 
         def __enter__(self):
+            if not self.metric:
+                raise TypeError("Cannot used timed without a metric!")
             self.start = time()
 
         def __exit__(self, type, value, traceback):
@@ -155,11 +161,13 @@ class DogStatsd(object):
             self.statsd.timing(self.metric, time() - self.start,
                                self.tags, self.sample_rate)
 
-    def timed(self, metric, tags=None, sample_rate=1):
+    def timed(self, metric=None, tags=None, sample_rate=1):
         """
         A decorator or context manager that will measure the distribution of a
         function's/context's run time. Optionally specify a list of tags or a
-        sample rate.
+        sample rate. If the metric is not defined as a decorator, the module
+        name and function name will be used. The metric is required as a context
+        manager.
         ::
 
             @statsd.timed('user.query.time', sample_rate=0.5)

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -169,6 +169,30 @@ class TestDogStatsd(object):
         t.assert_equal('timed.test', name)
         self.assert_almost_equal(0.5, float(value), 0.1)
 
+    def test_timed_no_metric(self, ):
+        """Test using a decorator without providing a metric."""
+
+        @self.statsd.timed()
+        def func(a, b, c=1, d=1):
+            """docstring"""
+            time.sleep(0.5)
+            return (a, b, c, d)
+
+        t.assert_equal('func', func.__name__)
+        t.assert_equal('docstring', func.__doc__)
+
+        result = func(1, 2, d=3)
+        # Assert it handles args and kwargs correctly.
+        t.assert_equal(result, (1, 2, 1, 3))
+
+        packet = self.recv()
+        name_value, type_ = packet.split('|')
+        name, value = name_value.split(':')
+
+        t.assert_equal('ms', type_)
+        t.assert_equal('tests.unit.dogstatsd.test_statsd.func', name)
+        self.assert_almost_equal(0.5, float(value), 0.1)
+
     def test_timed_context(self):
         with self.statsd.timed('timed_context.test'):
             time.sleep(0.5)
@@ -202,6 +226,20 @@ class TestDogStatsd(object):
         t.assert_equal('ms', type_)
         t.assert_equal('timed_context.test.exception', name)
         self.assert_almost_equal(0.5, float(value), 0.1)
+
+    def test_timed_context_no_metric_exception(self):
+        """Test that an exception occurs if using a context manager without a metric."""
+
+        def func(self):
+            with self.statsd.timed():
+                time.sleep(0.5)
+
+        # Ensure the exception was raised.
+        t.assert_raises(TypeError, func, self)
+
+        # Ensure the timing was recorded.
+        packet = self.recv()
+        t.assert_equal(packet, None)
 
     def test_batched(self):
         self.statsd.open_buffer()


### PR DESCRIPTION
If the metric is *NOT* provided, it defaults to the function's module and name.

I find this convenient to wrap some functions where the metric is simply going to be the name of the function, in particular to wrap celery tasks.

I discussed this briefly with @remh on IRC and he suggested I put up a PR and we can discuss it.