### PR TITLE
[dogshell] add hostname by default to event/metric posts

### DIFF
--- a/datadog/api/base.py
+++ b/datadog/api/base.py
@@ -84,7 +84,7 @@ class HTTPClient(object):
                 if 'series' in body:
                     # Adding the host name to all objects
                     for obj_params in body['series']:
-                        if 'host' not in obj_params:
+                        if obj_params.get('host', "") == "":
                             obj_params['host'] = _host_name
                 else:
                     if body.get('host', "") == "":

--- a/datadog/api/base.py
+++ b/datadog/api/base.py
@@ -87,7 +87,7 @@ class HTTPClient(object):
                         if 'host' not in obj_params:
                             obj_params['host'] = _host_name
                 else:
-                    if 'host' not in body:
+                    if body.get('host', "") == "":
                         body['host'] = _host_name
 
             # If defined, make sure tags are defined as a comma-separated string

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import os
 import sys
 import logging
-import socket
 
 # datadog
 from datadog.util.compat import is_p3k, configparser, IterableUserDict,\
@@ -33,19 +32,6 @@ def report_warnings(res):
             print_err('WARNING: ' + e)
         return True
     return False
-
-
-memoized_hostname = None
-
-
-def find_localhost():
-    try:
-        global memoized_hostname
-        if memoized_hostname is None:
-            memoized_hostname = socket.getfqdn()
-        return memoized_hostname
-    except Exception:
-        logging.exception("Cannot determine local hostname")
 
 
 class DogshellConfig(IterableUserDict):

--- a/datadog/dogshell/metric.py
+++ b/datadog/dogshell/metric.py
@@ -1,6 +1,9 @@
+# stdlib
+from collections import defaultdict
+
 # datadog
 from datadog import api
-from datadog.dogshell.common import report_errors, report_warnings, find_localhost
+from datadog.dogshell.common import report_errors, report_warnings
 
 
 class MetricClient(object):
@@ -14,31 +17,50 @@ class MetricClient(object):
         post_parser.add_argument('name', help="metric name")
         post_parser.add_argument('value', help="metric value (integer or decimal value)",
                                  type=float)
-        post_parser.add_argument('--host', help="scopes your metric to a specific host",
-                                 default=None)
+        post_parser.add_argument('--host', help="scopes your metric to a specific host "
+                                 "(default to the local host name)",
+                                 default="")
+        post_parser.add_argument('--no_host', help="no host is associated with the metric"
+                                 " (overrides --host))", action='store_true')
         post_parser.add_argument('--device', help="scopes your metric to a specific device",
                                  default=None)
         post_parser.add_argument('--tags', help="comma-separated list of tags", default=None)
-        post_parser.add_argument('--localhostname', help="same as --host=`hostname`"
-                                 " (overrides --host)", action='store_true')
+        post_parser.add_argument('--localhostname', help="deprecated, used to force `--host`"
+                                 " to the local hostname "
+                                 "(now default when no `--host` is specified)", action='store_true')
         post_parser.add_argument('--type', help="type of the metric - gauge(32bit float)"
                                  " or counter(64bit integer)", default=None)
         parser.set_defaults(func=cls._post)
 
     @classmethod
     def _post(cls, args):
+        """
+        Post a metric.
+        """
+        # Format parameters
         api._timeout = args.timeout
-        if args.localhostname:
-            host = find_localhost()
-        else:
-            host = args.host
+
+        host = None if args.no_host else args.host
+
         if args.tags:
             tags = sorted(set([t.strip() for t in
                                args.tags.split(',') if t]))
         else:
             tags = None
+
+        # Submit metric
         res = api.Metric.send(
             metric=args.name, points=args.value, host=host,
             device=args.device, tags=tags, metric_type=args.type)
+
+        # Report
+        res = defaultdict(list, res)
+
+        if args.localhostname:
+            # Warn about`--localhostname` command line flag deprecation
+            res['warnings'].append(
+                u"`--localhostname` command line flag is deprecated, made default when no `--host` "
+                u"is specified. See the `--host` option for more information."
+            )
         report_warnings(res)
         report_errors(res)


### PR DESCRIPTION
**[dogshell] add hostname by default to event posts**

By default, `dogshell` event posts (`dog event post` command) are now
automatically associated with the local host.
The `--host` and `--no-host` (new) options allow to override this value
with a given host, or no host.

 ```python
 # Event is associated with the local host
 dog event post "title" "content"

 # Event is associated with `foo.bar` host
 dog event post --host "foo.bar" "title" "content"

 # Event is not associated with any host
 dog event post --no-host "title" "content"
 ```
**[dogshell] add hostname by default to metric posts**

By default, `dogshell` event posts (`dog metric post` command) are now
automatically associated with the local host.
The `--host` and `--no-host` (new) options allow to override this value
with a given host, or no host.
The `--localhostname` option is deprecated, as made default when no
`--host` is set.

 ```python
 # Metric is associated with the local host
 dog metric post "metric.example" 1

 # Metric is associated with `foo.bar` host
 dog metric post --host "foo.bar" "metric.example" 1

 # Metric is not associated with any host
 dog metric post --no-host "metric.example" 1
 ```


Fix #115 