### PR TITLE
add support for default_sample_rate

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -25,7 +25,7 @@ class DogStatsd(object):
 
     def __init__(self, host='localhost', port=8125, max_buffer_size=50, namespace=None,
                  constant_tags=None, use_ms=False, use_default_route=False,
-                 socket_path=None):
+                 socket_path=None, default_sample_rate=1):
         """
         Initialize a DogStatsd object.
 
@@ -60,6 +60,9 @@ class DogStatsd(object):
         :param socket_path: Communicate with dogstatsd through a UNIX socket instead of
         UDP. If set, disables UDP transmission (Linux only)
         :type socket_path: string
+
+        :param default_sample_rate: Sample rate to use by default for all metrics
+        :type default_sample_rate: float
         """
 
         # Connection
@@ -85,6 +88,7 @@ class DogStatsd(object):
         self.constant_tags = constant_tags + env_tags
         self.namespace = namespace
         self.use_ms = use_ms
+        self.default_sample_rate = default_sample_rate
 
     def __enter__(self):
         self.open_buffer(self.max_buffer_size)
@@ -149,7 +153,7 @@ class DogStatsd(object):
         self._send = self._send_to_server
         self._flush_buffer()
 
-    def gauge(self, metric, value, tags=None, sample_rate=1):
+    def gauge(self, metric, value, tags=None, sample_rate=None):
         """
         Record the value of a gauge, optionally setting a list of tags and a
         sample rate.
@@ -159,7 +163,7 @@ class DogStatsd(object):
         """
         return self._report(metric, 'g', value, tags, sample_rate)
 
-    def increment(self, metric, value=1, tags=None, sample_rate=1):
+    def increment(self, metric, value=1, tags=None, sample_rate=None):
         """
         Increment a counter, optionally setting a value, tags and a sample
         rate.
@@ -169,7 +173,7 @@ class DogStatsd(object):
         """
         self._report(metric, 'c', value, tags, sample_rate)
 
-    def decrement(self, metric, value=1, tags=None, sample_rate=1):
+    def decrement(self, metric, value=1, tags=None, sample_rate=None):
         """
         Decrement a counter, optionally setting a value, tags and a sample
         rate.
@@ -180,7 +184,7 @@ class DogStatsd(object):
         metric_value = -value if value else value
         self._report(metric, 'c', metric_value, tags, sample_rate)
 
-    def histogram(self, metric, value, tags=None, sample_rate=1):
+    def histogram(self, metric, value, tags=None, sample_rate=None):
         """
         Sample a histogram value, optionally setting tags and a sample rate.
 
@@ -189,7 +193,7 @@ class DogStatsd(object):
         """
         self._report(metric, 'h', value, tags, sample_rate)
 
-    def timing(self, metric, value, tags=None, sample_rate=1):
+    def timing(self, metric, value, tags=None, sample_rate=None):
         """
         Record a timing, optionally setting tags and a sample rate.
 
@@ -197,7 +201,7 @@ class DogStatsd(object):
         """
         self._report(metric, 'ms', value, tags, sample_rate)
 
-    def timed(self, metric=None, tags=None, sample_rate=1, use_ms=None):
+    def timed(self, metric=None, tags=None, sample_rate=None, use_ms=None):
         """
         A decorator or context manager that will measure the distribution of a
         function's/context's run time. Optionally specify a list of tags or a
@@ -225,7 +229,7 @@ class DogStatsd(object):
         """
         return TimedContextManagerDecorator(self, metric, tags, sample_rate, use_ms)
 
-    def set(self, metric, value, tags=None, sample_rate=1):
+    def set(self, metric, value, tags=None, sample_rate=None):
         """
         Sample a set value.
 
@@ -249,6 +253,9 @@ class DogStatsd(object):
         """
         if value is None:
             return
+
+        if sample_rate is None:
+            sample_rate = self.default_sample_rate
 
         if sample_rate != 1 and random() > sample_rate:
             return

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -161,6 +161,13 @@ class TestDogStatsd(object):
         self.assert_almost_equal(3000, len(self.statsd.socket.payloads), 150)
         t.assert_equal('sampled_counter:1|c|@0.3', self.recv())
 
+    def test_default_sample_rate(self):
+        self.statsd.default_sample_rate = 0.3
+        for i in range(10000):
+            self.statsd.increment('sampled_counter')
+        self.assert_almost_equal(3000, len(self.statsd.socket.payloads), 150)
+        t.assert_equal('sampled_counter:1|c|@0.3', self.recv())
+
     def test_tags_and_samples(self):
         for i in range(100):
             self.statsd.gauge('gst', 23, tags=["sampled"], sample_rate=0.9)


### PR DESCRIPTION
The idea is quite similar to constant_tags: when initializing a
DogStatsd object, you can specify a value that should apply to *all*
metrics.

This change is backwards compatible. You can still pass in sample_rate
on a per-call basis and the value will override the default.