### PR TITLE
[api] option to unmute ApiError exceptions

### DIFF
--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -14,7 +14,7 @@ _timeout = 3
 _max_timeouts = 3
 _max_retries = 3
 _backoff_period = 300
-_swallow = True
+_mute = True
 
 # Resources
 from datadog.api.comments import Comment

--- a/datadog/api/base.py
+++ b/datadog/api/base.py
@@ -61,7 +61,7 @@ class HTTPClient(object):
 
             # Import API, User and HTTP settings
             from datadog.api import _api_key, _application_key, _api_host, \
-                _swallow, _host_name, _proxies, _max_retries, _timeout, \
+                _mute, _host_name, _proxies, _max_retries, _timeout, \
                 _cacert
 
             # Check keys and add then to params
@@ -124,6 +124,7 @@ class HTTPClient(object):
                 raise HttpTimeout('%s %s timed out after %d seconds.' % (method, url, _timeout))
             except requests.exceptions.HTTPError as e:
                 if e.response.status_code in (400, 403, 404):
+                    # This gets caught afterwards and raises an ApiError exception
                     pass
                 else:
                     raise
@@ -160,7 +161,7 @@ class HTTPClient(object):
                 return response_formatter(response_obj)
 
         except ClientError as e:
-            if _swallow:
+            if _mute:
                 log.error(str(e))
                 if error_formatter is None:
                     return {'errors': e.args[0]}
@@ -169,7 +170,7 @@ class HTTPClient(object):
             else:
                 raise
         except ApiError as e:
-            if _swallow:
+            if _mute:
                 for error in e.args[0]['errors']:
                     log.error(str(error))
                 if error_formatter is None:

--- a/tests/unit/api/helper.py
+++ b/tests/unit/api/helper.py
@@ -21,10 +21,10 @@ FAKE_PROXY = {
 }
 
 
-class MockReponse(requests.Response):
+class MockResponse(requests.Response):
 
     def __init__(self, raise_for_status=False):
-        super(MockReponse, self).__init__()
+        super(MockResponse, self).__init__()
         self._raise_for_status = raise_for_status
 
     def raise_for_status(self):
@@ -74,7 +74,7 @@ class DatadogAPITestCase(unittest.TestCase):
         self.request_patcher = patch('requests.Session')
         request_class_mock = self.request_patcher.start()
         self.request_mock = request_class_mock.return_value
-        self.request_mock.request = Mock(return_value=MockReponse())
+        self.request_mock.request = Mock(return_value=MockResponse())
 
     def tearDown(self):
         self.request_patcher.stop()
@@ -83,7 +83,7 @@ class DatadogAPITestCase(unittest.TestCase):
         """
         Arm the mocked request to raise for status.
         """
-        self.request_mock.request = Mock(return_value=MockReponse(raise_for_status=True))
+        self.request_mock.request = Mock(return_value=MockResponse(raise_for_status=True))
 
     def get_request_data(self):
         """


### PR DESCRIPTION
Datadog API HTTP client raises ApiError (400, 403 or 404 status codes)
and HTTPError (others) exceptions for bad requests.
BUT, we are, by default, muting any exceptions before they escape from
the library. This makes difficult to catch errors and interact with the
API.

These changes introduces a `mute` option settable from `initialize`
method, to select the desired behavior.

Fix #74