### PR TITLE
[util] do not read hostname from `datadog.conf`

### DIFF
--- a/datadog/util/compat.py
+++ b/datadog/util/compat.py
@@ -33,7 +33,6 @@ get_input = input
 
 # Python 3.x
 if is_p3k():
-    from io import StringIO
     import builtins
     import configparser
     import urllib.request as url_lib, urllib.error, urllib.parse
@@ -51,7 +50,6 @@ if is_p3k():
 # Python 2.x
 else:
     import __builtin__ as builtins
-    from cStringIO import StringIO
     from itertools import imap
     import ConfigParser as configparser
     import urllib2 as url_lib

--- a/datadog/util/config.py
+++ b/datadog/util/config.py
@@ -1,20 +1,8 @@
 import os
-import string
 import sys
 
 # datadog
-from datadog.util.compat import configparser, StringIO, is_p3k, pkg
-
-# CONSTANTS
-DATADOG_CONF = "datadog.conf"
-
-
-class CfgNotFound(Exception):
-    pass
-
-
-class PathNotFound(Exception):
-    pass
+from datadog.util.compat import pkg
 
 
 def get_os():
@@ -31,98 +19,6 @@ def get_os():
         return 'solaris'
     else:
         return sys.platform
-
-
-def skip_leading_wsp(f):
-    "Works on a file, returns a file-like object"
-    if is_p3k():
-        return StringIO("\n".join(x.strip(" ") for x in f.readlines()))
-    else:
-        return StringIO("\n".join(map(string.strip, f.readlines())))
-
-
-def _windows_commondata_path():
-    """Return the common appdata path, using ctypes
-    From http://stackoverflow.com/questions/626796/\
-    how-do-i-find-the-windows-common-application-data-folder-using-python
-    """
-    import ctypes
-    from ctypes import wintypes, windll
-
-    CSIDL_COMMON_APPDATA = 35
-
-    _SHGetFolderPath = windll.shell32.SHGetFolderPathW
-    _SHGetFolderPath.argtypes = [wintypes.HWND,
-                                 ctypes.c_int,
-                                 wintypes.HANDLE,
-                                 wintypes.DWORD, wintypes.LPCWSTR]
-
-    path_buf = ctypes.create_unicode_buffer(wintypes.MAX_PATH)
-    _SHGetFolderPath(0, CSIDL_COMMON_APPDATA, 0, 0, path_buf)
-    return path_buf.value
-
-
-def _windows_config_path():
-    common_data = _windows_commondata_path()
-    path = os.path.join(common_data, 'Datadog', DATADOG_CONF)
-    if os.path.exists(path):
-        return path
-    raise PathNotFound(path)
-
-
-def _unix_config_path():
-    path = os.path.join('/etc/dd-agent', DATADOG_CONF)
-    if os.path.exists(path):
-        return path
-    raise PathNotFound(path)
-
-
-def _mac_config_path():
-    path = os.path.join('~/.datadog-agent/agent', DATADOG_CONF)
-    path = os.path.expanduser(path)
-    if os.path.exists(path):
-        return path
-    raise PathNotFound(path)
-
-
-def get_config_path(cfg_path=None, os_name=None):
-    # Check if there's an override and if it exists
-    if cfg_path is not None and os.path.exists(cfg_path):
-        return cfg_path
-
-    if os_name is None:
-        os_name = get_os()
-
-    # Check for an OS-specific path, continue on not-found exceptions
-    if os_name == 'windows':
-        return _windows_config_path()
-    elif os_name == 'mac':
-        return _mac_config_path()
-    else:
-        return _unix_config_path()
-
-
-def get_config(cfg_path=None, options=None):
-    agentConfig = {}
-
-    # Config handling
-    try:
-        # Find the right config file
-        path = os.path.realpath(__file__)
-        path = os.path.dirname(path)
-
-        config_path = get_config_path(cfg_path, os_name=get_os())
-        config = configparser.ConfigParser()
-        config.readfp(skip_leading_wsp(open(config_path)))
-
-        # bulk import
-        for option in config.options('Main'):
-            agentConfig[option] = config.get('Main', option)
-
-    except Exception:
-        raise CfgNotFound
-
-    return agentConfig
 
 
 def get_version():

--- a/datadog/util/hostname.py
+++ b/datadog/util/hostname.py
@@ -7,7 +7,7 @@ import types
 
 # datadog
 from datadog.util.compat import url_lib, is_p3k, iteritems, json
-from datadog.util.config import get_config, get_os, CfgNotFound
+from datadog.util.config import get_os
 
 VALID_HOSTNAME_RFC_1123_PATTERN = re.compile(r"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$")  # noqa
 MAX_HOSTNAME_LEN = 255
@@ -41,22 +41,12 @@ def get_hostname():
 
     Tries, in order:
 
-      * agent config (datadog.conf, "hostname:")
       * 'hostname -f' (on unix)
       * socket.gethostname()
     """
 
     hostname = None
     config = None
-
-    # first, try the config
-    try:
-        config = get_config()
-        config_hostname = config.get('hostname')
-        if config_hostname and is_valid_hostname(config_hostname):
-            return config_hostname
-    except CfgNotFound:
-        log.info("No agent or invalid configuration file found")
 
     # Try to get GCE instance name
     if hostname is None:

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -66,26 +66,6 @@ class TestInitialization(DatadogAPINoInitialization):
         MyCreatable.create()
         self.assertEquals(self.request_mock.request.call_count, 1)
 
-    @mock.patch('datadog.util.config.get_config_path')
-    def test_get_hostname(self, mock_config_path):
-        """
-        API hostname parameter fallback with Datadog Agent hostname when available.
-        """
-        # Generate a fake agent config
-        tmpfilepath = os.path.join(tempfile.gettempdir(), "tmp-agentconfig")
-        with open(tmpfilepath, "wb") as f:
-            if is_p3k():
-                f.write(bytes("[Main]\n", 'UTF-8'))
-                f.write(bytes("hostname: {0}\n".format(HOST_NAME), 'UTF-8'))
-            else:
-                f.write("[Main]\n")
-                f.write("hostname: {0}\n".format(HOST_NAME))
-        # Mock get_config_path to return this fake agent config
-        mock_config_path.return_value = tmpfilepath
-
-        initialize()
-        self.assertEquals(api._host_name, HOST_NAME, api._host_name)
-
     def test_request_parameters(self):
         """
         API parameters are set with `initialize` method.


### PR DESCRIPTION
To be able to read the `datadog.conf` Datadog Agent configuration file,
the user must have read privilege to the file (default to `0640
dd-agent:root`).

It is also useless: if a `datadog.conf` file is present on the host, one
can use `statsd` to have metrics, events... sent with the appropriate
hostname.

Fix #176, #178. Thanks @tgwizard, @donato.