### PR TITLE
Convert README to reST automatically for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,17 @@
-from setuptools import setup
 import sys
+from setuptools import setup
+try:
+    from pypandoc import convert
+except ImportError:
+    print('WARNING: Please, run `pip install pypandoc` to convert the README for PyPI.')
+
+    def convert(filename, fmt):
+        if sys.version_info[0] < 3:
+            with open(filename) as fd:
+                return fd.read()
+        else:
+            with open(filename, encoding="utf-8") as fd:
+                return fd.read()
 
 install_reqs = [
     "decorator>=3.3.2",
@@ -30,6 +42,7 @@ setup(
     author="Datadog, Inc.",
     author_email="dev@datadoghq.com",
     description="The Datadog Python library",
+    long_description=convert('README.md', 'rst'),
     license="BSD",
     keywords="datadog",
     url="https://www.datadoghq.com",


### PR DESCRIPTION
The change makes the Markdown README usable for PyPI.

The [`datadog` package](https://pypi.python.org/pypi/datadog) on PyPI currently has no long description. The PR adds the content of the README as the package description. Usually this requires the README to be in reStructuredText format (i.e. `.rst`). With `pypandoc` the README can remain being an `.md` file.