### PR TITLE
[dogstatsd] support unicode tags 🔣

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -2,19 +2,22 @@
 """
 DogStatsd is a Python client for DogStatsd, a Statsd fork for Datadog.
 """
-
-import logging
-import os
+# stdlib
+from functools import wraps
 from random import random
 from time import time
+import logging
+import os
 import socket
 import struct
-from functools import wraps
 
 try:
     from itertools import imap
 except ImportError:
     imap = map
+
+# datadog
+from datadog.util.compat import text
 
 
 log = logging.getLogger('dogstatsd')
@@ -289,7 +292,7 @@ class DogStatsd(object):
         if tags:
             payload.extend(["|#", ",".join(tags)])
 
-        encoded = "".join(imap(str, payload))
+        encoded = "".join(imap(text, payload))
 
         # Send it
         self._send(encoded)

--- a/datadog/util/compat.py
+++ b/datadog/util/compat.py
@@ -24,6 +24,8 @@ if is_p3k():
     def iternext(iter):
         return next(iter)
 
+    text = str
+
 else:
     get_input = raw_input
     import ConfigParser as configparser
@@ -35,6 +37,8 @@ else:
 
     def iternext(iter):
         return iter.next()
+
+    text = unicode
 
 
 try:

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -103,8 +103,8 @@ class TestDogStatsd(object):
         t.assert_equal('gt:123.4|g|#country:china,age:45,blue', self.recv())
 
     def test_tagged_counter(self):
-        self.statsd.increment('ct', tags=['country:canada', 'red'])
-        t.assert_equal('ct:1|c|#country:canada,red', self.recv())
+        self.statsd.increment('ct', tags=[u'country:españa', 'red'])
+        t.assert_equal(u'ct:1|c|#country:españa,red', self.recv())
 
     def test_tagged_histogram(self):
         self.statsd.histogram('h', 1, tags=['red'])


### PR DESCRIPTION
Using unicode with DogStatsD tags causes `UnicodeDecodeError`
exceptions.

Do not raise on unicode tags. Fix #132.