### PR TITLE
Correct docstring for histogram

### DIFF
--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -188,9 +188,9 @@ class ThreadStats(object):
     def histogram(self, metric_name, value, timestamp=None, tags=None, sample_rate=1, host=None):
         """
         Sample a histogram value. Histograms will produce metrics that
-        describe the distribution of the recorded values, namely the minimum,
-        maximum, average, count and the 75th, 85th, 95th and 99th percentiles.
-        Optionally, specify a list of ``tags`` to associate with the metric.
+        describe the distribution of the recorded values, namely the maximum,
+        median, average, count and the 95th percentile. Optionally, specify 
+        a list of ``tags`` to associate with the metric.
 
         >>> stats.histogram('uploaded_file.size', uploaded_file.size())
         """


### PR DESCRIPTION
By default, histogram sends a more limited set of metrics than the documetation claims. 