### PR TITLE
[api] `Metrics`: support long` data type

### DIFF
--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -14,13 +14,16 @@ class Metric(SearchableAPIResource, SendableAPIResource):
     _METRIC_QUERY_ENDPOINT = '/query'
     _METRIC_SUBMIT_ENDPOINT = '/series'
 
+    _SUPPORTED_DATA_TYPES = (int, float, long)
+
     @classmethod
     def _process_points(cls, points):
         now = time.time()
-        if isinstance(points, (float, int)):
+        if isinstance(points, cls._SUPPORTED_DATA_TYPES):
             points = [(now, points)]
         elif isinstance(points, tuple):
             points = [points]
+
         return points
 
     @classmethod

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -309,3 +309,13 @@ class TestMetricResource(DatadogAPIWithInitialization):
         serie = [dict(metric='metric.1', points=13),
                  dict(metric='metric.2', points=19)]
         self.submit_and_assess_metric_payload(serie)
+
+    def test_data_type_support(self):
+        """
+        `Metric` API supports built-in real numerical data types.
+        """
+        supported_data_types = [1, 1.0, 1L]
+
+        for point in supported_data_types:
+            serie = dict(metric='metric.numerical', points=point)
+            self.submit_and_assess_metric_payload(serie)


### PR DESCRIPTION
 `Metric` API supports built-in real numerical data types.