### PR TITLE
Fix bug where tags list increases in size

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -225,7 +225,7 @@ class DogStatsd(object):
         # Append all client level tags to every metric
         if self.constant_tags:
             if tags:
-                tags += self.constant_tags
+                tags = tags + self.constant_tags
             else:
                 tags = self.constant_tags
 

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -157,6 +157,17 @@ class TestDogStatsd(object):
         self.statsd.increment('page.views', tags=['extra'])
         t.assert_equal('page.views:1|c|#extra,bar:baz,foo', self.recv())
 
+    def test_gauge_constant_tags_with_metric_level_tags_twice(self):
+        metric_level_tag = ['foo:bar']
+        self.statsd.constant_tags=['bar:baz']
+        self.statsd.gauge('gauge', 123.4, tags=metric_level_tag)
+        assert self.recv() == 'gauge:123.4|g|#foo:bar,bar:baz'
+
+        # sending metrics multiple times with same metric-level tags
+        # should not duplicate the tags being sent
+        self.statsd.gauge('gauge', 123.4, tags=metric_level_tag)
+        assert self.recv() == 'gauge:123.4|g|#foo:bar,bar:baz'
+
     @staticmethod
     def assert_almost_equal(a, b, delta):
         assert 0 <= abs(a - b) <= delta, "%s - %s not within %s" % (a, b, delta)


### PR DESCRIPTION
## Summary
When previously-defined metric-level tags (non-literal list) are passed into the `gauge()` function,
the metric-level tag list will be modified if `constant_tags` is not `None`. This is due
to the `+=` operator modifying the metric-level list by appending
the list `constant_tags`.

If you're using dogstatsd to send your metrics, this will inevitably lead to a `error: [Errno 90] Message too long` since the UDP packet size has an upper limit.

For an example of this, see the new test, `test_gauge_constant_tags_with_metric_level_tags_twice`.

## Fix
Use the following instead of `+=`:
```python
# WILL modify metric-level tags passed into the function
tags += self.constant_tags

# WON'T modify metric-level tags passed into the function
tags = tags + self.constant_tags
```