### PR TITLE
[dogstatsd] add a top-level import for DogStatsd

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -14,7 +14,7 @@ import os.path
 
 # datadog
 from datadog import api
-from datadog.dogstatsd import statsd
+from datadog.dogstatsd import DogStatsd, statsd  # noqa
 from datadog.threadstats import ThreadStats  # noqa
 from datadog.util.hostname import get_hostname
 from datadog.util.compat import iteritems

--- a/datadog/dogstatsd/__init__.py
+++ b/datadog/dogstatsd/__init__.py
@@ -1,1 +1,1 @@
-from datadog.dogstatsd.base import statsd  # noqa
+from datadog.dogstatsd.base import DogStatsd, statsd  # noqa


### PR DESCRIPTION
Add a top-level import for DogStatsd, i.e.
```python
from datadog import DogStatsd
```
is equivalent to

```python
from datadog.dogstatsd.base import DogStatsd
```