### PR TITLE
dogwrap python3 string changes

### DIFF
--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -65,7 +65,7 @@ class OutputReader(threading.Thread):
         '''
         for line in iter(self._out.readline, b''):
             if self._fwd_out is not None:
-                self._fwd_out.write(line)
+                self._fwd_out.write(line.decode(self._fwd_out.encoding))
             line = line.decode('utf-8')
             self._out_content += line
         self._out.close()


### PR DESCRIPTION
Wrapping a command with python3 is broken due to string changes in python3. This decodes the string using the `_fwd_out` encoding. 

Another option is to just use the `utf-8` decoded line below for both.

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/dbt/src/datadog/datadog/dogshell/wrap.py", line 68, in run
    self._fwd_out.write(line)
TypeError: write() argument must be str, not bytes
```