### PR TITLE
[dogstatsd] better exceptions on route resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+# 0.15.0 / Unreleased
+* [IMPROVEMENT] DogStatsD: Better exceptions on system default route resolution failures [#166][], [#156][]
+
+
 # 0.14.0 / 2016-09-22
 
 **Logging**
@@ -194,7 +198,9 @@ See [#8][], thanks [@benweatherman][]
 [#152]: https://github.com/DataDog/datadogpy/issues/152
 [#154]: https://github.com/DataDog/datadogpy/issues/154
 [#155]: https://github.com/DataDog/datadogpy/issues/155
+[#156]: https://github.com/DataDog/datadogpy/issues/156
 [#161]: https://github.com/DataDog/datadogpy/issues/161
+[#166]: https://github.com/DataDog/datadogpy/issues/166
 [@GrahamDumpleton]: https://github.com/GrahamDumpleton
 [@aknuds1]: https://github.com/aknuds1
 [@aristiden7o]: https://github.com/aristiden7o

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -72,15 +72,12 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     api._api_host = api_host if api_host is not None else \
         os.environ.get('DATADOG_HOST', 'https://app.datadoghq.com')
 
-    # Statsd configuration -overrides default statsd instance attributes-
-    if statsd_host:
-        statsd.host = statsd_host
-
+    # Statsd configuration
+    # ...overrides the default `statsd` instance attributes
+    if statsd_host or statsd_use_default_route:
+        statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)
     if statsd_port:
         statsd.port = int(statsd_port)
-
-    if statsd_use_default_route:
-        statsd.use_default_route = statsd_use_default_route
 
     # HTTP client and API options
     for key, value in iteritems(kwargs):

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -4,11 +4,15 @@ import time
 
 # datadog
 from datadog.api import _api_version, _max_timeouts, _backoff_period
-from datadog.api.exceptions import ClientError, ApiError, HttpBackoff, \
-    HttpTimeout, ApiNotInitialized
+from datadog.api.exceptions import (
+    ClientError,
+    ApiError,
+    HttpBackoff,
+    HttpTimeout,
+    ApiNotInitialized
+)
 from datadog.api.http_client import resolve_http_client
 from datadog.util.compat import json, is_p3k
-
 
 log = logging.getLogger('datadog.api')
 

--- a/datadog/dogstatsd/route.py
+++ b/datadog/dogstatsd/route.py
@@ -1,0 +1,38 @@
+"""
+Helper(s), resolve the system's default interface.
+"""
+# stdlib
+import socket
+import struct
+
+
+class UnresolvableDefaultRoute(Exception):
+    """
+    Unable to resolve system's default route.
+    """
+
+
+def get_default_route():
+    """
+    Return the system default interface using the proc filesystem.
+
+    Returns:
+        string: default route
+
+    Raises:
+        `NotImplementedError`: No proc filesystem is found (non-Linux systems)
+        `StopIteration`: No default route found
+    """
+    try:
+        with open('/proc/net/route') as f:
+            for line in f.readlines():
+                fields = line.strip().split()
+                if fields[1] == '00000000':
+                    return socket.inet_ntoa(struct.pack('<L', int(fields[2], 16)))
+    except IOError:
+        raise NotImplementedError(
+            u"Unable to open `/proc/net/route`. "
+            u"`use_default_route` option is available on Linux only."
+        )
+
+    raise UnresolvableDefaultRoute(u"Unable to resolve the system default's route.")

--- a/datadog/util/compat.py
+++ b/datadog/util/compat.py
@@ -34,6 +34,7 @@ get_input = input
 # Python 3.x
 if is_p3k():
     from io import StringIO
+    import builtins
     import configparser
     import urllib.request as url_lib, urllib.error, urllib.parse
 
@@ -49,6 +50,7 @@ if is_p3k():
 
 # Python 2.x
 else:
+    import __builtin__ as builtins
     from cStringIO import StringIO
     from itertools import imap
     import ConfigParser as configparser

--- a/tests/unit/dogstatsd/fixtures.py
+++ b/tests/unit/dogstatsd/fixtures.py
@@ -1,0 +1,15 @@
+"""
+Helper(s), load fixtures.
+"""
+# stdlib
+import os
+
+
+def load_fixtures(name):
+    """
+    Load fixtures.
+
+    Args:
+        name (string): name of the fixture
+    """
+    return open(os.path.join(os.path.dirname(__file__), 'fixtures', '{}'.format(name))).read()

--- a/tests/unit/dogstatsd/fixtures/route
+++ b/tests/unit/dogstatsd/fixtures/route
@@ -1,0 +1,3 @@
+Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+eth0	00000000	010011AC	0003	0	0	0	00000000	0	0	0                                                                               
+eth0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0                                                                               


### PR DESCRIPTION
DogStatsd fails resolving the system's default route in the following
scenarios:
* no proc filesystem
* no default gateway found in `/proc/net/route`

Raise user intelligible exceptions in those cases.


Fix https://github.com/DataDog/datadogpy/issues/156