### PR TITLE
[dogstatsd] `timed` support for coroutine functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ nosetests.xml
 .DS_Store
 .eggs/
 .env/
+.idea/

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -3,35 +3,21 @@
 DogStatsd is a Python client for DogStatsd, a Statsd fork for Datadog.
 """
 # stdlib
-from functools import wraps
-
-import sys
 from random import random
-from time import time
 import logging
 import os
 import socket
 import struct
 
-try:
-    from itertools import imap
-except ImportError:
-    imap = map
+# datadog
+from datadog.dogstatsd.context import TimedContextManagerDecorator
+from datadog.util.compat import imap
 
 # datadog
 from datadog.util.compat import text
 
 
 log = logging.getLogger('dogstatsd')
-
-PY_35 = sys.version_info >= (3, 5)
-
-if PY_35:
-    from asyncio import iscoroutinefunction
-    from .base3 import _get_wrapped_co
-else:
-    def iscoroutinefunction(_):
-        return False
 
 
 class DogStatsd(object):
@@ -191,61 +177,6 @@ class DogStatsd(object):
         """
         self._report(metric, 'ms', value, tags, sample_rate)
 
-    class _TimedContextManagerDecorator(object):
-        """
-        A context manager and a decorator which will report the elapsed time in
-        the context OR in a function call.
-        """
-
-        def __init__(self, statsd, metric=None, tags=None, sample_rate=1, use_ms=None):
-            self.statsd = statsd
-            self.metric = metric
-            self.tags = tags
-            self.sample_rate = sample_rate
-            self.use_ms = use_ms
-            self.elapsed = None
-
-        def __call__(self, func):
-            """Decorator which returns the elapsed time of the function call."""
-            # Default to the function name if metric was not provided.
-            if not self.metric:
-                self.metric = '%s.%s' % (func.__module__, func.__name__)
-
-            if iscoroutinefunction(func):
-                return _get_wrapped_co(self, func)
-
-            @wraps(func)
-            def wrapped(*args, **kwargs):
-                start = time()
-                try:
-                    return func(*args, **kwargs)
-                finally:
-                    self._send(start)
-            return wrapped
-
-        def __enter__(self):
-            if not self.metric:
-                raise TypeError("Cannot used timed without a metric!")
-            self.start = time()
-            return self
-
-        def __exit__(self, type, value, traceback):
-            # Report the elapsed time of the context manager.
-            self._send(self.start)
-
-        def _send(self, start):
-            elapsed = time() - start
-            use_ms = self.use_ms if self.use_ms is not None else self.statsd.use_ms
-            elapsed = int(round(1000 * elapsed)) if use_ms else elapsed
-            self.statsd.timing(self.metric, elapsed, self.tags, self.sample_rate)
-            self.elapsed = elapsed
-
-        def start(self):
-            self.__enter__()
-
-        def stop(self):
-            self.__exit__(None, None, None)
-
     def timed(self, metric=None, tags=None, sample_rate=1, use_ms=None):
         """
         A decorator or context manager that will measure the distribution of a
@@ -272,7 +203,7 @@ class DogStatsd(object):
             finally:
                 statsd.timing('user.query.time', time.time() - start)
         """
-        return self._TimedContextManagerDecorator(self, metric, tags, sample_rate, use_ms)
+        return TimedContextManagerDecorator(self, metric, tags, sample_rate, use_ms)
 
     def set(self, metric, value, tags=None, sample_rate=1):
         """

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -24,10 +24,10 @@ from datadog.util.compat import text
 
 log = logging.getLogger('dogstatsd')
 
-PY_35 = sys.version_info >= (3, 5)
+PY_34 = sys.version_info >= (3, 4)
 
-if PY_35:
-    from asyncio import iscoroutinefunction
+if PY_34:
+    from asyncio import iscoroutinefunction, coroutine
 
 
 class DogStatsd(object):
@@ -207,13 +207,15 @@ class DogStatsd(object):
             if not self.metric:
                 self.metric = '%s.%s' % (func.__module__, func.__name__)
 
-            if PY_35:
+            if PY_34:
                 if iscoroutinefunction(func):
                     @wraps(func)
-                    async def wrapped_co(*args, **kwargs):
+                    @coroutine
+                    def wrapped_co(*args, **kwargs):
                         start = time()
                         try:
-                            return await func(*args, **kwargs)
+                            result = yield from func(*args, **kwargs)
+                            return result
                         finally:
                             self._send(start)
                     return wrapped_co

--- a/datadog/dogstatsd/base3.py
+++ b/datadog/dogstatsd/base3.py
@@ -1,0 +1,14 @@
+from functools import wraps
+from time import time
+
+
+def _get_wrapped_co(self, func):
+    @wraps(func)
+    async def wrapped_co(*args, **kwargs):
+        start = time()
+        try:
+            result = await func(*args, **kwargs)
+            return result
+        finally:
+            self._send(start)
+    return wrapped_co

--- a/datadog/dogstatsd/context.py
+++ b/datadog/dogstatsd/context.py
@@ -1,0 +1,79 @@
+# stdlib
+from functools import wraps
+from time import time
+
+# datadog
+from datadog.util.compat import (
+    is_higher_py35,
+    iscoroutinefunction,
+)
+
+
+if is_higher_py35():
+    from datadog.dogstatsd.context_async import _get_wrapped_co
+else:
+    def _get_wrapped_co(self, func):
+        raise NotImplementedError(
+            u"Decorator `timed` compatibility with coroutine functions"
+            u" requires Python 3.5 or higher."
+        )
+
+
+class TimedContextManagerDecorator(object):
+    """
+    A context manager and a decorator which will report the elapsed time in
+    the context OR in a function call.
+    """
+    def __init__(self, statsd, metric=None, tags=None, sample_rate=1, use_ms=None):
+        self.statsd = statsd
+        self.metric = metric
+        self.tags = tags
+        self.sample_rate = sample_rate
+        self.use_ms = use_ms
+        self.elapsed = None
+
+    def __call__(self, func):
+        """
+        Decorator which returns the elapsed time of the function call.
+
+        Default to the function name if metric was not provided.
+        """
+        if not self.metric:
+            self.metric = '%s.%s' % (func.__module__, func.__name__)
+
+        # Coroutines
+        if iscoroutinefunction(func):
+            return _get_wrapped_co(self, func)
+
+        # Others
+        @wraps(func)
+        def wrapped(*args, **kwargs):
+            start = time()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                self._send(start)
+        return wrapped
+
+    def __enter__(self):
+        if not self.metric:
+            raise TypeError("Cannot used timed without a metric!")
+        self.start = time()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        # Report the elapsed time of the context manager.
+        self._send(self.start)
+
+    def _send(self, start):
+        elapsed = time() - start
+        use_ms = self.use_ms if self.use_ms is not None else self.statsd.use_ms
+        elapsed = int(round(1000 * elapsed)) if use_ms else elapsed
+        self.statsd.timing(self.metric, elapsed, self.tags, self.sample_rate)
+        self.elapsed = elapsed
+
+    def start(self):
+        self.__enter__()
+
+    def stop(self):
+        self.__exit__(None, None, None)

--- a/datadog/dogstatsd/context_async.py
+++ b/datadog/dogstatsd/context_async.py
@@ -1,8 +1,17 @@
+"""
+Decorator `timed` for coroutine methods.
+
+Warning: requires Python 3.5 or higher.
+"""
+# stdlib
 from functools import wraps
 from time import time
 
 
 def _get_wrapped_co(self, func):
+    """
+    `timed` wrapper for coroutine methods.
+    """
     @wraps(func)
     async def wrapped_co(*args, **kwargs):
         start = time()


### PR DESCRIPTION
Rebase of #146.

**Additional changes:**
* Move Python 3.5+ evaluation methods to `datadog.util.compat` module
* Move `TimedContextManager` to `datadog.dogstatsd.context` module
* Quarantine `TimedContextManager` coroutine decorator in
  `datadog.dogstatsd.context_async`
* Unit test coverage to assert DogStatsd compatibility with coroutine
  functions


Thanks a lot of @thehesiod 🙇 