### PR TITLE
Explicitly close requests Session in RequestClient

### DIFF
--- a/datadog/api/http_client.py
+++ b/datadog/api/http_client.py
@@ -59,35 +59,35 @@ class RequestClient(HTTPClient):
         """
         """
         # Use a session to set a max_retries parameters
-        s = requests.Session()
-        http_adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
-        s.mount('https://', http_adapter)
+        with requests.Session() as s:
+            http_adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
+            s.mount('https://', http_adapter)
 
-        try:
-            result = s.request(
-                method, url,
-                headers=headers, params=params, data=data,
-                timeout=timeout,
-                proxies=proxies, verify=verify)
+            try:
+                result = s.request(
+                    method, url,
+                    headers=headers, params=params, data=data,
+                    timeout=timeout,
+                    proxies=proxies, verify=verify)
 
-            result.raise_for_status()
+                result.raise_for_status()
 
-        except requests.ConnectionError as e:
-            raise ClientError(method, url, e)
-        except requests.exceptions.Timeout:
-            raise HttpTimeout(method, url, timeout)
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code in (400, 403, 404, 409):
-                # This gets caught afterwards and raises an ApiError exception
-                pass
-            else:
-                raise HTTPError(e.response.status_code, result.reason)
-        except TypeError as e:
-            raise TypeError(
-                u"Your installed version of `requests` library seems not compatible with"
-                u"Datadog's usage. We recommand upgrading it ('pip install -U requests')."
-                u"If you need help or have any question, please contact support@datadoghq.com"
-            )
+            except requests.ConnectionError as e:
+                raise ClientError(method, url, e)
+            except requests.exceptions.Timeout:
+                raise HttpTimeout(method, url, timeout)
+            except requests.exceptions.HTTPError as e:
+                if e.response.status_code in (400, 403, 404, 409):
+                    # This gets caught afterwards and raises an ApiError exception
+                    pass
+                else:
+                    raise HTTPError(e.response.status_code, result.reason)
+            except TypeError as e:
+                raise TypeError(
+                    u"Your installed version of `requests` library seems not compatible with"
+                    u"Datadog's usage. We recommand upgrading it ('pip install -U requests')."
+                    u"If you need help or have any question, please contact support@datadoghq.com"
+                )
 
         return result
 


### PR DESCRIPTION
Fixes a bug where a socket is leaked every time a RequestClient
is created.

The bug yields this warning per each HTTP request:
`ResourceWarning: unclosed <ssl.SSLSocket fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=(<IP ADDRESS>, 57977), raddr=(<IP ADDRESS>, 443)>`