### PR TITLE
attach additional tags as defined in DOGSTATSD_TAGS environment variable

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -45,7 +45,7 @@ class DogStatsd(object):
         :param use_ms: Report timed values in milliseconds instead of seconds (default False)
         :type use_ms: boolean
 
-        :envvar DOGSTATSD_TAGS: Tags to attach to every metric reported by dogstatsd client
+        :envvar DATADOG_TAGS: Tags to attach to every metric reported by dogstatsd client
         :type constant_tags: list of strings
         """
         self.host = host
@@ -54,7 +54,7 @@ class DogStatsd(object):
         self.max_buffer_size = max_buffer_size
         self._send = self._send_to_server
         self.encoding = 'utf-8'
-        env_tags = [tag for tag in os.environ.get('DOGSTATSD_TAGS', '').split(',') if tag]
+        env_tags = [tag for tag in os.environ.get('DATADOG_TAGS', '').split(',') if tag]
         if constant_tags is None:
             constant_tags = []
         self.constant_tags = constant_tags + env_tags

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -54,10 +54,10 @@ class DogStatsd(object):
         self.max_buffer_size = max_buffer_size
         self._send = self._send_to_server
         self.encoding = 'utf-8'
-        self.env_tags = [tag for tag in os.environ.get('DOGSTATSD_TAGS', '').split(',') if tag]
+        env_tags = [tag for tag in os.environ.get('DOGSTATSD_TAGS', '').split(',') if tag]
         if constant_tags is None:
             constant_tags = []
-        self.constant_tags = constant_tags + self.env_tags
+        self.constant_tags = constant_tags + env_tags
         self.use_ms = use_ms
 
     def __enter__(self):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -4,6 +4,7 @@ DogStatsd is a Python client for DogStatsd, a Statsd fork for Datadog.
 """
 
 import logging
+import os
 from random import random
 from time import time
 import socket
@@ -43,6 +44,9 @@ class DogStatsd(object):
 
         :param use_ms: Report timed values in milliseconds instead of seconds (default False)
         :type use_ms: boolean
+
+        :envvar DOGSTATSD_TAGS: Tags to attach to every metric reported by dogstatsd client
+        :type constant_tags: list of strings
         """
         self.host = host
         self.port = int(port)
@@ -50,7 +54,10 @@ class DogStatsd(object):
         self.max_buffer_size = max_buffer_size
         self._send = self._send_to_server
         self.encoding = 'utf-8'
-        self.constant_tags = constant_tags
+        self.env_tags = [tag for tag in os.environ.get('DOGSTATSD_TAGS', '').split(',') if tag]
+        if constant_tags is None:
+            constant_tags = []
+        self.constant_tags = constant_tags + self.env_tags
         self.use_ms = use_ms
 
     def __enter__(self):

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -6,6 +6,7 @@ on your application's needs.
 """
 
 import logging
+import os
 from functools import wraps
 from contextlib import contextmanager
 from time import time
@@ -28,10 +29,16 @@ class ThreadStats(object):
 
         :param constant_tags: Tags to attach to every metric reported by this client
         :type constant_tags: list of strings
+
+        :envvar DOGSTATSD_TAGS: Tags to attach to every metric reported by ThreadStats client
+        :type constant_tags: list of strings
         """
         # Don't collect until start is called.
         self._disabled = True
-        self.constant_tags = constant_tags
+        self.env_tags = [tag for tag in os.environ.get('DOGSTATSD_TAGS', '').split(',') if tag]
+        if constant_tags is None:
+            constant_tags = []
+        self.constant_tags = constant_tags + self.env_tags
 
     def start(self, flush_interval=10, roll_up_interval=10, device=None,
               flush_in_thread=True, flush_in_greenlet=False, disabled=False):

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -30,12 +30,12 @@ class ThreadStats(object):
         :param constant_tags: Tags to attach to every metric reported by this client
         :type constant_tags: list of strings
 
-        :envvar DOGSTATSD_TAGS: Tags to attach to every metric reported by ThreadStats client
+        :envvar DATADOG_TAGS: Tags to attach to every metric reported by ThreadStats client
         :type constant_tags: list of strings
         """
         # Don't collect until start is called.
         self._disabled = True
-        env_tags = [tag for tag in os.environ.get('DOGSTATSD_TAGS', '').split(',') if tag]
+        env_tags = [tag for tag in os.environ.get('DATADOG_TAGS', '').split(',') if tag]
         if constant_tags is None:
             constant_tags = []
         self.constant_tags = constant_tags + env_tags

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -35,10 +35,10 @@ class ThreadStats(object):
         """
         # Don't collect until start is called.
         self._disabled = True
-        self.env_tags = [tag for tag in os.environ.get('DOGSTATSD_TAGS', '').split(',') if tag]
+        env_tags = [tag for tag in os.environ.get('DOGSTATSD_TAGS', '').split(',') if tag]
         if constant_tags is None:
             constant_tags = []
-        self.constant_tags = constant_tags + self.env_tags
+        self.constant_tags = constant_tags + env_tags
 
     def start(self, flush_interval=10, roll_up_interval=10, device=None,
               flush_in_thread=True, flush_in_greenlet=False, disabled=False):

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -4,6 +4,7 @@ Tests for dogstatsd.py
 """
 
 from collections import deque
+import os
 import six
 import socket
 import time
@@ -401,6 +402,22 @@ class TestDogStatsd(object):
         dogpound.socket = fresh_socket
         t.assert_equal(fresh_socket, dogpound.get_socket())
         t.assert_not_equal(FakeSocket(), dogpound.get_socket())
+
+    def test_tags_from_environment(self):
+        os.environ['DOGSTATSD_TAGS'] = 'country:china,age:45,blue'
+        statsd = DogStatsd()
+        del(os.environ['DOGSTATSD_TAGS'])
+        statsd.socket = FakeSocket()
+        statsd.gauge('gt', 123.4)
+        t.assert_equal('gt:123.4|g|#country:china,age:45,blue', statsd.socket.recv())
+
+    def test_tags_from_environment_and_constant(self):
+        os.environ['DOGSTATSD_TAGS'] = 'country:china,age:45,blue'
+        statsd = DogStatsd(constant_tags=['country:canada', 'red'])
+        del(os.environ['DOGSTATSD_TAGS'])
+        statsd.socket = FakeSocket()
+        statsd.gauge('gt', 123.4)
+        t.assert_equal('gt:123.4|g|#country:canada,red,country:china,age:45,blue', statsd.socket.recv())
 
 if __name__ == '__main__':
     statsd = statsd

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -14,6 +14,8 @@ from nose import tools as t
 from datadog.dogstatsd.base import DogStatsd
 from datadog import initialize, statsd
 
+from tests.util.contextmanagers import preserve_environment_variable
+
 
 class FakeSocket(object):
     """ A fake socket for testing. """
@@ -404,17 +406,17 @@ class TestDogStatsd(object):
         t.assert_not_equal(FakeSocket(), dogpound.get_socket())
 
     def test_tags_from_environment(self):
-        os.environ['DOGSTATSD_TAGS'] = 'country:china,age:45,blue'
-        statsd = DogStatsd()
-        del(os.environ['DOGSTATSD_TAGS'])
+        with preserve_environment_variable('DOGSTATSD_TAGS'):
+            os.environ['DOGSTATSD_TAGS'] = 'country:china,age:45,blue'
+            statsd = DogStatsd()
         statsd.socket = FakeSocket()
         statsd.gauge('gt', 123.4)
         t.assert_equal('gt:123.4|g|#country:china,age:45,blue', statsd.socket.recv())
 
     def test_tags_from_environment_and_constant(self):
-        os.environ['DOGSTATSD_TAGS'] = 'country:china,age:45,blue'
-        statsd = DogStatsd(constant_tags=['country:canada', 'red'])
-        del(os.environ['DOGSTATSD_TAGS'])
+        with preserve_environment_variable('DOGSTATSD_TAGS'):
+           os.environ['DOGSTATSD_TAGS'] = 'country:china,age:45,blue'
+           statsd = DogStatsd(constant_tags=['country:canada', 'red'])
         statsd.socket = FakeSocket()
         statsd.gauge('gt', 123.4)
         t.assert_equal('gt:123.4|g|#country:canada,red,country:china,age:45,blue', statsd.socket.recv())

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -406,16 +406,16 @@ class TestDogStatsd(object):
         t.assert_not_equal(FakeSocket(), dogpound.get_socket())
 
     def test_tags_from_environment(self):
-        with preserve_environment_variable('DOGSTATSD_TAGS'):
-            os.environ['DOGSTATSD_TAGS'] = 'country:china,age:45,blue'
+        with preserve_environment_variable('DATADOG_TAGS'):
+            os.environ['DATADOG_TAGS'] = 'country:china,age:45,blue'
             statsd = DogStatsd()
         statsd.socket = FakeSocket()
         statsd.gauge('gt', 123.4)
         t.assert_equal('gt:123.4|g|#country:china,age:45,blue', statsd.socket.recv())
 
     def test_tags_from_environment_and_constant(self):
-        with preserve_environment_variable('DOGSTATSD_TAGS'):
-           os.environ['DOGSTATSD_TAGS'] = 'country:china,age:45,blue'
+        with preserve_environment_variable('DATADOG_TAGS'):
+           os.environ['DATADOG_TAGS'] = 'country:china,age:45,blue'
            statsd = DogStatsd(constant_tags=['country:canada', 'red'])
         statsd.socket = FakeSocket()
         statsd.gauge('gt', 123.4)

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -14,6 +14,8 @@ from nose.plugins.skip import SkipTest
 from datadog import ThreadStats
 from datadog.api.exceptions import ApiNotInitialized
 
+from tests.util.contextmanagers import preserve_environment_variable
+
 
 # Silence the logger.
 logger = logging.getLogger('dd.datadogpy')
@@ -518,9 +520,9 @@ class TestUnitThreadStats(object):
 
     def test_tags_from_environment(self):
         test_tags = ['country:china', 'age:45', 'blue']
-        os.environ['DOGSTATSD_TAGS'] = ','.join(test_tags)
-        dog = ThreadStats()
-        del(os.environ['DOGSTATSD_TAGS'])
+        with preserve_environment_variable('DOGSTATSD_TAGS'):
+            os.environ['DOGSTATSD_TAGS'] = ','.join(test_tags)
+            dog = ThreadStats()
         dog.start(roll_up_interval=10, flush_in_thread=False)
         reporter = dog.reporter = MemoryReporter()
 
@@ -564,9 +566,9 @@ class TestUnitThreadStats(object):
     def test_tags_from_environment_and_constant(self):
         test_tags = ['country:china', 'age:45', 'blue']
         constant_tags = ['country:canada', 'red']
-        os.environ['DOGSTATSD_TAGS'] = ','.join(test_tags)
-        dog = ThreadStats(constant_tags=constant_tags)
-        del(os.environ['DOGSTATSD_TAGS'])
+        with preserve_environment_variable('DOGSTATSD_TAGS'):
+            os.environ['DOGSTATSD_TAGS'] = ','.join(test_tags)
+            dog = ThreadStats(constant_tags=constant_tags)
         dog.start(roll_up_interval=10, flush_in_thread=False)
         reporter = dog.reporter = MemoryReporter()
 

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -520,8 +520,8 @@ class TestUnitThreadStats(object):
 
     def test_tags_from_environment(self):
         test_tags = ['country:china', 'age:45', 'blue']
-        with preserve_environment_variable('DOGSTATSD_TAGS'):
-            os.environ['DOGSTATSD_TAGS'] = ','.join(test_tags)
+        with preserve_environment_variable('DATADOG_TAGS'):
+            os.environ['DATADOG_TAGS'] = ','.join(test_tags)
             dog = ThreadStats()
         dog.start(roll_up_interval=10, flush_in_thread=False)
         reporter = dog.reporter = MemoryReporter()
@@ -566,8 +566,8 @@ class TestUnitThreadStats(object):
     def test_tags_from_environment_and_constant(self):
         test_tags = ['country:china', 'age:45', 'blue']
         constant_tags = ['country:canada', 'red']
-        with preserve_environment_variable('DOGSTATSD_TAGS'):
-            os.environ['DOGSTATSD_TAGS'] = ','.join(test_tags)
+        with preserve_environment_variable('DATADOG_TAGS'):
+            os.environ['DATADOG_TAGS'] = ','.join(test_tags)
             dog = ThreadStats(constant_tags=constant_tags)
         dog.start(roll_up_interval=10, flush_in_thread=False)
         reporter = dog.reporter = MemoryReporter()

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -2,6 +2,7 @@
 Tests for the ThreadStats class, using HTTP mode
 """
 
+import os
 import logging
 import random
 import time
@@ -514,3 +515,94 @@ class TestUnitThreadStats(object):
             dog.gauge('metric', i)
         time.sleep(2)
         assert dog.flush_count in [flush_count, flush_count + 1]
+
+    def test_tags_from_environment(self):
+        test_tags = ['country:china', 'age:45', 'blue']
+        os.environ['DOGSTATSD_TAGS'] = ','.join(test_tags)
+        dog = ThreadStats()
+        del(os.environ['DOGSTATSD_TAGS'])
+        dog.start(roll_up_interval=10, flush_in_thread=False)
+        reporter = dog.reporter = MemoryReporter()
+
+        # Add two events
+        event1_title = "Event 1 title"
+        event2_title = "Event 1 title"
+        event1_text = "Event 1 text"
+        event2_text = "Event 2 text"
+        dog.event(event1_title, event1_text)
+        dog.event(event2_title, event2_text)
+
+        # Flush and test
+        dog.flush()
+        event1, event2 = reporter.events
+        nt.assert_equal(event1['title'], event1_title)
+        nt.assert_equal(event1['text'], event1_text)
+        nt.assert_equal(event1['tags'], test_tags)
+        nt.assert_equal(event2['title'], event2_title)
+        nt.assert_equal(event2['text'], event2_text)
+        nt.assert_equal(event2['text'], event2_text)
+        nt.assert_equal(event2['tags'], test_tags)
+
+        # Test more parameters
+        reporter.events = []
+        event1_priority = "low"
+        event1_date_happened = 1375296969
+        event1_tag = "Event 2 tag"
+        dog.event(event1_title, event1_text, priority=event1_priority,
+                  date_happened=event1_date_happened, tags=[event1_tag])
+
+        # Flush and test
+        dog.flush()
+        event, = reporter.events
+        nt.assert_equal(event['title'], event1_title)
+        nt.assert_equal(event['text'], event1_text)
+        nt.assert_equal(event['priority'], event1_priority)
+        nt.assert_equal(event['date_happened'], event1_date_happened)
+        nt.assert_equal(event['tags'], [event1_tag] + test_tags)
+        dog.start(flush_interval=1, roll_up_interval=1)
+
+    def test_tags_from_environment_and_constant(self):
+        test_tags = ['country:china', 'age:45', 'blue']
+        constant_tags = ['country:canada', 'red']
+        os.environ['DOGSTATSD_TAGS'] = ','.join(test_tags)
+        dog = ThreadStats(constant_tags=constant_tags)
+        del(os.environ['DOGSTATSD_TAGS'])
+        dog.start(roll_up_interval=10, flush_in_thread=False)
+        reporter = dog.reporter = MemoryReporter()
+
+        # Add two events
+        event1_title = "Event 1 title"
+        event2_title = "Event 1 title"
+        event1_text = "Event 1 text"
+        event2_text = "Event 2 text"
+        dog.event(event1_title, event1_text)
+        dog.event(event2_title, event2_text)
+
+        # Flush and test
+        dog.flush()
+        event1, event2 = reporter.events
+        nt.assert_equal(event1['title'], event1_title)
+        nt.assert_equal(event1['text'], event1_text)
+        nt.assert_equal(event1['tags'], constant_tags + test_tags)
+        nt.assert_equal(event2['title'], event2_title)
+        nt.assert_equal(event2['text'], event2_text)
+        nt.assert_equal(event2['text'], event2_text)
+        nt.assert_equal(event2['tags'], constant_tags + test_tags)
+
+        # Test more parameters
+        reporter.events = []
+        event1_priority = "low"
+        event1_date_happened = 1375296969
+        event1_tag = "Event 2 tag"
+        dog.event(event1_title, event1_text, priority=event1_priority,
+                  date_happened=event1_date_happened, tags=[event1_tag])
+
+        # Flush and test
+        dog.flush()
+        event, = reporter.events
+        nt.assert_equal(event['title'], event1_title)
+        nt.assert_equal(event['text'], event1_text)
+        nt.assert_equal(event['priority'], event1_priority)
+        nt.assert_equal(event['date_happened'], event1_date_happened)
+        nt.assert_equal(event['tags'], [event1_tag] + constant_tags + test_tags)
+        dog.start(flush_interval=1, roll_up_interval=1)

--- a/tests/util/contextmanagers.py
+++ b/tests/util/contextmanagers.py
@@ -1,0 +1,14 @@
+import os
+from contextlib import contextmanager
+
+
+@contextmanager
+def preserve_environment_variable(env_name):
+    environ_api_param = os.environ.get(env_name)
+    try:
+        yield
+    finally:
+        if environ_api_param is not None:
+            os.environ[env_name] = environ_api_param
+        else:
+            del os.environ[env_name]


### PR DESCRIPTION
creates an additional technique for adding tags to all metrics by defining a comma separated list of tags in the `DOGSTATSD_TAGS` environment variable.

use case:

currently we add a plethora of global tags by adding them to our dd-agent configuration on each node. as we progress towards using container technologies, it would be swell if we could seamlessly inject some of these tags on a container by container basis (app name, version, build) rather than adding them to the dd-agent which will be configured with tags for instance id, region, availability-zone etc.