### PR TITLE
Fix ServiceCheck none parameters for calls from dogshell, etc on python3.

### DIFF
--- a/datadog/api/service_checks.py
+++ b/datadog/api/service_checks.py
@@ -35,9 +35,7 @@ class ServiceCheck(ActionAPIResource):
 
         # Validate checks, include only non-null values
         for param, value in params.items():
-            if value is None:
-                del params[param]
-            elif param == 'status' and params[param] not in CheckStatus.ALL:
+            if param == 'status' and params[param] not in CheckStatus.ALL:
                 raise ApiError('Invalid status, expected one of: %s'
                                % ', '.join(str(v) for v in CheckStatus.ALL))
 

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -10,7 +10,7 @@ import mock
 
 # datadog
 from datadog import initialize, api
-from datadog.api import Metric
+from datadog.api import Metric, ServiceCheck
 from datadog.api.exceptions import ApiError, ApiNotInitialized
 from datadog.util.compat import is_p3k
 from tests.unit.api.helper import (
@@ -327,3 +327,19 @@ class TestMetricResource(DatadogAPIWithInitialization):
         for point in supported_data_types:
             serie = dict(metric='metric.numerical', points=point)
             self.submit_and_assess_metric_payload(serie)
+
+class TestServiceCheckResource(DatadogAPIWithInitialization):
+
+    def test_service_check_supports_none_parameters(self):
+        """
+        ServiceCheck should support none parameters
+
+        ```
+        $ dog service_check check check_pg host0 1
+        ```
+
+        resulted in `RuntimeError: dictionary changed size during iteration`
+        """
+        ServiceCheck.check(
+            check='check_pg', host_name='host0', status=1, message=None,
+            timestamp=None, tags=None)


### PR DESCRIPTION
https://github.com/DataDog/datadogpy/issues/206#issuecomment-343512407 introduced a basic python3 error where we attempted to iterate over a dictionary we were modifying, yielding an exception.

We didn't have any unit tests around this so I added one. This fixes both the actual call that I was making and provides a regression test.

I'm happy to clean up the commits once I get basic validation that this is the right direction.

If it's more important than I realize to actually filter out the `None` params, we'll need to change the way that we do that (iterating over `keys` and building up a new dictionary with the appropriate key/value pairs.