### PR TITLE
Allow starting and stopping timed() manually

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -224,6 +224,12 @@ class DogStatsd(object):
             elapsed = int(round(1000 * elapsed)) if use_ms else elapsed
             self.statsd.timing(self.metric, elapsed, self.tags, self.sample_rate)
 
+        def start(self):
+            self.__enter__()
+
+        def stop(self):
+            self.__exit__(None, None, None)
+
     def timed(self, metric=None, tags=None, sample_rate=1, use_ms=None):
         """
         A decorator or context manager that will measure the distribution of a

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -375,6 +375,35 @@ class TestDogStatsd(object):
         packet = self.recv()
         t.assert_equal(packet, None)
 
+    def test_timed_start_stop_calls(self):
+        # In seconds
+        timer = self.statsd.timed('timed_context.test')
+        timer.start()
+        time.sleep(0.5)
+        timer.stop()
+
+        packet = self.recv()
+        name_value, type_ = packet.split('|')
+        name, value = name_value.split(':')
+
+        t.assert_equal('ms', type_)
+        t.assert_equal('timed_context.test', name)
+        self.assert_almost_equal(0.5, float(value), 0.1)
+
+        # In milliseconds
+        timer = self.statsd.timed('timed_context.test', use_ms=True)
+        timer.start()
+        time.sleep(0.5)
+        timer.stop()
+
+        packet = self.recv()
+        name_value, type_ = packet.split('|')
+        name, value = name_value.split(':')
+
+        t.assert_equal('ms', type_)
+        t.assert_equal('timed_context.test', name)
+        self.assert_almost_equal(500, float(value), 100)
+
     def test_batched(self):
         self.statsd.open_buffer()
         self.statsd.gauge('page.views', 123)


### PR DESCRIPTION
Added support for manually starting and stopping a timer.

Now it can be used something like this:

```python
@app.before_request
def before():
    request.page_load_timer = statsd.timed('metric')
    request.page_load_timer.start()

@app.after_request
def after():
    request.page_load_timer.stop()
```