### PR TITLE
add socket_path option to enable unix socket traffic to dogstatsd6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+# 0.17.0 / unreleased
+* [FEATURE] DogStatsD: add socket_path option to enable unix socket traffic to dogstatsd6 [199][]
+
 # 0.16.0 / 2017-04-26
 * [FEATURE] Dogshell: Add filtering options to the `monitor show_all` command, [#194][]
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -282,6 +282,9 @@ class DogStatsd(object):
         try:
             # If set, use socket directly
             (self.socket or self.get_socket()).send(packet.encode(self.encoding))
+        except socket.timeout:
+            # dogstatsd is overflowing, drop the packets (mimicks the UDP behaviour)
+            return
         except socket.error:
             log.info("Error submitting packet, will try refreshing the socket")
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -286,16 +286,8 @@ class DogStatsd(object):
             # dogstatsd is overflowing, drop the packets (mimicks the UDP behaviour)
             return
         except socket.error:
-            log.info("Error submitting packet, will try refreshing the socket")
-
+            log.info("Error submitting packet, dropping the packet and closing the socket")
             self.close_socket()
-
-            try:
-                self.get_socket().send(packet.encode(self.encoding))
-            except socket.error:
-                self.close_socket()
-
-                log.exception("Failed to send packet with a newly bound socket")
 
     def _send_to_buffer(self, packet):
         self.buffer.append(packet)

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -24,7 +24,8 @@ class DogStatsd(object):
     OK, WARNING, CRITICAL, UNKNOWN = (0, 1, 2, 3)
 
     def __init__(self, host='localhost', port=8125, max_buffer_size=50, namespace=None,
-                 constant_tags=None, use_ms=False, use_default_route=False):
+                 constant_tags=None, use_ms=False, use_default_route=False,
+                 use_unix_socket=None):
         """
         Initialize a DogStatsd object.
 
@@ -56,10 +57,20 @@ class DogStatsd(object):
         (Useful when running the client in a container) (Linux only)
         :type use_default_route: boolean
 
+        :param use_unix_socket: Communicate with dogstatsd through a UNIX socket instead of
+        UDP. If set, disables UDP transmission (Linux only)
+        :type use_unix_socket: string
         """
+
         # Connection
-        self.host = self.resolve_host(host, use_default_route)
-        self.port = int(port)
+        if use_unix_socket is not None:
+            self.socket_path = use_unix_socket
+            self.host = None
+            self.port = None
+        else:
+            self.socket_path = None
+            self.host = self.resolve_host(host, use_default_route)
+            self.port = int(port)
 
         # Socket
         self.socket = None
@@ -105,9 +116,15 @@ class DogStatsd(object):
         avoid bad thread race conditions.
         """
         if not self.socket:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            sock.connect((self.host, self.port))
-            self.socket = sock
+            if self.socket_path is not None:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+                sock.connect(self.socket_path)
+                sock.setblocking(0)
+                self.socket = sock
+            else:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                sock.connect((self.host, self.port))
+                self.socket = sock
 
         return self.socket
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -25,7 +25,7 @@ class DogStatsd(object):
 
     def __init__(self, host='localhost', port=8125, max_buffer_size=50, namespace=None,
                  constant_tags=None, use_ms=False, use_default_route=False,
-                 use_unix_socket=None):
+                 socket_path=None):
         """
         Initialize a DogStatsd object.
 
@@ -57,14 +57,14 @@ class DogStatsd(object):
         (Useful when running the client in a container) (Linux only)
         :type use_default_route: boolean
 
-        :param use_unix_socket: Communicate with dogstatsd through a UNIX socket instead of
+        :param socket_path: Communicate with dogstatsd through a UNIX socket instead of
         UDP. If set, disables UDP transmission (Linux only)
-        :type use_unix_socket: string
+        :type socket_path: string
         """
 
         # Connection
-        if use_unix_socket is not None:
-            self.socket_path = use_unix_socket
+        if socket_path is not None:
+            self.socket_path = socket_path
             self.host = None
             self.port = None
         else:


### PR DESCRIPTION
### What does this PR do?

dogstatsd6 will allow custom metrics to be sent via a datagram unix socket instead of UDP (see https://github.com/DataDog/datadog-agent/pull/252). This PR add a use_unix_socket option to the DogstatsD object in order to allow using this communication channel.

### Motivation

Containers make it harder to reach the dogstatsd server from client applications and we don't have a future-proof network solution that could work across all orchestrators. This allows to bypass the network stack altogether and use a host-local protocol. See https://github.com/DataDog/docker-dd-agent/issues/195 for more context.

As unix datagram and UDP share the same semantics, the patch is pretty small and unobstrusive.

Socket connection is set to non blocking: if the server is unresponsive, the packets are dropped, mirroring what would happen with UDP.

### Additional Notes

Still WIP as we need to:

- [ ] Work on better error handling if the server stops (currently, the exceptions are caught and packets are dropped, but CPU usage increases significantly)