### PR TITLE
[dogshell][py3] print usage when no argument

### DIFF
--- a/datadog/dogshell/__init__.py
+++ b/datadog/dogshell/__init__.py
@@ -51,7 +51,8 @@ def main():
 
     # Set up subparsers for each service
 
-    subparsers = parser.add_subparsers(title='Modes')
+    subparsers = parser.add_subparsers(title='Modes', dest='mode')
+    subparsers.required = True
 
     CommentClient.setup_parser(subparsers)
     SearchClient.setup_parser(subparsers)

--- a/datadog/dogshell/comment.py
+++ b/datadog/dogshell/comment.py
@@ -14,7 +14,9 @@ class CommentClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
         parser = subparsers.add_parser('comment', help="Post, update, and delete comments.")
-        verb_parsers = parser.add_subparsers(title='Verbs')
+
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         post_parser = verb_parsers.add_parser('post', help="Post comments.")
         post_parser.add_argument('--handle', help="handle to post as. if unset, posts as the owner"

--- a/datadog/dogshell/downtime.py
+++ b/datadog/dogshell/downtime.py
@@ -14,7 +14,8 @@ class DowntimeClient(object):
         parser.add_argument('--string_ids', action='store_true', dest='string_ids',
                             help="Represent downtime IDs as strings instead of ints in JSON")
 
-        verb_parsers = parser.add_subparsers(title='Verbs')
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         post_parser = verb_parsers.add_parser('post', help="Create a downtime")
         post_parser.add_argument('scope', help="scope to apply downtime to")

--- a/datadog/dogshell/event.py
+++ b/datadog/dogshell/event.py
@@ -69,7 +69,8 @@ class EventClient(object):
     def setup_parser(cls, subparsers):
         parser = subparsers.add_parser('event', help="Post events, get event details,"
                                        " and view the event stream.")
-        verb_parsers = parser.add_subparsers(title='Verbs')
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         post_parser = verb_parsers.add_parser('post', help="Post events.")
         post_parser.add_argument('title', help="event title")

--- a/datadog/dogshell/event.py
+++ b/datadog/dogshell/event.py
@@ -19,10 +19,9 @@ def prettyprint_event(event):
     date = event['date_happened']
     dt = datetime.datetime.fromtimestamp(date)
     link = event['url']
-    # Encode UTF-8
-    title = title.encode('utf8')
-    handle = handle.encode('utf8')
-    print((title + ' ' + text + ' ' + b' (' + handle + b')').strip())
+
+    # Print
+    print((title + ' ' + text + ' ' + ' (' + handle + ')').strip())
     print(dt.isoformat(' ') + ' | ' + link)
 
 

--- a/datadog/dogshell/host.py
+++ b/datadog/dogshell/host.py
@@ -11,7 +11,8 @@ class HostClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
         parser = subparsers.add_parser('host', help='Mute, unmute hosts')
-        verb_parsers = parser.add_subparsers(title='Verbs')
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         mute_parser = verb_parsers.add_parser('mute', help='Mute a host')
         mute_parser.add_argument('host_name', help='host to mute')

--- a/datadog/dogshell/metric.py
+++ b/datadog/dogshell/metric.py
@@ -8,7 +8,8 @@ class MetricClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
         parser = subparsers.add_parser('metric', help="Post metrics.")
-        verb_parsers = parser.add_subparsers(title='Verbs')
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         post_parser = verb_parsers.add_parser('post', help="Post metrics")
         post_parser.add_argument('name', help="metric name")

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -14,7 +14,8 @@ class MonitorClient(object):
         parser.add_argument('--string_ids', action='store_true', dest='string_ids',
                             help="Represent monitor IDs as strings instead of ints in JSON")
 
-        verb_parsers = parser.add_subparsers(title='Verbs')
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         post_parser = verb_parsers.add_parser('post', help="Create a monitor")
         post_parser.add_argument('type', help="type of the monitor, e.g."

--- a/datadog/dogshell/screenboard.py
+++ b/datadog/dogshell/screenboard.py
@@ -22,7 +22,8 @@ class ScreenboardClient(object):
         parser.add_argument('--string_ids', action='store_true', dest='string_ids',
                             help="Represent screenboard IDs as strings instead of ints in JSON")
 
-        verb_parsers = parser.add_subparsers(title='Verbs')
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         post_parser = verb_parsers.add_parser('post', help="Create screenboards.")
         post_parser.add_argument('title', help="title for the new screenboard")

--- a/datadog/dogshell/search.py
+++ b/datadog/dogshell/search.py
@@ -12,7 +12,8 @@ class SearchClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
         parser = subparsers.add_parser('search', help="search datadog")
-        verb_parsers = parser.add_subparsers(title='Verbs')
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         query_parser = verb_parsers.add_parser('query', help="Search datadog.")
         query_parser.add_argument('query', help="optionally faceted search query")

--- a/datadog/dogshell/service_check.py
+++ b/datadog/dogshell/service_check.py
@@ -11,7 +11,8 @@ class ServiceCheckClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
         parser = subparsers.add_parser('service_check', help="Perform service checks")
-        verb_parsers = parser.add_subparsers(title='Verbs')
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         check_parser = verb_parsers.add_parser('check', help="text for the message")
         check_parser.add_argument('check', help="text for the message")

--- a/datadog/dogshell/tag.py
+++ b/datadog/dogshell/tag.py
@@ -11,7 +11,8 @@ class TagClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
         parser = subparsers.add_parser('tag', help="View and modify host tags.")
-        verb_parsers = parser.add_subparsers(title='Verbs')
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         add_parser = verb_parsers.add_parser('add', help="Add a host to one or more tags.",
                                              description='Hosts can be specified by name or id.')

--- a/datadog/dogshell/timeboard.py
+++ b/datadog/dogshell/timeboard.py
@@ -23,7 +23,8 @@ class TimeboardClient(object):
         parser.add_argument('--string_ids', action='store_true', dest='string_ids',
                             help="Represent timeboard IDs as strings instead of ints in JSON")
 
-        verb_parsers = parser.add_subparsers(title='Verbs')
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
 
         post_parser = verb_parsers.add_parser('post', help="Create timeboards")
         post_parser.add_argument('title', help="title for the new timeboard")

--- a/datadog/util/hostname.py
+++ b/datadog/util/hostname.py
@@ -201,7 +201,7 @@ class EC2(object):
         try:
             iam_role = url_lib.urlopen(EC2.URL + "/iam/security-credentials").read().strip()
             iam_params = json.loads(url_lib.urlopen(EC2.URL + "/iam/security-credentials" + "/" +
-                                    unicode(iam_role)).read().strip())
+                                    str(iam_role)).read().strip())
             from boto.ec2.connection import EC2Connection
             connection = EC2Connection(aws_access_key_id=iam_params['AccessKeyId'],
                                        aws_secret_access_key=iam_params['SecretAccessKey'],
@@ -257,7 +257,7 @@ class EC2(object):
         for k in ('instance-id', 'hostname', 'local-hostname', 'public-hostname', 'ami-id',
                   'local-ipv4', 'public-keys', 'public-ipv4', 'reservation-id', 'security-groups'):
             try:
-                v = url_lib.urlopen(EC2.URL + "/" + unicode(k)).read().strip()
+                v = url_lib.urlopen(EC2.URL + "/" + str(k)).read().strip()
                 assert type(v) in (types.StringType, types.UnicodeType) and len(v) > 0, \
                     "%s is not a string" % v
                 EC2.metadata[k] = v


### PR DESCRIPTION
**[dogshell][py3] print usage when no argument**

In accordance with the behavior on Python 2.x, `dog` command with
Python 3.x should print the usage when no subparser is specified.
Instead, the uncalled code block is executed and raises:
```
AttributeError: 'Namespace' object has no attribute 'func'
```
Fix it and print usage.

More information: http://bugs.python.org/issue16308

Fix #85

**[py3] better compatibility**

Improve compatibility with Python 3.x.
