### PR TITLE
_TimedContextManagerDecorator enter -> self

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -209,6 +209,7 @@ class DogStatsd(object):
             if not self.metric:
                 raise TypeError("Cannot used timed without a metric!")
             self.start = time()
+            return self
 
         def __exit__(self, type, value, traceback):
             # Report the elapsed time of the context manager.

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -314,8 +314,8 @@ class TestDogStatsd(object):
         """
         # In seconds
         with self.statsd.timed('timed_context.test') as timer:
-            self.assertIsInstance(timer,
-                                  DogStatsd._TimedContextManagerDecorator)
+            self.assert_is_instance(timer,
+                                    DogStatsd._TimedContextManagerDecorator)
             time.sleep(0.5)
 
         packet = self.recv()

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -313,7 +313,9 @@ class TestDogStatsd(object):
         Measure the distribution of a context's run time.
         """
         # In seconds
-        with self.statsd.timed('timed_context.test'):
+        with self.statsd.timed('timed_context.test') as timer:
+            self.assertIsInstance(timer,
+                                  DogStatsd._TimedContextManagerDecorator)
             time.sleep(0.5)
 
         packet = self.recv()

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -314,8 +314,7 @@ class TestDogStatsd(object):
         """
         # In seconds
         with self.statsd.timed('timed_context.test') as timer:
-            self.assert_is_instance(timer,
-                                    DogStatsd._TimedContextManagerDecorator)
+            t.assert_is_instance(timer, DogStatsd._TimedContextManagerDecorator)
             time.sleep(0.5)
 
         packet = self.recv()


### PR DESCRIPTION
Have `_TimedContextManagerDecorator` return `self` from `__enter__` so that it can be modified within the block. e.g.

```Python
with timed('foo.bar', tags=['key:val']) as timer:
    # do some stuff
    if blip:
       timer.tags.append('result:blip')
```

This can be worked around by assigning timed's result to a var and then doing a `with timer`, but this is much cleaner and shouldn't result in any backwards compatibility issues. 