### PR TITLE
catch value errors and mute if applicable

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -177,6 +177,15 @@ class APIClient(object):
                     return error_formatter(e.args[0])
             else:
                 raise
+        except ValueError as e:
+            if _mute:
+                log.error(str(e))
+                if error_formatter is None:
+                    return {'errors': e.args[0]}
+                else:
+                    return error_formatter({'errors': e.args[0]})
+            else:
+                raise
 
     @classmethod
     def _should_submit(cls):


### PR DESCRIPTION
currently this api wrapper will catch most errors and obey the `_mute` property to ignore errors, except in the case of invalid JSON being returned from datadog (aka, a 403 forbidden).  this PR catches the value error and only raises it if `_mute` is `False`