### PR TITLE
[api] set follow_redirects=False on App Engine; recommended in docs

### DIFF
--- a/datadog/api/http_client.py
+++ b/datadog/api/http_client.py
@@ -120,7 +120,10 @@ class URLFetchClient(HTTPClient):
                 headers=headers,
                 validate_certificate=validate_certificate,
                 deadline=timeout,
-                payload=data
+                payload=data,
+                # setting follow_redirects=False may be slightly faster:
+                # https://cloud.google.com/appengine/docs/python/microservice-performance#use_the_shortest_route
+                follow_redirects=False
             )
 
             cls.raise_on_status(result)


### PR DESCRIPTION
The documentation at the following URL states: "Explicitly set
follow_redirects=False when calling Urlfetch, as it avoids a heavier-weight
service designed to follow redirects." I have not been able to measure any
significant difference, but since the Datadog API doesn't use redirects,
this should be a safe change. Source:

https://cloud.google.com/appengine/docs/python/microservice-performance#use_the_shortest_route


We will be using this in production at Bluecore very shortly. Happy to abandon this or sign a CLA or whatever you might want me to do. Thanks!