### PR TITLE
fix socket "leak"

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -40,8 +40,8 @@ class DogStatsd(object):
         if sending metrics in batch
         :type max_buffer_size: integer
 
-        :param namepace: Namespace to prefix all metric names
-        :type namepace: string
+        :param namespace: Namespace to prefix all metric names
+        :type namespace: string
 
         :param constant_tags: Tags to attach to all metrics
         :type constant_tags: list of strings
@@ -259,7 +259,11 @@ class DogStatsd(object):
             (self.socket or self.get_socket()).send(packet.encode(self.encoding))
         except socket.error:
             log.info("Error submitting packet, will try refreshing the socket")
-            self.socket = None
+
+            if self.socket:
+                self.socket.close()
+                self.socket = None
+
             try:
                 self.get_socket().send(packet.encode(self.encoding))
             except socket.error:

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -216,6 +216,14 @@ class DogStatsd(object):
         """
         self._report(metric, 's', value, tags, sample_rate)
 
+    def close_socket(self):
+        """
+        Closes connected socket if connected.
+        """
+        if self.socket:
+            self.socket.close()
+            self.socket = None
+
     def _report(self, metric, metric_type, value, tags, sample_rate):
         """
         Create a metric packet and send it.
@@ -260,13 +268,13 @@ class DogStatsd(object):
         except socket.error:
             log.info("Error submitting packet, will try refreshing the socket")
 
-            if self.socket:
-                self.socket.close()
-                self.socket = None
+            self.close_socket()
 
             try:
                 self.get_socket().send(packet.encode(self.encoding))
             except socket.error:
+                self.close_socket()
+
                 log.exception("Failed to send packet with a newly binded socket")
 
     def _send_to_buffer(self, packet):

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -44,6 +44,9 @@ class FakeSocket(object):
         except IndexError:
             return None
 
+    def close(self):
+        pass
+
     def __repr__(self):
         return str(self.payloads)
 


### PR DESCRIPTION
Our unittests have been printing out warnings for awhile since we're unable to close the socket after it's nulled out.  This ensures the socket is closed if it was opened.