### PR TITLE
change http-method GET to POST on api.Screenboard#share

### DIFF
--- a/datadog/api/screenboards.py
+++ b/datadog/api/screenboards.py
@@ -22,7 +22,7 @@ class Screenboard(GetableAPIResource, CreateableAPIResource,
 
         :returns: Dictionary representing the API's JSON response
         """
-        return super(Screenboard, cls)._trigger_action('GET', 'screen/share', board_id)
+        return super(Screenboard, cls)._trigger_action('POST', 'screen/share', board_id)
 
     @classmethod
     def revoke(cls, board_id):


### PR DESCRIPTION
The http-method of the share of the Screenboard API changed from GET to POST and it stopped working, I fixed it.