### PR TITLE
[logging] rename loggers and set handlers to null

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -8,6 +8,7 @@ without hindering performance.
 * datadog.dogshell: a command-line tool, wrapping datadog.api, to interact with Datadog REST API.
 """
 # stdlib
+import logging
 import os
 import os.path
 
@@ -21,6 +22,11 @@ from datadog.util.hostname import get_hostname
 
 
 __version__ = get_version()
+
+# Loggers
+logging.getLogger('datadog.api').addHandler(logging.NullHandler())
+logging.getLogger('datadog.dogstatsd').addHandler(logging.NullHandler())
+logging.getLogger('datadog.threadstats').addHandler(logging.NullHandler())
 
 
 def initialize(api_key=None, app_key=None, host_name=None, api_host=None,

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -10,7 +10,7 @@ from datadog.api.http_client import resolve_http_client
 from datadog.util.compat import json, is_p3k
 
 
-log = logging.getLogger('dd.datadogpy')
+log = logging.getLogger('datadog.api')
 
 
 class APIClient(object):

--- a/datadog/api/http_client.py
+++ b/datadog/api/http_client.py
@@ -24,7 +24,7 @@ except ImportError:
 from datadog.api.exceptions import ClientError, HTTPError, HttpTimeout
 
 
-log = logging.getLogger('dd.datadogpy')
+log = logging.getLogger('datadog.api')
 
 
 class HTTPClient(object):

--- a/datadog/api/resources.py
+++ b/datadog/api/resources.py
@@ -1,14 +1,8 @@
 """
 Datadog API resources.
 """
-# stdlib
-import logging
-
 # datadog
 from datadog.api.api_client import APIClient
-
-
-log = logging.getLogger('dd.datadogpy')
 
 
 class CreateableAPIResource(object):

--- a/datadog/dogshell/__init__.py
+++ b/datadog/dogshell/__init__.py
@@ -1,5 +1,4 @@
 # stdlib
-import logging
 import os
 
 # 3p
@@ -21,11 +20,8 @@ from datadog.dogshell.tag import TagClient
 from datadog.dogshell.timeboard import TimeboardClient
 from datadog.util.config import get_version
 
-logging.getLogger('dd.datadogpy').setLevel(logging.CRITICAL)
-
 
 def main():
-
     parser = argparse.ArgumentParser(description="Interact with the Datadog API",
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--config', help="location of your dogrc file (default ~/.dogrc)",
@@ -49,7 +45,6 @@ def main():
     config = DogshellConfig()
 
     # Set up subparsers for each service
-
     subparsers = parser.add_subparsers(title='Modes', dest='mode')
     subparsers.required = True
 

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -2,13 +2,10 @@
 from __future__ import print_function
 import os
 import sys
-import logging
 
 # datadog
 from datadog.util.compat import is_p3k, configparser, IterableUserDict,\
     get_input
-
-log = logging.getLogger('dd.datadogpy')
 
 
 def print_err(msg):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -20,7 +20,8 @@ except ImportError:
 from datadog.util.compat import text
 
 
-log = logging.getLogger('dogstatsd')
+# Logging
+log = logging.getLogger('datadog.dogstatsd')
 
 
 class DogStatsd(object):

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -18,7 +18,7 @@ from datadog.threadstats.events import EventsAggregator
 from datadog.threadstats.reporters import HttpReporter
 
 # Loggers
-log = logging.getLogger('dd.datadogpy')
+log = logging.getLogger('datadog.threadstats')
 
 
 class ThreadStats(object):

--- a/datadog/util/config.py
+++ b/datadog/util/config.py
@@ -1,5 +1,4 @@
 import os
-import logging
 import string
 import sys
 
@@ -8,8 +7,6 @@ from datadog.util.compat import configparser, StringIO, is_p3k, pkg
 
 # CONSTANTS
 DATADOG_CONF = "datadog.conf"
-
-log = logging.getLogger('dd.datadogpy')
 
 
 class CfgNotFound(Exception):

--- a/datadog/util/hostname.py
+++ b/datadog/util/hostname.py
@@ -12,7 +12,7 @@ from datadog.util.config import get_config, get_os, CfgNotFound
 VALID_HOSTNAME_RFC_1123_PATTERN = re.compile(r"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$")  # noqa
 MAX_HOSTNAME_LEN = 255
 
-log = logging.getLogger('dd.datadogpy')
+log = logging.getLogger('datadog.api')
 
 
 def is_valid_hostname(hostname):


### PR DESCRIPTION
Split `dd.datadogpy` logger to one per module, i.e.
* `datadog.api`
* `datadog.dogstatsd`
* `datadog.threadstats`

Setup the `NullHandler` handler by default as advised in
https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library