### PR TITLE
[ci] test with python 3.5 ✅

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 sudo: false
 language: python
-python: 2.7
+python:
+  - 3.5
 env:
   - TOX_ENV=py26
   - TOX_ENV=py27
   - TOX_ENV=pypy
   - TOX_ENV=py33
   - TOX_ENV=py34
+  - TOX_ENV=py35
   - TOX_ENV=flake8
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 	pypy,
 	py33,
 	py34,
+	py35,
 	flake8
 
 [testenv]


### PR DESCRIPTION
Set Travis CI and Tox to test with Python 3.5.
Fix #148.