### PR TITLE
[deps] make dependencies abstract + use `simplejson` with Python 3.x

### DIFF
--- a/datadog/api/base.py
+++ b/datadog/api/base.py
@@ -3,11 +3,14 @@ import time
 import logging
 import requests
 
+# 3p
+import simplejson as json
+
 # datadog
 from datadog.api.exceptions import ClientError, ApiError, HttpBackoff, \
     HttpTimeout, ApiNotInitialized
 from datadog.api import _api_version, _max_timeouts, _backoff_period
-from datadog.util.compat import json, is_p3k
+from datadog.util.compat import is_p3k
 
 log = logging.getLogger('dd.datadogpy')
 

--- a/datadog/dogshell/__init__.py
+++ b/datadog/dogshell/__init__.py
@@ -1,22 +1,25 @@
-import argparse
+# stdlib
+import logging
 import os
 import pkg_resources as pkg
 
-import logging
+# 3p
+import argparse
 
-from datadog.dogshell.common import DogshellConfig
-from datadog.dogshell.comment import CommentClient
-from datadog.dogshell.search import SearchClient
-from datadog.dogshell.metric import MetricClient
-from datadog.dogshell.tag import TagClient
-from datadog.dogshell.event import EventClient
-from datadog.dogshell.monitor import MonitorClient
-from datadog.dogshell.downtime import DowntimeClient
-from datadog.dogshell.screenboard import ScreenboardClient
-from datadog.dogshell.timeboard import TimeboardClient
-from datadog.dogshell.host import HostClient
-from datadog.dogshell.service_check import ServiceCheckClient
+# datadog
 from datadog import initialize
+from datadog.dogshell.comment import CommentClient
+from datadog.dogshell.common import DogshellConfig
+from datadog.dogshell.downtime import DowntimeClient
+from datadog.dogshell.event import EventClient
+from datadog.dogshell.host import HostClient
+from datadog.dogshell.metric import MetricClient
+from datadog.dogshell.monitor import MonitorClient
+from datadog.dogshell.screenboard import ScreenboardClient
+from datadog.dogshell.search import SearchClient
+from datadog.dogshell.service_check import ServiceCheckClient
+from datadog.dogshell.tag import TagClient
+from datadog.dogshell.timeboard import TimeboardClient
 
 logging.getLogger('dd.datadogpy').setLevel(logging.CRITICAL)
 

--- a/datadog/dogshell/comment.py
+++ b/datadog/dogshell/comment.py
@@ -1,8 +1,12 @@
+# stdlib
 import sys
 
+# 3p
+import simplejson as json
+
+# datadog
 from datadog.dogshell.common import report_errors, report_warnings
 from datadog import api
-from datadog.util.compat import json
 
 
 class CommentClient(object):

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -1,9 +1,11 @@
+# stdlib
 from __future__ import print_function
 import os
 import sys
 import logging
 import socket
 
+# datadog
 from datadog.util.compat import is_p3k, configparser, IterableUserDict,\
     get_input
 

--- a/datadog/dogshell/downtime.py
+++ b/datadog/dogshell/downtime.py
@@ -1,7 +1,9 @@
-from datadog.util.compat import json
-from datadog.dogshell.common import report_errors, report_warnings
+# 3p
+import simplejson as json
 
+# datadog
 from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings
 
 
 class DowntimeClient(object):

--- a/datadog/dogshell/event.py
+++ b/datadog/dogshell/event.py
@@ -1,11 +1,15 @@
+# stdlib
 import datetime
 import time
 import re
 import sys
 
-from datadog.util.compat import json
-from datadog.dogshell.common import report_errors, report_warnings
+# 3p
+import simplejson as json
+
+# datadog
 from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings
 
 
 def prettyprint_event(event):

--- a/datadog/dogshell/host.py
+++ b/datadog/dogshell/host.py
@@ -1,6 +1,9 @@
-from datadog.dogshell.common import report_errors, report_warnings
-from datadog.util.compat import json
+# 3p
+import simplejson as json
+
+# datadog
 from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings
 
 
 class HostClient(object):

--- a/datadog/dogshell/metric.py
+++ b/datadog/dogshell/metric.py
@@ -1,5 +1,6 @@
-from datadog.dogshell.common import report_errors, report_warnings, find_localhost
+# datadog
 from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings, find_localhost
 
 
 class MetricClient(object):

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -1,6 +1,9 @@
-from datadog.util.compat import json
-from datadog.dogshell.common import report_errors, report_warnings
+# 3p
+import simplejson as json
+
+# datadog
 from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings
 
 
 class MonitorClient(object):

--- a/datadog/dogshell/screenboard.py
+++ b/datadog/dogshell/screenboard.py
@@ -1,12 +1,16 @@
+# stdlib
 import argparse
 import sys
 import platform
 import webbrowser
 
-from datetime import datetime
-from datadog.util.compat import json
-from datadog.dogshell.common import report_errors, report_warnings, print_err
+# 3p
+import simplejson as json
+
+# datadog
 from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings, print_err
+from datetime import datetime
 
 
 class ScreenboardClient(object):

--- a/datadog/dogshell/search.py
+++ b/datadog/dogshell/search.py
@@ -1,6 +1,9 @@
-from datadog.util.compat import json
-from datadog.dogshell.common import report_errors, report_warnings
+# 3p
+import simplejson as json
+
+# datadog
 from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings
 
 
 # TODO IS there a test ?

--- a/datadog/dogshell/service_check.py
+++ b/datadog/dogshell/service_check.py
@@ -1,6 +1,9 @@
-from datadog.util.compat import json
-from datadog.dogshell.common import report_errors, report_warnings
+# 3p
+import simplejson as json
+
+# datadog
 from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings
 
 
 class ServiceCheckClient(object):

--- a/datadog/dogshell/tag.py
+++ b/datadog/dogshell/tag.py
@@ -1,6 +1,9 @@
-from datadog.util.compat import json
-from datadog.dogshell.common import report_errors, report_warnings
+# 3p
+import simplejson as json
+
+# datadog
 from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings
 
 
 class TagClient(object):

--- a/datadog/dogshell/timeboard.py
+++ b/datadog/dogshell/timeboard.py
@@ -1,13 +1,17 @@
-import argparse
+# stdlib
 import os.path
 import platform
 import sys
 import webbrowser
 
-from datetime import datetime
-from datadog.util.compat import json
-from datadog.dogshell.common import report_errors, report_warnings, print_err
+# 3p
+import argparse
+import simplejson as json
+
+# datadog
 from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings, print_err
+from datetime import datetime
 
 
 class TimeboardClient(object):

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -17,14 +17,15 @@ And you can give the command a timeout too:
 dogwrap -n test-job -k $API_KEY --timeout=1 "sleep 3"
 
 '''
-
-import sys
-import time
+# stdlib
 import optparse
-import threading
-import subprocess
 import pkg_resources as pkg
+import subprocess
+import sys
+import threading
+import time
 
+# datadog
 from datadog import initialize, api
 
 

--- a/datadog/util/compat.py
+++ b/datadog/util/compat.py
@@ -51,9 +51,3 @@ try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse
-
-# prefer simplejson but fall back to stdlib python
-try:
-    import simplejson as json
-except ImportError:
-    import json

--- a/datadog/util/hostname.py
+++ b/datadog/util/hostname.py
@@ -1,10 +1,15 @@
+# stdlib
 import socket
 import re
 import logging
 import subprocess
 import types
 
-from datadog.util.compat import url_lib, is_p3k, iteritems, json
+# 3p
+import simplejson as json
+
+# datadog
+from datadog.util.compat import url_lib, is_p3k, iteritems
 from datadog.util.config import get_config, get_os, CfgNotFound
 
 VALID_HOSTNAME_RFC_1123_PATTERN = re.compile(r"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$")  # noqa

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,10 @@
 from setuptools import setup
 import sys
 
-install_reqs = [
-    "decorator>=3.3.2",
-    "requests>=2.6.0",
-]
-if sys.version_info[0] == 2:
-    # simplejson is not python3 compatible
-    install_reqs.append("simplejson>=2.0.9")
-
-if [sys.version_info[0], sys.version_info[1]] < [2, 7]:
-    install_reqs.append("argparse>=1.2")
-
 setup(
     name="datadog",
     version="0.8.0",
-    install_requires=install_reqs,
+    install_requires=["argparse", "requests", "simplejson"],
     tests_require=["tox", "nose", "mock", "six", "pillow"],
     packages=[
         'datadog',

--- a/tests/unit/api/helper.py
+++ b/tests/unit/api/helper.py
@@ -1,15 +1,17 @@
-# python
+# stdlib
 import unittest
+
+# 3p
+from mock import patch, Mock
+import requests
+import simplejson as json
 
 # datadog
 from datadog import initialize, api
 from datadog.api.base import CreateableAPIResource, UpdatableAPIResource, DeletableAPIResource,\
     GetableAPIResource, ListableAPIResource, ActionAPIResource
-from datadog.util.compat import iteritems, json
+from datadog.util.compat import iteritems
 
-# 3p
-import requests
-from mock import patch, Mock
 
 API_KEY = "apikey"
 APP_KEY = "applicationkey"


### PR DESCRIPTION
#### Changes
1. Make dependencies completely abstract to enhance reusability.
2. `simplejson==3.0.0` introduced Python > 3.3 support. Use it instead of
falling back with stdlib `json` package.

#### Notes
@miketheman: b50adcbc6879c4bad576e8c3d7d4d758fc06dc72  is somehow a regression of https://github.com/DataDog/datadogpy/pull/63. 
I found that setting a version (even a minimum) in the `setup.py` abstract dependencies is making it very difficult to embed in other projects :confused: ...
