### PR TITLE
[dogshell] filter options to monitor command

### DIFF
--- a/datadog/api/monitors.py
+++ b/datadog/api/monitors.py
@@ -38,13 +38,21 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
         :type group_states: string list, strings are chosen from one or more \
         from 'all', 'alert', 'warn', or 'no data'
 
+        :param name: name to filter the list of monitors by
+        :type name: string
+
         :param tags: tags to filter the list of monitors by scope
         :type tags: string list
 
+        :param monitor_tags: list indicating what service and/or custom tags, if any, \
+        should be used to filter the list of monitors
+        :type monitor_tags: string list
+
         :returns: JSON response from HTTP request
         """
-        if 'group_states' in params and isinstance(params['group_states'], list):
-            params['group_states'] = ','.join(params['group_states'])
+        for p in ['group_states', 'tags', 'monitor_tags']:
+            if p in params and isinstance(params[p], list):
+                params[p] = ','.join(params[p])
 
         return super(Monitor, cls).get_all(**params)
 

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -45,6 +45,20 @@ class MonitorClient(object):
         show_parser.set_defaults(func=cls._show)
 
         show_all_parser = verb_parsers.add_parser('show_all', help="Show a list of all monitors")
+        show_all_parser.add_argument(
+            '--group_states', help="comma separated list of group states to filter by"
+            "(choose one or more from 'all', 'alert', 'warn', or 'no data')"
+        )
+        show_all_parser.add_argument('--name', help="string to filter monitors by name")
+        show_all_parser.add_argument(
+            '--tags', help="comma separated list indicating what tags, if any, "
+            "should be used to filter the list of monitors by scope (e.g. 'host:host0')"
+        )
+        show_all_parser.add_argument(
+            '--monitor_tags', help="comma separated list indicating what service "
+            "and/or custom tags, if any, should be used to filter the list of monitors"
+        )
+
         show_all_parser.set_defaults(func=cls._show_all)
 
         delete_parser = verb_parsers.add_parser('delete', help="Delete a monitor")
@@ -133,7 +147,11 @@ class MonitorClient(object):
     def _show_all(cls, args):
         api._timeout = args.timeout
         format = args.format
-        res = api.Monitor.get_all()
+
+        res = api.Monitor.get_all(
+            group_states=args.group_states, name=args.name,
+            tags=args.tags, monitor_tags=args.monitor_tags
+        )
         report_warnings(res)
         report_errors(res)
 


### PR DESCRIPTION
Add the different available options to filter monitors to the `dog
monitor show_all` command.
Also update the PyDoc to document the different parameters according to
http://docs.datadoghq.com/api/.