### PR TITLE
[api] events are deletable

### DIFF
--- a/datadog/api/events.py
+++ b/datadog/api/events.py
@@ -1,9 +1,9 @@
 from datadog.api.resources import GetableAPIResource, CreateableAPIResource, \
-    SearchableAPIResource
+    SearchableAPIResource, DeletableAPIResource
 from datadog.util.compat import iteritems
 
 
-class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource):
+class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource, DeletableAPIResource):
     """
     A wrapper around Event HTTP API.
     """


### PR DESCRIPTION
We're adding a delete endpoint for events in the app, so this PR makes `Event`s `Deletable`.