### PR TITLE
don't send None to statsd daemon as metric value

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -133,10 +133,8 @@ class DogStatsd(object):
         >>> statsd.decrement('files.remaining')
         >>> statsd.decrement('active.connections', 2)
         """
-        if value is None:
-            return
-
-        self._report(metric, 'c', -value, tags, sample_rate)
+        metric_value = -value if value else value
+        self._report(metric, 'c', metric_value, tags, sample_rate)
 
     def histogram(self, metric, value, tags=None, sample_rate=1):
         """

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -133,6 +133,9 @@ class DogStatsd(object):
         >>> statsd.decrement('files.remaining')
         >>> statsd.decrement('active.connections', 2)
         """
+        if value is None:
+            return
+
         self._report(metric, 'c', -value, tags, sample_rate)
 
     def histogram(self, metric, value, tags=None, sample_rate=1):
@@ -231,6 +234,9 @@ class DogStatsd(object):
 
         More information about the packets' format: http://docs.datadoghq.com/guides/dogstatsd/
         """
+        if value is None:
+            return
+
         if sample_rate != 1 and random() > sample_rate:
             return
 

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -429,6 +429,27 @@ class TestDogStatsd(object):
         statsd.gauge('gt', 123.4)
         t.assert_equal('gt:123.4|g|#country:canada,red,country:china,age:45,blue', statsd.socket.recv())
 
+    def test_gauge_doesnt_send_None(self):
+        self.statsd.gauge('metric', None)
+        assert self.recv() is None
+
+    def test_increment_doesnt_send_None(self):
+        self.statsd.increment('metric', None)
+        assert self.recv() is None
+
+    def test_decrement_doesnt_send_None(self):
+        self.statsd.decrement('metric', None)
+        assert self.recv() is None
+
+    def test_timing_doesnt_send_None(self):
+        self.statsd.timing('metric', None)
+        assert self.recv() is None
+
+    def test_histogram_doesnt_send_None(self):
+        self.statsd.histogram('metric', None)
+        assert self.recv() is None
+
+
 if __name__ == '__main__':
     statsd = statsd
     while True:


### PR DESCRIPTION
If you do, you'll get errors like this in `/var/log/messages`:

```
Metric value must be a number: metric.name, None
```