### PR TITLE
[dogstatsd] fix thread-safety of @timed decorator

### DIFF
--- a/tests/performance/test_statsd_thread_safety.py
+++ b/tests/performance/test_statsd_thread_safety.py
@@ -1,15 +1,17 @@
-import time
+# stdlib
+from collections import deque
 import six
 import threading
-from collections import deque
-from nose import tools as t
+import unittest
 
+# datadog
 from datadog.dogstatsd.base import DogStatsd
 
 
 class FakeSocket(object):
-    """ A fake socket for testing. """
-
+    """
+    Mocked socket for testing.
+    """
     def __init__(self):
         self.payloads = deque()
 
@@ -27,41 +29,177 @@ class FakeSocket(object):
         return str(self.payloads)
 
 
-class DogstatsdTest(DogStatsd):
-    def send_metrics(self):
-        self.increment('whatever')
-
-
-class TestDogStatsdThreadSafety(object):
-
+class TestDogStatsDThreadSafety(unittest.TestCase):
+    """
+    DogStatsD thread safety tests.
+    """
     def setUp(self):
+        """
+        Mock a socket.
+        """
         self.socket = FakeSocket()
 
-    def recv(self):
-        return self.socket.recv()
+    def assertMetrics(self, values):
+        """
+        Helper, assertions on metrics.
+        """
+        count = len(values)
 
-    def test_send_metrics(self):
-        statsd = DogstatsdTest()
-        statsd.socket = self.socket
-        for _ in range(10000):
-            threading.Thread(target=statsd.send_metrics).start()
-        time.sleep(1)
-        t.assert_equal(10000, len(self.recv()), len(self.recv()))
+        # Split packet per metric (required when buffered) and discard empty packets
+        packets = map(lambda x: x.split("\n"), self.socket.recv())
+        packets = reduce(lambda prev, ele: prev + ele, packets, [])
+        packets = filter(lambda x: x, packets)
 
-    def test_send_batch_metrics(self):
-        with DogstatsdTest() as batch:
-            batch.socket = self.socket
-            for _ in range(10000):
-                threading.Thread(target=batch.send_metrics).start()
-        time.sleep(1)
-        payload = map(lambda x: x.split("\n"), self.recv())
-        payload = reduce(lambda prev, ele: prev + ele, payload, [])
-        t.assert_equal(10001, len(payload), len(payload))
+        # Count
+        self.assertEquals(
+            len(packets), count,
+            u"Metric size assertion failed: expected={expected}, received={received}".format(
+                expected=count, received=len(packets)
+            )
+        )
+        # Values
+        for packet in packets:
+            metric_value = int(packet.split(':', 1)[1].split('|', 1)[0])
+            self.assertIn(
+                metric_value, values,
+                u"Metric assertion failed: unexpected metric value {metric_value}".format(
+                    metric_value=metric_value
+                )
+            )
+            values.remove(metric_value)
 
     def test_socket_creation(self):
         """
-        Assess thread safeness in socket creation.
+        Socket creation plays well with multiple threads.
         """
-        statsd = DogstatsdTest()
-        for _ in range(10000):
-            threading.Thread(target=statsd.send_metrics).start()
+        # Create a DogStatsD client but no socket
+        statsd = DogStatsd()
+
+        # Submit metrics from different threads to create a socket
+        threads = []
+        for value in range(10000):
+            t = threading.Thread(target=statsd.gauge, args=("foo", value))
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+
+    @staticmethod
+    def _submit_with_multiple_threads(statsd, submit_method, values):
+        """
+        Helper, use the given statsd client and method to submit the values
+        within multiple threads.
+        """
+        threads = []
+        for value in values:
+            t = threading.Thread(
+                target=getattr(statsd, submit_method),
+                args=("foo", value)
+            )
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+
+    def test_increment(self):
+        """
+        Increments can be submitted from concurrent threads.
+        """
+        # Create a DogStatsD client with a mocked socket
+        statsd = DogStatsd()
+        statsd.socket = self.socket
+
+        # Samples
+        values = set(range(10000))
+
+        # Submit metrics from different threads
+        self._submit_with_multiple_threads(statsd, "increment", values)
+
+        #  All metrics were properly submitted
+        self.assertMetrics(values)
+
+    def test_decrement(self):
+        """
+        Decrements can be submitted from concurrent threads.
+        """
+        # Create a DogStatsD client with a mocked socket
+        statsd = DogStatsd()
+        statsd.socket = self.socket
+
+        # Samples
+        values = set(range(10000))
+        expected_value = set([-value for value in values])
+
+        # Submit metrics from different threads
+        self._submit_with_multiple_threads(statsd, "decrement", expected_value)
+
+        #  All metrics were properly submitted
+        self.assertMetrics(values)
+
+    def test_gauge(self):
+        """
+        Gauges can be submitted from concurrent threads.
+        """
+        # Create a DogStatsD client with a mocked socket
+        statsd = DogStatsd()
+        statsd.socket = self.socket
+
+        # Samples
+        values = set(range(10000))
+
+        # Submit metrics from different threads
+        self._submit_with_multiple_threads(statsd, "gauge", values)
+
+        #  All metrics were properly submitted
+        self.assertMetrics(values)
+
+    def test_histogram(self):
+        """
+        Histograms can be submitted from concurrent threads.
+        """
+        # Create a DogStatsD client with a mocked socket
+        statsd = DogStatsd()
+        statsd.socket = self.socket
+
+        # Samples
+        values = set(range(10000))
+
+        # Submit metrics from different threads
+        self._submit_with_multiple_threads(statsd, "histogram", values)
+
+        #  All metrics were properly submitted
+        self.assertMetrics(values)
+
+    def test_timing(self):
+        """
+        Timings can be submitted from concurrent threads.
+        """
+        # Create a DogStatsD client with a mocked socket
+        statsd = DogStatsd()
+        statsd.socket = self.socket
+
+        # Samples
+        values = set(range(10000))
+
+        # Submit metrics from different threads
+        self._submit_with_multiple_threads(statsd, "timing", values)
+
+        # All metrics were properly submitted
+        self.assertMetrics(values)
+
+    def test_send_batch_metrics(self):
+        """
+        Metrics can be buffered, submitted from concurrent threads.
+        """
+        with DogStatsd() as batch_statsd:
+            # Create a DogStatsD buffer client with a mocked socket
+            batch_statsd.socket = self.socket
+
+            # Samples
+            values = set(range(10000))
+
+            # Submit metrics from different threads
+            self._submit_with_multiple_threads(batch_statsd, "gauge", values)
+
+        # All metrics were properly submitted
+        self.assertMetrics(values)

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -7,6 +7,7 @@ from collections import deque
 import os
 import six
 import socket
+import threading
 import time
 
 from nose import tools as t


### PR DESCRIPTION
**[dogstatsd][test] rewrite thread safety tests**
Rewrite DogStatsd thread safety tests.

**[dogstatsd] fix thread-safety of @timed decorator**
Rebase of #112.
> When using @timed as a decorator, it's not thread-safe to call itself as a context manager. The decorator creates one instance of this class, and since the context manager stores the start time on the instance, calling it again in parallel will overwrite the start time of the earlier call.
So, for the decorator version, the start time needs to be kept in the call
stack.
This includes a test case which demonstrates the problem.

Rebased to move tests to `tests/unit/dogstatsd/test_statsd.py`
Thanks again @mgood !