### PR TITLE
Add beta support for sending global distribution metrics via dogstatsd

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -188,6 +188,17 @@ class DogStatsd(object):
         """
         self._report(metric, 'h', value, tags, sample_rate)
 
+    def distribution(self, metric, value, tags=None, sample_rate=1):
+        """
+        Send a global distribution value, optionally setting tags and a sample rate.
+
+        >>> statsd.distribution('uploaded.file.size', 1445)
+        >>> statsd.distribution('album.photo.count', 26, tags=["gender:female"])
+
+        This is a beta feature that must be enabled specifically for your organization.
+        """
+        self._report(metric, 'd', value, tags, sample_rate)
+
     def timing(self, metric, value, tags=None, sample_rate=1):
         """
         Record a timing, optionally setting tags and a sample rate.


### PR DESCRIPTION
Adds support to datadogpy for sending global distribution values via dogstatsd.

This is a beta feature. 

I did not add support to the threadstats package because it doesn't seem to make sense - no local aggregation should be done on these.