### PR TITLE
Document parameter alert_type in Event.create

### DIFF
--- a/datadog/api/events.py
+++ b/datadog/api/events.py
@@ -24,6 +24,9 @@ class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource):
         :param text: event message
         :type text: string
 
+        :param alert_type: "error", "warning", "info" or "success".
+        :type alert_type: string
+
         :param date_happened: when the event occurred. if unset defaults to the current time. \
         (POSIX timestamp)
         :type date_happened: integer


### PR DESCRIPTION
As far as I can tell, you've forgot to document the parameter `alert_type` in `Event.create`. I guess there should also be a test for this, but I wasn't sure how to go about this.