### PR TITLE
fix flake8 version to 3.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - pip install flake8
+  - pip install flake8==3.4.1
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then flake8 --max-line-length=100 datadog; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then python setup.py test; else python setup.py test -s tests.unit; fi


### PR DESCRIPTION
Fix flake8's version to 3.4.1.
flake8 3.5.0 makes failure to current datadogpy's code base.
(The failure of #234 is the same reason)

```
$ flake8 --max-line-length=100 datadog
datadog/dogshell/monitor.py:100:13: E722 do not use bare except'
datadog/dogshell/monitor.py:119:13: E722 do not use bare except'
datadog/dogshell/screenboard.py:177:9: E722 do not use bare except'
datadog/dogshell/screenboard.py:198:9: E722 do not use bare except'
datadog/dogshell/screenboard.py:274:9: E722 do not use bare except'
datadog/dogshell/timeboard.py:144:9: E722 do not use bare except'
datadog/dogshell/timeboard.py:235:9: E722 do not use bare except'
datadog/dogshell/timeboard.py:255:9: E722 do not use bare except'
datadog/threadstats/base.py:305:9: E722 do not use bare except'
datadog/threadstats/base.py:308:13: E722 do not use bare except'
datadog/threadstats/base.py:366:13: E722 do not use bare except'
datadog/threadstats/base.py:369:17: E722 do not use bare except'
datadog/threadstats/base.py:391:17: E722 do not use bare except'
datadog/threadstats/base.py:394:21: E722 do not use bare except'
datadog/util/hostname.py:126:5: E722 do not use bare except'
```