### PR TITLE
Add metric metadata endpoints

### DIFF
--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -22,7 +22,7 @@ from datadog.api.downtimes import Downtime
 from datadog.api.timeboards import Timeboard
 from datadog.api.events import Event
 from datadog.api.infrastructure import Infrastructure
-from datadog.api.infrastructure import Metadata
+from datadog.api.metadata import Metadata
 from datadog.api.metrics import Metric
 from datadog.api.monitors import Monitor
 from datadog.api.screenboards import Screenboard

--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -22,6 +22,7 @@ from datadog.api.downtimes import Downtime
 from datadog.api.timeboards import Timeboard
 from datadog.api.events import Event
 from datadog.api.infrastructure import Infrastructure
+from datadog.api.infrastructure import Metadata
 from datadog.api.metrics import Metric
 from datadog.api.monitors import Monitor
 from datadog.api.screenboards import Screenboard

--- a/datadog/api/metadata.py
+++ b/datadog/api/metadata.py
@@ -1,0 +1,64 @@
+# stdlib
+import time
+from numbers import Number
+
+# datadog
+from datadog.api.exceptions import ApiError
+from datadog.api.resources import SearchableAPIResource, SendableAPIResource
+
+
+class Metadata(SearchableAPIResource, SendableAPIResource):
+    """
+    A wrapper around Metric Metadata HTTP API
+    """
+    _class_url = '/metrics'
+    _json_name = 'metrics'
+
+    @classmethod
+    def get(cls, metric_name):
+        """
+        Get metadata information on an existing Datadog metric
+
+        param metric_name: metric name (ex. system.cpu.idle)
+
+        :returns: JSON response from HTTP request
+        """
+        if not metric_name:
+            raise KeyError("'metric_name' parameter is required")
+
+        return super(Metadata, cls)._trigger_action('GET', 'metrics', metric_name)
+
+    @classmethod
+    def update(cls, metric_name, **params):
+        """
+        Query metrics from Datadog
+
+        :param metric_type: type of metric (ex. "gauge", "rate", etc.)
+                            see http://docs.datadoghq.com/metrictypes/
+        :type metric_type: string
+
+        :param description: description of the metric
+        :type description: string
+
+        :param short_name: short name of the metric
+        :type short_name: string
+
+        :param unit: unit type associated with the metric (ex. "byte", "operation")
+                     see http://docs.datadoghq.com/units/ for full list
+        :type unit: string
+
+        :param per_unit: per unit type (ex. "second" as in "queries per second")
+                         see http://docs.datadoghq.com/units/ for full list
+        :type per_unit: string
+
+        :param interval: interval for metric (in seconds)
+        :type interval: integer
+
+        :return: JSON response from HTTP request
+
+        >>> api.Metadata.update(metric_name='api.requests.served', metric_type="counter")
+        """
+        if not metric_name:
+            raise KeyError("'metric_name' parameter is required")
+
+        return super(Metadata, cls)._trigger_class_action('PUT', 'metrics', metric_name, **params)

--- a/datadog/api/metadata.py
+++ b/datadog/api/metadata.py
@@ -1,9 +1,8 @@
 # datadog
-from datadog.api.resources import GetableAPIResource, CreateableAPIResource, \
-    UpdatableAPIResource, ActionAPIResource
+from datadog.api.resources import GetableAPIResource, UpdatableAPIResource
 
 
-class Metadata(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource, ActionAPIResource):
+class Metadata(GetableAPIResource, UpdatableAPIResource):
     """
     A wrapper around Metric Metadata HTTP API
     """

--- a/datadog/api/metadata.py
+++ b/datadog/api/metadata.py
@@ -7,7 +7,7 @@ from datadog.api.exceptions import ApiError
 from datadog.api.resources import SearchableAPIResource, SendableAPIResource
 
 
-class Metadata(SearchableAPIResource, SendableAPIResource):
+class Metadata(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource):
     """
     A wrapper around Metric Metadata HTTP API
     """
@@ -26,7 +26,7 @@ class Metadata(SearchableAPIResource, SendableAPIResource):
         if not metric_name:
             raise KeyError("'metric_name' parameter is required")
 
-        return super(Metadata, cls)._trigger_action('GET', 'metrics', metric_name)
+        return super(Metadata, cls).get(metric_name, metric_name)
 
     @classmethod
     def update(cls, metric_name, **params):

--- a/datadog/api/metadata.py
+++ b/datadog/api/metadata.py
@@ -4,10 +4,11 @@ from numbers import Number
 
 # datadog
 from datadog.api.exceptions import ApiError
-from datadog.api.resources import SearchableAPIResource, SendableAPIResource
+from datadog.api.resources import GetableAPIResource, CreateableAPIResource, \
+    UpdatableAPIResource, ActionAPIResource
 
 
-class Metadata(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource):
+class Metadata(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource, ActionAPIResource):
     """
     A wrapper around Metric Metadata HTTP API
     """
@@ -26,7 +27,7 @@ class Metadata(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource):
         if not metric_name:
             raise KeyError("'metric_name' parameter is required")
 
-        return super(Metadata, cls).get(metric_name, metric_name)
+        return super(Metadata, cls).get(metric_name)
 
     @classmethod
     def update(cls, metric_name, **params):

--- a/datadog/api/metadata.py
+++ b/datadog/api/metadata.py
@@ -32,7 +32,9 @@ class Metadata(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource, 
     @classmethod
     def update(cls, metric_name, **params):
         """
-        Query metrics from Datadog
+        Update metadata fields for an existing Datadog metric.
+        If the metadata does not exist for the metric it is created by
+        the update.
 
         :param type: type of metric (ex. "gauge", "rate", etc.)
                             see http://docs.datadoghq.com/metrictypes/
@@ -62,4 +64,4 @@ class Metadata(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource, 
         if not metric_name:
             raise KeyError("'metric_name' parameter is required")
 
-        return super(Metadata, cls)._trigger_class_action('PUT', 'metrics', metric_name, **params)
+        return super(Metadata, cls).update(id=metric_name, **params)

--- a/datadog/api/metadata.py
+++ b/datadog/api/metadata.py
@@ -33,9 +33,9 @@ class Metadata(SearchableAPIResource, SendableAPIResource):
         """
         Query metrics from Datadog
 
-        :param metric_type: type of metric (ex. "gauge", "rate", etc.)
+        :param type: type of metric (ex. "gauge", "rate", etc.)
                             see http://docs.datadoghq.com/metrictypes/
-        :type metric_type: string
+        :type type: string
 
         :param description: description of the metric
         :type description: string
@@ -51,8 +51,8 @@ class Metadata(SearchableAPIResource, SendableAPIResource):
                          see http://docs.datadoghq.com/units/ for full list
         :type per_unit: string
 
-        :param interval: interval for metric (in seconds)
-        :type interval: integer
+        :param statsd_interval: statsd flush interval for metric in seconds (if applicable)
+        :type statsd_interval: integer
 
         :return: JSON response from HTTP request
 

--- a/datadog/api/metadata.py
+++ b/datadog/api/metadata.py
@@ -1,9 +1,4 @@
-# stdlib
-import time
-from numbers import Number
-
 # datadog
-from datadog.api.exceptions import ApiError
 from datadog.api.resources import GetableAPIResource, CreateableAPIResource, \
     UpdatableAPIResource, ActionAPIResource
 

--- a/datadog/dogshell/__init__.py
+++ b/datadog/dogshell/__init__.py
@@ -68,5 +68,6 @@ def main():
 
     args.func(args)
 
+
 if __name__ == '__main__':
     main()

--- a/datadog/dogshell/event.py
+++ b/datadog/dogshell/event.py
@@ -10,6 +10,9 @@ from datadog.dogshell.common import report_errors, report_warnings
 from datadog.util.compat import json
 
 
+time_pat = re.compile(r'(?P<delta>[0-9]*\.?[0-9]+)(?P<unit>[mhd])')
+
+
 def prettyprint_event(event):
     title = event['title'] or ''
     text = event.get('text', '') or ''
@@ -34,8 +37,6 @@ def prettyprint_event_details(event):
 def print_event_details(event):
     prettyprint_event(event)
 
-time_pat = re.compile(r'(?P<delta>[0-9]*\.?[0-9]+)(?P<unit>[mhd])')
-
 
 def parse_time(timestring):
     now = time.mktime(datetime.datetime.now().timetuple())
@@ -44,7 +45,7 @@ def parse_time(timestring):
     else:
         try:
             t = int(timestring)
-        except:
+        except Exception:
             match = time_pat.match(timestring)
             if match is None:
                 raise Exception

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -321,5 +321,6 @@ returned (the command outputs remains buffered in dogwrap meanwhile)")
 
     sys.exit(returncode)
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- Adds GET and PUT operations for the metadata endpoint.
- Some confusion around https://github.com/DataDog/datadogpy/compare/agrant/metrics_metadata?expand=1#diff-0741b06f081c976a404268a44c97cc2fR15 and if this should be `metrics` or `metadata` ?
