### PR TITLE
[api] event's `host` must be a string, not a list

### DIFF
--- a/datadog/api/events.py
+++ b/datadog/api/events.py
@@ -48,7 +48,7 @@ class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource, De
         :type tags: list of strings
 
         :param host: host to post the event with
-        :type host: list of strings
+        :type host: string
 
         :param device_name: device_name to post the event with
         :type device_name: list of strings


### PR DESCRIPTION
Fix the documentation. When creating an event, the associated `host`
must be a string, not a list.