### PR TITLE
[threadstats] flush all metrics on exit

### DIFF
--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -4,7 +4,7 @@ performance. It collects metrics in the application thread with very little over
 and allows flushing metrics in process, in a thread or in a greenlet, depending
 on your application's needs.
 """
-#stdlib
+# stdlib
 from contextlib import contextmanager
 from functools import wraps
 from time import time

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -138,7 +138,11 @@ class MetricsAggregator(object):
 
     def flush(self, timestamp):
         """ Flush all metrics up to the given timestamp. """
-        interval = timestamp - timestamp % self._roll_up_interval
+        if timestamp == float('inf'):
+            interval = float('inf')
+        else:
+            interval = timestamp - timestamp % self._roll_up_interval
+
         past_intervals = [i for i in self._metrics.keys() if i < interval]
         metrics = []
         for i in past_intervals:

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -556,8 +556,8 @@ class TestUnitThreadStats(unittest.TestCase):
 
     def test_disabled_mode(self):
         dog = ThreadStats()
-        reporter = dog.reporter = MemoryReporter()
         dog.start(disabled=True, flush_interval=1, roll_up_interval=1)
+        reporter = dog.reporter = MemoryReporter()
         dog.gauge('testing', 1, timestamp=1000)
         dog.gauge('testing', 2, timestamp=1000)
         dog.flush(2000.0)
@@ -566,6 +566,7 @@ class TestUnitThreadStats(unittest.TestCase):
     def test_stop(self):
         dog = ThreadStats()
         dog.start(flush_interval=1, roll_up_interval=1)
+        dog.reporter = MemoryReporter()
         for i in range(10):
             dog.gauge('metric', i)
         time.sleep(2)


### PR DESCRIPTION
On exit, flush all metrics regardless of the rollup intervals.