### PR TITLE
Bump default timeout from 3 to 60 seconds.

### DIFF
--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -10,7 +10,7 @@ _cacert = True
 
 # HTTP(S) settings
 _proxies = None
-_timeout = 3
+_timeout = 60
 _max_timeouts = 3
 _max_retries = 3
 _backoff_period = 300


### PR DESCRIPTION
We have  1000+ monitors in our setup, and often hit the 3 default timeout of 3 seconds when poking around using datadog/api.

This bumps the default setting to 60 seconds, which allows us to retrieve our monitors. I do realise  bumping the default value is not the most subtle approach, but as 3 seconds is pretty short -much shorter than any CLI http client I've seen, and considering the REST response times for larger customers are often over 3 seconds this could be good enough.