### PR TITLE
Fix thread-safety of @timed decorator

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -162,8 +162,11 @@ class DogStatsd(object):
 
             @wraps(func)
             def wrapped(*args, **kwargs):
-                with self:
+                start = time()
+                try:
                     return func(*args, **kwargs)
+                finally:
+                    self._send(start)
             return wrapped
 
         def __enter__(self):
@@ -173,7 +176,10 @@ class DogStatsd(object):
 
         def __exit__(self, type, value, traceback):
             # Report the elapsed time of the context manager.
-            elapsed = time() - self.start
+            self._send(self.start)
+
+        def _send(self, start):
+            elapsed = time() - start
             use_ms = self.use_ms if self.use_ms is not None else self.statsd.use_ms
             elapsed = int(round(1000 * elapsed)) if use_ms else elapsed
             self.statsd.timing(self.metric, elapsed, self.tags, self.sample_rate)

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -6,6 +6,7 @@ Tests for dogstatsd.py
 from collections import deque
 import six
 import socket
+import threading
 import time
 
 from nose import tools as t
@@ -219,6 +220,39 @@ class TestDogStatsd(object):
         t.assert_equal('ms', type_)
         t.assert_equal('timed.test', name)
         self.assert_almost_equal(500, float(value), 100)
+
+    def test_timed_threaded(self):
+        @self.statsd.timed('timed.test')
+        def func():
+            time.sleep(0.5)
+
+        t1 = threading.Thread(target=func)
+        t2 = threading.Thread(target=func)
+
+        t1.start()
+        time.sleep(0.2)
+        t2.start()
+
+        t1.join()
+        t2.join()
+
+        # packet 1
+        packet = self.recv()
+        name_value, type_ = packet.split('|')
+        name, value = name_value.split(':')
+
+        t.assert_equal('ms', type_)
+        t.assert_equal('timed.test', name)
+        self.assert_almost_equal(0.5, float(value), 0.1)
+
+        # packet 2
+        packet = self.recv()
+        name_value, type_ = packet.split('|')
+        name, value = name_value.split(':')
+
+        t.assert_equal('ms', type_)
+        t.assert_equal('timed.test', name)
+        self.assert_almost_equal(0.5, float(value), 0.1)
 
     def test_timed_in_ms(self):
         """


### PR DESCRIPTION
When using @timed as a decorator, it's not thread-safe to call itself as a
context manager. The decorator creates one instance of this class, and since
the context manager stores the start time on the instance, calling it again
in parallel will overwrite the start time of the earlier call.

So, for the decorator version, the start time needs to be kept in the call
stack.

This includes a test case which demonstrates the problem.