### PR TITLE
[api] Add user CRUD

### DIFF
--- a/datadog/api/base.py
+++ b/datadog/api/base.py
@@ -126,7 +126,7 @@ class HTTPClient(object):
                 cls._timeout_counter += 1
                 raise HttpTimeout('%s %s timed out after %d seconds.' % (method, url, _timeout))
             except requests.exceptions.HTTPError as e:
-                if e.response.status_code in (400, 403, 404):
+                if e.response.status_code in (400, 403, 404, 409):
                     # This gets caught afterwards and raises an ApiError exception
                     pass
                 else:

--- a/datadog/api/users.py
+++ b/datadog/api/users.py
@@ -1,7 +1,17 @@
-from datadog.api.base import ActionAPIResource
+from datadog.api.base import ActionAPIResource, GetableAPIResource, \
+    CreateableAPIResource, UpdatableAPIResource, ListableAPIResource, \
+    DeletableAPIResource
 
 
-class User(ActionAPIResource):
+class User(ActionAPIResource, GetableAPIResource, CreateableAPIResource,
+           UpdatableAPIResource, ListableAPIResource,
+           DeletableAPIResource):
+
+    _class_name = 'user'
+    _class_url = '/user'
+    _plural_class_name = 'users'
+    _json_name = 'user'
+
     """
     A wrapper around User HTTP API.
     """
@@ -17,6 +27,8 @@ class User(ActionAPIResource):
 
         :returns: JSON response from HTTP request
         """
+        print("[DEPRECATION] User.invite() is deprecated. Use `create` instead.")
+
         if not isinstance(emails, list):
             emails = [emails]
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -75,6 +75,7 @@ Datadog.api client requires to run :mod:`datadog` `initialize` method first.
 .. autoclass:: datadog.api.User
     :members:
     :inherited-members:
+    :exclude-members: invite
 
 
 Datadog.threadstats module


### PR DESCRIPTION
Additional changes:
- Add a deprecation message to `invite` method of `api/users`
- 409 HTTP error codes are now recognized as ApiError exceptions