### PR TITLE
Add aggregation_key to events documentation

### DIFF
--- a/datadog/api/events.py
+++ b/datadog/api/events.py
@@ -24,6 +24,9 @@ class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource, De
         :param text: event message
         :type text: string
 
+        :param aggregation_key: key by which to group events in event stream
+        :type aggregation_key: string
+
         :param alert_type: "error", "warning", "info" or "success".
         :type alert_type: string
 


### PR DESCRIPTION
Datadog Event API documentation specifies `aggregation_key`: https://docs.datadoghq.com/api/#events. I also tested and it works.