### PR TITLE
ThreadStats - Send correct metric type instead of always sending Gauge

### DIFF
--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -12,7 +12,6 @@ from contextlib import contextmanager
 from time import time
 
 from datadog.api.exceptions import ApiNotInitialized
-from datadog.threadstats.constants import MetricType
 from datadog.threadstats.metrics import MetricsAggregator, Counter, Gauge, Histogram, Timing
 from datadog.threadstats.events import EventsAggregator
 from datadog.threadstats.reporters import HttpReporter
@@ -206,7 +205,7 @@ class ThreadStats(object):
         >>> stats.timing("query.response.time", 1234)
         """
         if not self._disabled:
-            self._metric_aggregator.add_point(metric_name, tags, timestamp or time(), value, 
+            self._metric_aggregator.add_point(metric_name, tags, timestamp or time(), value,
                                               Timing, sample_rate=sample_rate, host=host)
 
     @contextmanager

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -319,7 +319,7 @@ class ThreadStats(object):
 
         # FIXME: emit a dictionary from the aggregator
         metrics = []
-        for timestamp, value, name, tags, host in rolled_up_metrics:
+        for timestamp, value, name, tags, host, metric_type in rolled_up_metrics:
             metric_tags = tags
             metric_name = name
 
@@ -337,7 +337,7 @@ class ThreadStats(object):
             metric = {
                 'metric': metric_name,
                 'points': [[timestamp, value]],
-                'type': MetricType.Gauge,
+                'type': metric_type,
                 'host': host,
                 'device': self.device,
                 'tags': metric_tags

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -323,7 +323,7 @@ class ThreadStats(object):
 
         # FIXME: emit a dictionary from the aggregator
         metrics = []
-        for timestamp, value, name, tags, host, metric_type in rolled_up_metrics:
+        for timestamp, value, name, tags, host, metric_type, interval in rolled_up_metrics:
             metric_tags = tags
             metric_name = name
 
@@ -344,7 +344,8 @@ class ThreadStats(object):
                 'type': metric_type,
                 'host': host,
                 'device': self.device,
-                'tags': metric_tags
+                'tags': metric_tags,
+				'interval': interval
             }
             metrics.append(metric)
         return metrics

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -206,8 +206,8 @@ class ThreadStats(object):
         >>> stats.timing("query.response.time", 1234)
         """
         if not self._disabled:
-            self._metric_aggregator.add_point(metric_name, tags, timestamp or time(), value, Timing,
-                                              sample_rate=sample_rate, host=host)
+            self._metric_aggregator.add_point(metric_name, tags, timestamp or time(), value, 
+                                              Timing, sample_rate=sample_rate, host=host)
 
     @contextmanager
     def timer(self, metric_name, sample_rate=1, tags=None, host=None):

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -345,7 +345,7 @@ class ThreadStats(object):
                 'host': host,
                 'device': self.device,
                 'tags': metric_tags,
-				'interval': interval
+                'interval': interval
             }
             metrics.append(metric)
         return metrics

--- a/datadog/threadstats/constants.py
+++ b/datadog/threadstats/constants.py
@@ -4,6 +4,7 @@ class MetricType(object):
     Histogram = "histogram"
     Count = "count"
 
+
 class MonitorType(object):
     SERVICE_CHECK = 'service check'
     METRIC_ALERT = 'metric alert'

--- a/datadog/threadstats/constants.py
+++ b/datadog/threadstats/constants.py
@@ -2,7 +2,7 @@ class MetricType(object):
     Gauge = "gauge"
     Counter = "counter"
     Histogram = "histogram"
-    Count = "count"
+    Rate = "rate"
 
 
 class MonitorType(object):

--- a/datadog/threadstats/constants.py
+++ b/datadog/threadstats/constants.py
@@ -2,7 +2,7 @@ class MetricType(object):
     Gauge = "gauge"
     Counter = "counter"
     Histogram = "histogram"
-
+    Count = "count"
 
 class MonitorType(object):
     SERVICE_CHECK = 'service check'

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -94,8 +94,10 @@ class Histogram(Metric):
         metrics = [
             (timestamp, self.min, '%s.min' % self.name, self.tags, self.host, MetricType.Gauge),
             (timestamp, self.max, '%s.max' % self.name, self.tags, self.host, MetricType.Gauge),
-            (timestamp, self.count, '%s.count' % self.name, self.tags, self.host, MetricType.Count),
-            (timestamp, self.average(), '%s.avg' % self.name, self.tags, self.host, MetricType.Gauge)
+            (timestamp, self.count, '%s.count' % self.name, 
+             self.tags, self.host, MetricType.Count),
+            (timestamp, self.average(), '%s.avg' % self.name, 
+             self.tags, self.host, MetricType.Gauge)
         ]
         length = len(self.samples)
         self.samples.sort()

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -8,6 +8,7 @@ import itertools
 from datadog.util.compat import iternext
 from datadog.threadstats.constants import MetricType
 
+
 class Metric(object):
     """
     A base metric class that accepts points, slices them into time intervals
@@ -94,9 +95,9 @@ class Histogram(Metric):
         metrics = [
             (timestamp, self.min, '%s.min' % self.name, self.tags, self.host, MetricType.Gauge),
             (timestamp, self.max, '%s.max' % self.name, self.tags, self.host, MetricType.Gauge),
-            (timestamp, self.count, '%s.count' % self.name, 
+            (timestamp, self.count, '%s.count' % self.name,
              self.tags, self.host, MetricType.Count),
-            (timestamp, self.average(), '%s.avg' % self.name, 
+            (timestamp, self.average(), '%s.avg' % self.name,
              self.tags, self.host, MetricType.Gauge)
         ]
         length = len(self.samples)

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -39,7 +39,8 @@ class Gauge(Metric):
         self.value = value
 
     def flush(self, timestamp, interval):
-        return [(timestamp, self.value, self.name, self.tags, self.host, MetricType.Gauge, interval)]
+        return [(timestamp, self.value, self.name, self.tags, 
+                self.host, MetricType.Gauge, interval)]
 
 
 class Counter(Metric):
@@ -107,7 +108,7 @@ class Histogram(Metric):
         for p in self.percentiles:
             val = self.samples[int(round(p * length - 1))]
             name = '%s.%spercentile' % (self.name, int(p * 100))
-            metrics.append((timestamp, val, name, 
+            metrics.append((timestamp, val, name,
                            self.tags, self.host, MetricType.Gauge, interval))
         return metrics
 

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -39,7 +39,7 @@ class Gauge(Metric):
         self.value = value
 
     def flush(self, timestamp, interval):
-        return [(timestamp, self.value, self.name, self.tags, 
+        return [(timestamp, self.value, self.name, self.tags,
                 self.host, MetricType.Gauge, interval)]
 
 

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -6,7 +6,7 @@ import random
 import itertools
 
 from datadog.util.compat import iternext
-
+from datadog.threadstats.constants import MetricType
 
 class Metric(object):
     """
@@ -38,7 +38,7 @@ class Gauge(Metric):
         self.value = value
 
     def flush(self, timestamp):
-        return [(timestamp, self.value, self.name, self.tags, self.host)]
+        return [(timestamp, self.value, self.name, self.tags, self.host, MetricType.Gauge)]
 
 
 class Counter(Metric):
@@ -57,7 +57,7 @@ class Counter(Metric):
 
     def flush(self, timestamp):
         count = sum(self.count, 0)
-        return [(timestamp, count, self.name, self.tags, self.host)]
+        return [(timestamp, count, self.name, self.tags, self.host, MetricType.Count)]
 
 
 class Histogram(Metric):
@@ -92,17 +92,17 @@ class Histogram(Metric):
         if not self.count:
             return []
         metrics = [
-            (timestamp, self.min, '%s.min' % self.name, self.tags, self.host),
-            (timestamp, self.max, '%s.max' % self.name, self.tags, self.host),
-            (timestamp, self.count, '%s.count' % self.name, self.tags, self.host),
-            (timestamp, self.average(), '%s.avg' % self.name, self.tags, self.host)
+            (timestamp, self.min, '%s.min' % self.name, self.tags, self.host, MetricType.Gauge),
+            (timestamp, self.max, '%s.max' % self.name, self.tags, self.host, MetricType.Gauge),
+            (timestamp, self.count, '%s.count' % self.name, self.tags, self.host, MetricType.Count),
+            (timestamp, self.average(), '%s.avg' % self.name, self.tags, self.host, MetricType.Gauge)
         ]
         length = len(self.samples)
         self.samples.sort()
         for p in self.percentiles:
             val = self.samples[int(round(p * length - 1))]
             name = '%s.%spercentile' % (self.name, int(p * 100))
-            metrics.append((timestamp, val, name, self.tags, self.host))
+            metrics.append((timestamp, val, name, self.tags, self.host, MetricType.Gauge))
         return metrics
 
     def average(self):

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -59,7 +59,8 @@ class Counter(Metric):
 
     def flush(self, timestamp, interval):
         count = sum(self.count, 0)
-        return [(timestamp, count, self.name, self.tags, self.host, MetricType.Rate, interval)]
+        return [(timestamp, count/float(interval), self.name,
+                self.tags, self.host, MetricType.Rate, interval)]
 
 
 class Histogram(Metric):
@@ -98,7 +99,7 @@ class Histogram(Metric):
              self.tags, self.host, MetricType.Gauge, interval),
             (timestamp, self.max, '%s.max' % self.name,
              self.tags, self.host, MetricType.Gauge, interval),
-            (timestamp, self.count, '%s.count' % self.name,
+            (timestamp, self.count/float(interval), '%s.count' % self.name,
              self.tags, self.host, MetricType.Rate, interval),
             (timestamp, self.average(), '%s.avg' % self.name,
              self.tags, self.host, MetricType.Gauge, interval)

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -693,13 +693,13 @@ class TestUnitThreadStats(unittest.TestCase):
         max_, min_) = self.sort_metrics(reporter.metrics)
 		
 		# Assert Metric type
-        nt.assert_equal(first['type'], 'count')
+        nt.assert_equal(first['type'], 'rate')
         nt.assert_equal(second['type'], 'gauge')
         nt.assert_equal(p75['type'], 'gauge')
         nt.assert_equal(p85['type'], 'gauge')
         nt.assert_equal(p95['type'], 'gauge')
         nt.assert_equal(p99['type'], 'gauge')
         nt.assert_equal(avg['type'], 'gauge')
-        nt.assert_equal(cnt['type'], 'count')
+        nt.assert_equal(cnt['type'], 'rate')
         nt.assert_equal(max_['type'], 'gauge')
         nt.assert_equal(min_['type'], 'gauge')

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -233,7 +233,7 @@ class TestUnitThreadStats(unittest.TestCase):
         nt.assert_equal(h1avg1['points'][0][1], 35)
         nt.assert_equal(h1cnt1['metric'], 'histogram.1.count')
         nt.assert_equal(h1cnt1['points'][0][0], 100.0)
-        nt.assert_equal(h1cnt1['points'][0][1], 4)
+        nt.assert_equal(h1cnt1['points'][0][1], 0.4)
         nt.assert_equal(h1min1['metric'], 'histogram.1.min')
         nt.assert_equal(h1min1['points'][0][1], 20)
         nt.assert_equal(h1max1['metric'], 'histogram.1.max')
@@ -248,7 +248,7 @@ class TestUnitThreadStats(unittest.TestCase):
         nt.assert_equal(h1avg2['points'][0][1], 40)
         nt.assert_equal(h1cnt2['metric'], 'histogram.1.count')
         nt.assert_equal(h1cnt2['points'][0][0], 110.0)
-        nt.assert_equal(h1cnt2['points'][0][1], 3)
+        nt.assert_equal(h1cnt2['points'][0][1], 0.3)
         nt.assert_equal(h1752['metric'], 'histogram.1.75percentile')
         nt.assert_equal(h1752['points'][0][0], 110.0)
         nt.assert_equal(h1752['points'][0][1], 40.0)
@@ -261,7 +261,7 @@ class TestUnitThreadStats(unittest.TestCase):
         nt.assert_equal(h2avg1['points'][0][1], 40)
         nt.assert_equal(h2cnt1['metric'], 'histogram.2.count')
         nt.assert_equal(h2cnt1['points'][0][0], 100.0)
-        nt.assert_equal(h2cnt1['points'][0][1], 1)
+        nt.assert_equal(h2cnt1['points'][0][1], 0.1)
 
         # Flush again ensure they're gone.
         dog.reporter.metrics = []
@@ -347,7 +347,7 @@ class TestUnitThreadStats(unittest.TestCase):
         (first, second) = metrics
         nt.assert_equal(first['metric'], 'test.counter.1')
         nt.assert_equal(first['points'][0][0], 1000.0)
-        nt.assert_equal(first['points'][0][1], 3)
+        nt.assert_equal(first['points'][0][1], 0.3)
         nt.assert_equal(second['metric'], 'test.counter.2')
 
         # Test decrement
@@ -361,7 +361,7 @@ class TestUnitThreadStats(unittest.TestCase):
         first, = metrics
         nt.assert_equal(first['metric'], 'test.counter.1')
         nt.assert_equal(first['points'][0][0], 1000.0)
-        nt.assert_equal(first['points'][0][1], 8)
+        nt.assert_equal(first['points'][0][1], 0.8)
         nt.assert_equal(second['metric'], 'test.counter.2')
 
         # Flush again and make sure we're progressing.
@@ -416,11 +416,11 @@ class TestUnitThreadStats(unittest.TestCase):
         [c1, c2, c3, g1, g2, g3] = metrics
         (nt.assert_equal(c['metric'], 'counter') for c in [c1, c2, c3])
         nt.assert_equal(c1['tags'], None)
-        nt.assert_equal(c1['points'][0][1], 1)
+        nt.assert_equal(c1['points'][0][1], 0.1)
         nt.assert_equal(c2['tags'], ['env:production', 'db'])
-        nt.assert_equal(c2['points'][0][1], 1)
+        nt.assert_equal(c2['points'][0][1], 0.1)
         nt.assert_equal(c3['tags'], ['env:staging'])
-        nt.assert_equal(c3['points'][0][1], 1)
+        nt.assert_equal(c3['points'][0][1], 0.1)
 
         (nt.assert_equal(c['metric'], 'gauge') for c in [g1, g2, g3])
         nt.assert_equal(g1['tags'], None)
@@ -529,13 +529,13 @@ class TestUnitThreadStats(unittest.TestCase):
         (nt.assert_equal(c['metric'], 'counter') for c in [c1, c2, c3])
         nt.assert_equal(c1['host'], None)
         nt.assert_equal(c1['tags'], None)
-        nt.assert_equal(c1['points'][0][1], 2)
+        nt.assert_equal(c1['points'][0][1], 0.2)
         nt.assert_equal(c2['host'], 'test')
         nt.assert_equal(c2['tags'], None)
-        nt.assert_equal(c2['points'][0][1], 1)
+        nt.assert_equal(c2['points'][0][1], 0.1)
         nt.assert_equal(c3['host'], 'test')
         nt.assert_equal(c3['tags'], ['tag'])
-        nt.assert_equal(c3['points'][0][1], 2)
+        nt.assert_equal(c3['points'][0][1], 0.2)
 
         (nt.assert_equal(g['metric'], 'gauge') for g in [g1, g2, g3])
         nt.assert_equal(g1['host'], None)

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -670,3 +670,33 @@ class TestUnitThreadStats(unittest.TestCase):
         nt.assert_equal(event['date_happened'], event1_date_happened)
         nt.assert_equal(event['tags'], [event1_tag] + constant_tags + test_tags)
         dog.start(flush_interval=1, roll_up_interval=1)
+
+    def test_metric_type(self):
+        """
+        Checks the submitted metric's metric type.
+        """
+        # Set up ThreadStats with a namespace
+        dog = ThreadStats(namespace="foo")
+        dog.start(roll_up_interval=1, flush_in_thread=False)
+        reporter = dog.reporter = self.reporter
+
+        # Send a few metrics
+        dog.gauge("gauge", 20, timestamp=100.0)
+        dog.increment("counter", timestamp=100.0)
+        dog.histogram('histogram.1', 20, 100.0)
+        dog.flush(200.0)
+		
+        (first, second, p75, p85, p95, p99, avg, cnt, 
+        max_, min_) = self.sort_metrics(reporter.metrics)
+		
+		# Assert Metric type
+        nt.assert_equal(first['type'], 'count')
+        nt.assert_equal(second['type'], 'gauge')
+        nt.assert_equal(p75['type'], 'gauge')
+        nt.assert_equal(p85['type'], 'gauge')
+        nt.assert_equal(p95['type'], 'gauge')
+        nt.assert_equal(p99['type'], 'gauge')
+        nt.assert_equal(avg['type'], 'gauge')
+        nt.assert_equal(cnt['type'], 'count')
+        nt.assert_equal(max_['type'], 'gauge')
+        nt.assert_equal(min_['type'], 'gauge')

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -454,12 +454,14 @@ class TestUnitThreadStats(unittest.TestCase):
 
         # Assertions on gauges
         self.assertMetric(name='gauge', value=10, tags=["type:constant"], count=1)
-        self.assertMetric(name="gauge", value=15, tags=["env:production", "db", "type:constant"], count=1)  # noqa
+        self.assertMetric(name="gauge", value=15, 
+                          tags=["env:production", "db", "type:constant"], count=1)  # noqa
         self.assertMetric(name="gauge", value=20, tags=["env:staging", "type:constant"], count=1)
 
         # Assertions on counters
         self.assertMetric(name="counter", value=1, tags=["type:constant"], count=1)
-        self.assertMetric(name="counter", value=1, tags=["env:production", "db", "type:constant"], count=1)  # noqa
+        self.assertMetric(name="counter", value=1, 
+                          tags=["env:production", "db", "type:constant"], count=1)  # noqa
         self.assertMetric(name="counter", value=1, tags=["env:staging", "type:constant"], count=1)
 
         # Ensure histograms work as well.


### PR DESCRIPTION
# ThreadStats - Send correct Metric Type instead of always sending Gauge

**Problem**
At present in ThreadStats various types of metric gets created like gauge, count, histogram, etc. but at the time of flushing for each metric type is set to "gauge". This is a problem as sending count from server becomes gauge in the web. Changing the type in web will not have any effect as from the server it is always coming as gauge.

**Solution**
Assign the right metric type based on the metric functionality.