### PR TITLE
[dashboard list] Add new endpoints + dog cmd for dashboard lists

### DIFF
--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -18,6 +18,7 @@ _mute = True
 
 # Resources
 from datadog.api.comments import Comment
+from datadog.api.dashboard_lists import DashboardList
 from datadog.api.downtimes import Downtime
 from datadog.api.timeboards import Timeboard
 from datadog.api.events import Event

--- a/datadog/api/comments.py
+++ b/datadog/api/comments.py
@@ -6,6 +6,4 @@ class Comment(CreateableAPIResource, UpdatableAPIResource, DeletableAPIResource)
     """
     A wrapper around Comment HTTP API.
     """
-    _class_name = 'comment'
-    _class_url = '/comments'
-    _json_name = 'comment'
+    _resource_name = 'comments'

--- a/datadog/api/dashboard_lists.py
+++ b/datadog/api/dashboard_lists.py
@@ -1,0 +1,48 @@
+from datadog.api.resources import (
+    ActionAPIResource,
+    CreateableAPIResource,
+    DeletableAPIResource,
+    GetableAPIResource,
+    ListableAPIResource,
+    UpdatableAPIResource
+)
+
+class DashboardList(ActionAPIResource, CreateableAPIResource, DeletableAPIResource, GetableAPIResource,
+    ListableAPIResource, UpdatableAPIResource):
+    """
+    A wrapper around Dashboard List HTTP API.
+    """
+    _class_url = '/dashboard/lists/manual'
+
+    @classmethod
+    def get_dashboards(cls, id, **params):
+        """
+        Get dashboards for a dashboard list.
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        return super(DashboardList, cls)._trigger_class_action('GET', 'dashboards', id, params)
+
+    @classmethod
+    def add_dashboards(cls, id, **body):
+        """
+        Add dashboards to a dashboard list.
+
+        :param dashboards: dashboards to add to the dashboard list
+        :type dashboards: list of dashboard dicts, e.g. [{"type": "custom_timeboard", "id": 1104}]
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        return super(DashboardList, cls)._trigger_class_action('POST', 'dashboards', id, params=None, **body)
+
+    @classmethod
+    def delete_dashboards(cls, id, **body):
+        """
+        Delete dashboards from a dashboard list.
+
+        :param dashboards: dashboards to delete from the dashboard list
+        :type dashboards: list of dashboard dicts, e.g. [{"type": "custom_timeboard", "id": 1234}]
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        return super(DashboardList, cls)._trigger_class_action('DELETE', 'dashboards', id, params=None, **body)

--- a/datadog/api/dashboard_lists.py
+++ b/datadog/api/dashboard_lists.py
@@ -36,6 +36,18 @@ class DashboardList(ActionAPIResource, CreateableAPIResource, DeletableAPIResour
         return super(DashboardList, cls)._trigger_class_action('POST', 'dashboards', id, params=None, **body)
 
     @classmethod
+    def update_dashboards(cls, id, **body):
+        """
+        Update dashboards of a dashboard list.
+
+        :param dashboards: dashboards of the dashboard list
+        :type dashboards: list of dashboard dicts, e.g. [{"type": "custom_timeboard", "id": 1104}]
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        return super(DashboardList, cls)._trigger_class_action('PUT', 'dashboards', id, params=None, **body)
+
+    @classmethod
     def delete_dashboards(cls, id, **body):
         """
         Delete dashboards from a dashboard list.

--- a/datadog/api/dashboard_lists.py
+++ b/datadog/api/dashboard_lists.py
@@ -1,67 +1,21 @@
 from datadog.api.resources import (
-    ActionAPIResource,
+    AddableAPISubResource,
     CreateableAPIResource,
     DeletableAPIResource,
+    DeletableAPISubResource,
     GetableAPIResource,
     ListableAPIResource,
-    UpdatableAPIResource
+    ListableAPISubResource,
+    UpdatableAPIResource,
+    UpdatableAPISubResource
 )
 
 
-class DashboardList(ActionAPIResource, CreateableAPIResource, DeletableAPIResource,
-                    GetableAPIResource, ListableAPIResource, UpdatableAPIResource):
+class DashboardList(AddableAPISubResource, CreateableAPIResource, DeletableAPIResource,
+                    DeletableAPISubResource, GetableAPIResource, ListableAPIResource,
+                    ListableAPISubResource, UpdatableAPIResource, UpdatableAPISubResource):
     """
     A wrapper around Dashboard List HTTP API.
     """
-    _class_url = '/dashboard/lists/manual'
-
-    @classmethod
-    def get_dashboards(cls, id, **params):
-        """
-        Get dashboards for a dashboard list.
-
-        :returns: Dictionary representing the API's JSON response
-        """
-        return super(DashboardList, cls)._trigger_class_action('GET', 'dashboards', id, params)
-
-    @classmethod
-    def add_dashboards(cls, id, **body):
-        """
-        Add dashboards to a dashboard list.
-
-        :param dashboards: dashboards to add to the dashboard list
-        :type dashboards: list of dashboard dicts, e.g. [{"type": "custom_timeboard", "id": 1104}]
-
-        :returns: Dictionary representing the API's JSON response
-        """
-        return super(DashboardList, cls)._trigger_class_action(
-            'POST', 'dashboards', id, params=None, **body
-        )
-
-    @classmethod
-    def update_dashboards(cls, id, **body):
-        """
-        Update dashboards of a dashboard list.
-
-        :param dashboards: dashboards of the dashboard list
-        :type dashboards: list of dashboard dicts, e.g. [{"type": "custom_timeboard", "id": 1104}]
-
-        :returns: Dictionary representing the API's JSON response
-        """
-        return super(DashboardList, cls)._trigger_class_action(
-            'PUT', 'dashboards', id, params=None, **body
-        )
-
-    @classmethod
-    def delete_dashboards(cls, id, **body):
-        """
-        Delete dashboards from a dashboard list.
-
-        :param dashboards: dashboards to delete from the dashboard list
-        :type dashboards: list of dashboard dicts, e.g. [{"type": "custom_timeboard", "id": 1234}]
-
-        :returns: Dictionary representing the API's JSON response
-        """
-        return super(DashboardList, cls)._trigger_class_action(
-            'DELETE', 'dashboards', id, params=None, **body
-        )
+    _resource_name = 'dashboard/lists/manual'
+    _sub_resource_name = 'dashboards'

--- a/datadog/api/dashboard_lists.py
+++ b/datadog/api/dashboard_lists.py
@@ -7,8 +7,9 @@ from datadog.api.resources import (
     UpdatableAPIResource
 )
 
-class DashboardList(ActionAPIResource, CreateableAPIResource, DeletableAPIResource, GetableAPIResource,
-    ListableAPIResource, UpdatableAPIResource):
+
+class DashboardList(ActionAPIResource, CreateableAPIResource, DeletableAPIResource,
+                    GetableAPIResource, ListableAPIResource, UpdatableAPIResource):
     """
     A wrapper around Dashboard List HTTP API.
     """
@@ -33,7 +34,9 @@ class DashboardList(ActionAPIResource, CreateableAPIResource, DeletableAPIResour
 
         :returns: Dictionary representing the API's JSON response
         """
-        return super(DashboardList, cls)._trigger_class_action('POST', 'dashboards', id, params=None, **body)
+        return super(DashboardList, cls)._trigger_class_action(
+            'POST', 'dashboards', id, params=None, **body
+        )
 
     @classmethod
     def update_dashboards(cls, id, **body):
@@ -45,7 +48,9 @@ class DashboardList(ActionAPIResource, CreateableAPIResource, DeletableAPIResour
 
         :returns: Dictionary representing the API's JSON response
         """
-        return super(DashboardList, cls)._trigger_class_action('PUT', 'dashboards', id, params=None, **body)
+        return super(DashboardList, cls)._trigger_class_action(
+            'PUT', 'dashboards', id, params=None, **body
+        )
 
     @classmethod
     def delete_dashboards(cls, id, **body):
@@ -57,4 +62,6 @@ class DashboardList(ActionAPIResource, CreateableAPIResource, DeletableAPIResour
 
         :returns: Dictionary representing the API's JSON response
         """
-        return super(DashboardList, cls)._trigger_class_action('DELETE', 'dashboards', id, params=None, **body)
+        return super(DashboardList, cls)._trigger_class_action(
+            'DELETE', 'dashboards', id, params=None, **body
+        )

--- a/datadog/api/downtimes.py
+++ b/datadog/api/downtimes.py
@@ -7,4 +7,4 @@ class Downtime(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
     """
     A wrapper around Monitor Downtiming HTTP API.
     """
-    _class_url = '/downtime'
+    _resource_name = 'downtime'

--- a/datadog/api/events.py
+++ b/datadog/api/events.py
@@ -7,10 +7,7 @@ class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource, De
     """
     A wrapper around Event HTTP API.
     """
-    _class_name = 'event'
-    _class_url = '/events'
-    _plural_class_name = 'events'
-    _json_name = 'event'
+    _resource_name = 'events'
     _timestamp_keys = set(['start', 'end'])
 
     @classmethod

--- a/datadog/api/graphs.py
+++ b/datadog/api/graphs.py
@@ -11,7 +11,7 @@ class Graph(CreateableAPIResource, ActionAPIResource):
     """
     A wrapper around Graph HTTP API.
     """
-    _class_url = '/graph/snapshot'
+    _resource_name = 'graph/snapshot'
 
     @classmethod
     def create(cls, **params):
@@ -56,7 +56,7 @@ class Embed(ListableAPIResource, GetableAPIResource, ActionAPIResource, Createab
     """
     A wrapper around Embed HTTP API.
     """
-    _class_url = '/graph/embed'
+    _resource_name = 'graph/embed'
 
     @classmethod
     def enable(cls, embed_id):

--- a/datadog/api/hosts.py
+++ b/datadog/api/hosts.py
@@ -8,7 +8,7 @@ class Host(ActionAPIResource):
     _class_url = '/host'
 
     @classmethod
-    def mute(cls, host_name, **params):
+    def mute(cls, host_name, **body):
         """
         Mute a host.
 
@@ -28,7 +28,7 @@ class Host(ActionAPIResource):
         :returns: Dictionary representing the API's JSON response
 
         """
-        return super(Host, cls)._trigger_class_action('POST', 'mute', host_name, **params)
+        return super(Host, cls)._trigger_class_action('POST', 'mute', host_name, **body)
 
     @classmethod
     def unmute(cls, host_name):

--- a/datadog/api/hosts.py
+++ b/datadog/api/hosts.py
@@ -5,7 +5,7 @@ class Host(ActionAPIResource):
     """
     A wrapper around Host HTTP API.
     """
-    _class_url = '/host'
+    _resource_name = 'host'
 
     @classmethod
     def mute(cls, host_name, **body):

--- a/datadog/api/infrastructure.py
+++ b/datadog/api/infrastructure.py
@@ -5,8 +5,7 @@ class Infrastructure(SearchableAPIResource):
     """
     A wrapper around Infrastructure HTTP API.
     """
-    _class_url = '/search'
-    _plural_class_name = 'results'
+    _resource_name = 'search'
 
     @classmethod
     def search(cls, **params):

--- a/datadog/api/metadata.py
+++ b/datadog/api/metadata.py
@@ -6,8 +6,7 @@ class Metadata(GetableAPIResource, UpdatableAPIResource):
     """
     A wrapper around Metric Metadata HTTP API
     """
-    _class_url = '/metrics'
-    _json_name = 'metrics'
+    _resource_name = 'metrics'
 
     @classmethod
     def get(cls, metric_name):

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -11,12 +11,11 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
     """
     A wrapper around Metric HTTP API
     """
-    _class_url = None
-    _json_name = 'series'
+    _resource_name = None
 
-    _METRIC_QUERY_ENDPOINT = '/query'
-    _METRIC_SUBMIT_ENDPOINT = '/series'
-    _METRIC_LIST_ENDPOINT = '/metrics'
+    _METRIC_QUERY_ENDPOINT = 'query'
+    _METRIC_SUBMIT_ENDPOINT = 'series'
+    _METRIC_LIST_ENDPOINT = 'metrics'
 
     @classmethod
     def _process_points(cls, points):
@@ -75,7 +74,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
         :returns: Dictionary containing a list of active metrics
         """
 
-        cls._class_url = cls._METRIC_LIST_ENDPOINT
+        cls._resource_name = cls._METRIC_LIST_ENDPOINT
 
         try:
             seconds = int(from_epoch)
@@ -119,7 +118,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
                 metric['type'] = metric.pop('metric_type')
 
         # Set the right endpoint
-        cls._class_url = cls._METRIC_SUBMIT_ENDPOINT
+        cls._resource_name = cls._METRIC_SUBMIT_ENDPOINT
 
         # Format the payload
         try:
@@ -163,7 +162,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
                              query='avg:system.cpu.idle{*}')
         """
         # Set the right endpoint
-        cls._class_url = cls._METRIC_QUERY_ENDPOINT
+        cls._resource_name = cls._METRIC_QUERY_ENDPOINT
 
         # `from` is a reserved keyword in Python, therefore
         # `api.Metric.query(from=...)` is not permited

--- a/datadog/api/monitors.py
+++ b/datadog/api/monitors.py
@@ -8,7 +8,7 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
     """
     A wrapper around Monitor HTTP API.
     """
-    _class_url = '/monitor'
+    _resource_name = 'monitor'
 
     @classmethod
     def get(cls, id, **params):

--- a/datadog/api/monitors.py
+++ b/datadog/api/monitors.py
@@ -57,7 +57,7 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
         return super(Monitor, cls).get_all(**params)
 
     @classmethod
-    def mute(cls, id, **params):
+    def mute(cls, id, **body):
         """
         Mute a monitor.
 
@@ -70,10 +70,10 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
 
         :returns: Dictionary representing the API's JSON response
         """
-        return super(Monitor, cls)._trigger_class_action('POST', 'mute', id, **params)
+        return super(Monitor, cls)._trigger_class_action('POST', 'mute', id, **body)
 
     @classmethod
-    def unmute(cls, id, **params):
+    def unmute(cls, id, **body):
         """
         Unmute a monitor.
 
@@ -85,7 +85,7 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
 
         :returns: Dictionary representing the API's JSON response
         """
-        return super(Monitor, cls)._trigger_class_action('POST', 'unmute', id, **params)
+        return super(Monitor, cls)._trigger_class_action('POST', 'unmute', id, **body)
 
     @classmethod
     def mute_all(cls):

--- a/datadog/api/resources.py
+++ b/datadog/api/resources.py
@@ -33,14 +33,20 @@ class CreateableAPIResource(object):
         """
         if params is None:
             params = {}
+
+        path = cls._resource_name
+
         if method == 'GET':
-            return APIClient.submit('GET', cls._class_url, **body)
+            return APIClient.submit('GET', path, **body)
         if id is None:
-            return APIClient.submit('POST', cls._class_url, body,
+            return APIClient.submit('POST', path, body,
                                     attach_host_name=attach_host_name, **params)
-        else:
-            return APIClient.submit('POST', cls._class_url + "/" + str(id), body,
-                                    attach_host_name=attach_host_name, **params)
+
+        path = '{resource_name}/{resource_id}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id
+        )
+        return APIClient.submit('POST', path, body, attach_host_name=attach_host_name, **params)
 
 
 class SendableAPIResource(object):
@@ -64,11 +70,14 @@ class SendableAPIResource(object):
         :returns: Dictionary representing the API's JSON response
         """
         if id is None:
-            return APIClient.submit('POST', cls._class_url, body,
+            return APIClient.submit('POST', cls._resource_name, body,
                                     attach_host_name=attach_host_name)
-        else:
-            return APIClient.submit('POST', cls._class_url + "/" + str(id), body,
-                                    attach_host_name=attach_host_name)
+
+        path = '{resource_name}/{resource_id}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id
+        )
+        return APIClient.submit('POST', path, body, attach_host_name=attach_host_name)
 
 
 class UpdatableAPIResource(object):
@@ -90,7 +99,12 @@ class UpdatableAPIResource(object):
         """
         if params is None:
             params = {}
-        return APIClient.submit('PUT', cls._class_url + "/" + str(id), body, **params)
+
+        path = '{resource_name}/{resource_id}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id
+        )
+        return APIClient.submit('PUT', path, body, **params)
 
 
 class DeletableAPIResource(object):
@@ -107,7 +121,11 @@ class DeletableAPIResource(object):
 
         :returns: Dictionary representing the API's JSON response
         """
-        return APIClient.submit('DELETE', cls._class_url + "/" + str(id), **params)
+        path = '{resource_name}/{resource_id}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id
+        )
+        return APIClient.submit('DELETE', path, **params)
 
 
 class GetableAPIResource(object):
@@ -127,7 +145,11 @@ class GetableAPIResource(object):
 
         :returns: Dictionary representing the API's JSON response
         """
-        return APIClient.submit('GET', cls._class_url + "/" + str(id), **params)
+        path = '{resource_name}/{resource_id}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id
+        )
+        return APIClient.submit('GET', path, **params)
 
 
 class ListableAPIResource(object):
@@ -144,8 +166,121 @@ class ListableAPIResource(object):
 
         :returns: Dictionary representing the API's JSON response
         """
-        return APIClient.submit('GET', cls._class_url, **params)
+        return APIClient.submit('GET', cls._resource_name, **params)
 
+class ListableAPISubResource(object):
+    """
+    Listable API Sub-Resource
+    """
+    @classmethod
+    def get_items(cls, id, **params):
+        """
+        List API sub-resource objects from a resource
+
+        :param id: resource id to retrieve sub-resource objects from
+        :type id: id
+
+        :param params: parameters to filter API sub-resource stream
+        :type params: dictionary
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        path = '{resource_name}/{resource_id}/{sub_resource_name}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id,
+            sub_resource_name=cls._sub_resource_name
+        )
+        return APIClient.submit('GET', path, **params)
+
+class AddableAPISubResource(object):
+    """
+    Addable API Sub-Resource
+    """
+    @classmethod
+    def add_items(cls, id, params=None, **body):
+        """
+        Add new API sub-resource objects to a resource
+
+        :param id: resource id to add sub-resource objects to
+        :type id: id
+
+        :param params: request parameters
+        :type params: dictionary
+
+        :param body: new sub-resource objects attributes
+        :type body: dictionary
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        if params is None:
+            params = {}
+
+        path = '{resource_name}/{resource_id}/{sub_resource_name}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id,
+            sub_resource_name=cls._sub_resource_name
+        )
+        return APIClient.submit('POST', path, body, **params)
+
+class UpdatableAPISubResource(object):
+    """
+    Updatable API Sub-Resource
+    """
+    @classmethod
+    def update_items(cls, id, params=None, **body):
+        """
+        Update API sub-resource objects of a resource
+
+        :param id: resource id to update sub-resource objects from
+        :type id: id
+
+        :param params: request parameters
+        :type params: dictionary
+
+        :param body: updated sub-resource objects attributes
+        :type body: dictionary
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        if params is None:
+            params = {}
+
+        path = '{resource_name}/{resource_id}/{sub_resource_name}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id,
+            sub_resource_name=cls._sub_resource_name
+        )
+        return APIClient.submit('PUT', path, body, **params)
+
+class DeletableAPISubResource(object):
+    """
+    Deletable API Sub-Resource
+    """
+    @classmethod
+    def delete_items(cls, id, params=None, **body):
+        """
+        Delete API sub-resource objects from a resource
+
+        :param id: resource id to delete sub-resource objects from
+        :type id: id
+
+        :param params: request parameters
+        :type params: dictionary
+
+        :param body: deleted sub-resource objects attributes
+        :type body: dictionary
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        if params is None:
+            params = {}
+
+        path = '{resource_name}/{resource_id}/{sub_resource_name}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id,
+            sub_resource_name=cls._sub_resource_name
+        )
+        return APIClient.submit('DELETE', path, body, **params)
 
 class SearchableAPIResource(object):
     """
@@ -161,7 +296,7 @@ class SearchableAPIResource(object):
 
         :returns: Dictionary representing the API's JSON response
         """
-        return APIClient.submit('GET', cls._class_url, **params)
+        return APIClient.submit('GET', cls._resource_name, **params)
 
 
 class ActionAPIResource(object):
@@ -192,12 +327,20 @@ class ActionAPIResource(object):
         """
         if params is None:
             params = {}
+
         if id is None:
-            return APIClient.submit(method, cls._class_url + "/" + name, body, **params)
-        else:
-            return APIClient.submit(
-                method, cls._class_url + "/" + str(id) + "/" + name, body, **params
+            path = '{resource_name}/{action_name}'.format(
+                resource_name=cls._resource_name,
+                action_name=name
             )
+            return APIClient.submit(method, path, body, **params)
+
+        path = '{resource_name}/{resource_id}/{action_name}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id,
+            action_name=name
+        )
+        return APIClient.submit(method, path, body, **params)
 
     @classmethod
     def _trigger_action(cls, method, name, id=None, **body):
@@ -220,5 +363,9 @@ class ActionAPIResource(object):
         """
         if id is None:
             return APIClient.submit(method, name, body)
-        else:
-            return APIClient.submit(method, name + "/" + str(id), body)
+
+        path = '{action_name}/{resource_id}'.format(
+            action_name=name,
+            resource_id=id
+        )
+        return APIClient.submit(method, path, body)

--- a/datadog/api/resources.py
+++ b/datadog/api/resources.py
@@ -195,7 +195,9 @@ class ActionAPIResource(object):
         if id is None:
             return APIClient.submit(method, cls._class_url + "/" + name, body, **params)
         else:
-            return APIClient.submit(method, cls._class_url + "/" + str(id) + "/" + name, body, **params)
+            return APIClient.submit(
+                method, cls._class_url + "/" + str(id) + "/" + name, body, **params
+            )
 
     @classmethod
     def _trigger_action(cls, method, name, id=None, **body):

--- a/datadog/api/resources.py
+++ b/datadog/api/resources.py
@@ -169,7 +169,7 @@ class ActionAPIResource(object):
     Actionable API Resource
     """
     @classmethod
-    def _trigger_class_action(cls, method, name, id=None, **params):
+    def _trigger_class_action(cls, method, name, id=None, params=None, **body):
         """
         Trigger an action
 
@@ -185,15 +185,20 @@ class ActionAPIResource(object):
         :param params: action parameters
         :type params: dictionary
 
+        :param body: action body
+        :type body: dictionary
+
         :returns: Dictionary representing the API's JSON response
         """
+        if params is None:
+            params = {}
         if id is None:
-            return APIClient.submit(method, cls._class_url + "/" + name, params)
+            return APIClient.submit(method, cls._class_url + "/" + name, body, **params)
         else:
-            return APIClient.submit(method, cls._class_url + "/" + str(id) + "/" + name, params)
+            return APIClient.submit(method, cls._class_url + "/" + str(id) + "/" + name, body, **params)
 
     @classmethod
-    def _trigger_action(cls, method, name, id=None, **params):
+    def _trigger_action(cls, method, name, id=None, **body):
         """
         Trigger an action
 
@@ -206,12 +211,12 @@ class ActionAPIResource(object):
         :param id: trigger the action for the specified resource object
         :type id: id
 
-        :param params: action parameters
-        :type params: dictionary
+        :param body: action body
+        :type body: dictionary
 
         :returns: Dictionary representing the API's JSON response
         """
         if id is None:
-            return APIClient.submit(method, name, params)
+            return APIClient.submit(method, name, body)
         else:
-            return APIClient.submit(method, name + "/" + str(id), params)
+            return APIClient.submit(method, name + "/" + str(id), body)

--- a/datadog/api/resources.py
+++ b/datadog/api/resources.py
@@ -168,6 +168,7 @@ class ListableAPIResource(object):
         """
         return APIClient.submit('GET', cls._resource_name, **params)
 
+
 class ListableAPISubResource(object):
     """
     Listable API Sub-Resource
@@ -191,6 +192,7 @@ class ListableAPISubResource(object):
             sub_resource_name=cls._sub_resource_name
         )
         return APIClient.submit('GET', path, **params)
+
 
 class AddableAPISubResource(object):
     """
@@ -222,6 +224,7 @@ class AddableAPISubResource(object):
         )
         return APIClient.submit('POST', path, body, **params)
 
+
 class UpdatableAPISubResource(object):
     """
     Updatable API Sub-Resource
@@ -252,6 +255,7 @@ class UpdatableAPISubResource(object):
         )
         return APIClient.submit('PUT', path, body, **params)
 
+
 class DeletableAPISubResource(object):
     """
     Deletable API Sub-Resource
@@ -281,6 +285,7 @@ class DeletableAPISubResource(object):
             sub_resource_name=cls._sub_resource_name
         )
         return APIClient.submit('DELETE', path, body, **params)
+
 
 class SearchableAPIResource(object):
     """

--- a/datadog/api/screenboards.py
+++ b/datadog/api/screenboards.py
@@ -8,9 +8,7 @@ class Screenboard(GetableAPIResource, CreateableAPIResource,
     """
     A wrapper around Screenboard HTTP API.
     """
-    _class_name = 'screen'
-    _class_url = '/screen'
-    _json_name = 'board'
+    _resource_name = 'screen'
 
     @classmethod
     def share(cls, board_id):

--- a/datadog/api/service_checks.py
+++ b/datadog/api/service_checks.py
@@ -8,7 +8,7 @@ class ServiceCheck(ActionAPIResource):
     A wrapper around ServiceCheck HTTP API.
     """
     @classmethod
-    def check(cls, **params):
+    def check(cls, **body):
         """
         Post check statuses for use with monitors
 
@@ -34,9 +34,9 @@ class ServiceCheck(ActionAPIResource):
         """
 
         # Validate checks, include only non-null values
-        for param, value in params.items():
-            if param == 'status' and params[param] not in CheckStatus.ALL:
+        for param, value in body.items():
+            if param == 'status' and body[param] not in CheckStatus.ALL:
                 raise ApiError('Invalid status, expected one of: %s'
                                % ', '.join(str(v) for v in CheckStatus.ALL))
 
-        return super(ServiceCheck, cls)._trigger_action('POST', 'check_run', **params)
+        return super(ServiceCheck, cls)._trigger_action('POST', 'check_run', **body)

--- a/datadog/api/tags.py
+++ b/datadog/api/tags.py
@@ -7,9 +7,7 @@ class Tag(CreateableAPIResource, UpdatableAPIResource, GetableAPIResource,
     """
     A wrapper around Tag HTTP API.
     """
-    _class_name = 'tags'
-    _class_url = '/tags/hosts'
-    _plural_class_name = 'tags'
+    _resource_name = 'tags/hosts'
 
     @classmethod
     def create(cls, host, **body):

--- a/datadog/api/timeboards.py
+++ b/datadog/api/timeboards.py
@@ -8,7 +8,4 @@ class Timeboard(GetableAPIResource, CreateableAPIResource,
     """
     A wrapper around Timeboard HTTP API.
     """
-    _class_name = 'dash'
-    _class_url = '/dash'
-    _plural_class_name = 'dashes'
-    _json_name = 'dash'
+    _resource_name = 'dash'

--- a/datadog/api/users.py
+++ b/datadog/api/users.py
@@ -7,10 +7,7 @@ class User(ActionAPIResource, GetableAPIResource, CreateableAPIResource,
            UpdatableAPIResource, ListableAPIResource,
            DeletableAPIResource):
 
-    _class_name = 'user'
-    _class_url = '/user'
-    _plural_class_name = 'users'
-    _json_name = 'user'
+    _resource_name = 'user'
 
     """
     A wrapper around User HTTP API.

--- a/datadog/dogshell/__init__.py
+++ b/datadog/dogshell/__init__.py
@@ -8,6 +8,7 @@ import argparse
 from datadog import initialize
 from datadog.dogshell.comment import CommentClient
 from datadog.dogshell.common import DogshellConfig
+from datadog.dogshell.dashboard_list import DashboardListClient
 from datadog.dogshell.downtime import DowntimeClient
 from datadog.dogshell.event import EventClient
 from datadog.dogshell.host import HostClient
@@ -56,6 +57,7 @@ def main():
     MonitorClient.setup_parser(subparsers)
     TimeboardClient.setup_parser(subparsers)
     ScreenboardClient.setup_parser(subparsers)
+    DashboardListClient.setup_parser(subparsers)
     HostClient.setup_parser(subparsers)
     DowntimeClient.setup_parser(subparsers)
     ServiceCheckClient.setup_parser(subparsers)

--- a/datadog/dogshell/dashboard_list.py
+++ b/datadog/dogshell/dashboard_list.py
@@ -181,7 +181,7 @@ class DashboardListClient(object):
         format = args.format
         dashboard_list_id = args.dashboard_list_id
 
-        res = api.DashboardList.get_dashboards(dashboard_list_id)
+        res = api.DashboardList.get_items(dashboard_list_id)
         report_warnings(res)
         report_errors(res)
 
@@ -197,7 +197,7 @@ class DashboardListClient(object):
         dashboard_list_id = args.dashboard_list_id
         dashboards = json.loads(args.dashboards)
 
-        res = api.DashboardList.add_dashboards(dashboard_list_id, dashboards=dashboards)
+        res = api.DashboardList.add_items(dashboard_list_id, dashboards=dashboards)
         report_warnings(res)
         report_errors(res)
 
@@ -213,7 +213,7 @@ class DashboardListClient(object):
         dashboard_list_id = args.dashboard_list_id
         dashboards = json.loads(args.dashboards)
 
-        res = api.DashboardList.update_dashboards(dashboard_list_id, dashboards=dashboards)
+        res = api.DashboardList.update_items(dashboard_list_id, dashboards=dashboards)
         report_warnings(res)
         report_errors(res)
 
@@ -229,7 +229,7 @@ class DashboardListClient(object):
         dashboard_list_id = args.dashboard_list_id
         dashboards = json.loads(args.dashboards)
 
-        res = api.DashboardList.delete_dashboards(dashboard_list_id, dashboards=dashboards)
+        res = api.DashboardList.delete_items(dashboard_list_id, dashboards=dashboards)
         report_warnings(res)
         report_errors(res)
 

--- a/datadog/dogshell/dashboard_list.py
+++ b/datadog/dogshell/dashboard_list.py
@@ -11,9 +11,6 @@ class DashboardListClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
         parser = subparsers.add_parser('dashboard_list', help="Create, edit, and delete dashboard lists")
-        parser.add_argument('--string_ids', action='store_true', dest='string_ids',
-                            help="Represent dashboard list IDs as strings instead of ints in JSON")
-
         verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
         verb_parsers.required = True
 
@@ -56,6 +53,15 @@ class DashboardListClient(object):
             help='A JSON list of dashboard dicts, e.g. ' +
                  '[{"type": "custom_timeboard", "id": 1234}, {"type": "custom_screenboard", "id": 123}]')
         add_dashboards_parser.set_defaults(func=cls._add_dashboards)
+
+        # Update Dashboards of Dashboard List parser
+        update_dashboards_parser = verb_parsers.add_parser('update_dashboards',
+            help="Update dashboards of an existing dashboard list")
+        update_dashboards_parser.add_argument('dashboard_list_id', help="Dashboard list to update with dashboards")
+        update_dashboards_parser.add_argument('dashboards',
+            help='A JSON list of dashboard dicts, e.g. ' +
+                 '[{"type": "custom_timeboard", "id": 1234}, {"type": "custom_screenboard", "id": 123}]')
+        update_dashboards_parser.set_defaults(func=cls._update_dashboards)
 
         # Delete Dashboards from Dashboard List parser
         delete_dashboards_parser = verb_parsers.add_parser('delete_dashboards',
@@ -107,9 +113,6 @@ class DashboardListClient(object):
         report_warnings(res)
         report_errors(res)
 
-        if args.string_ids:
-            res['id'] = str(res['id'])
-
         if format == 'pretty':
             print(pretty_json(res))
         else:
@@ -123,10 +126,6 @@ class DashboardListClient(object):
         res = api.DashboardList.get_all()
         report_warnings(res)
         report_errors(res)
-
-        if args.string_ids:
-            for dashboard_list in res['dashboard_lists']:
-                dashboard_list['id'] = str(dashboard_list['id'])
 
         if format == 'pretty':
             print(pretty_json(res))
@@ -158,10 +157,6 @@ class DashboardListClient(object):
         report_warnings(res)
         report_errors(res)
 
-        if args.string_ids:
-            for dashboard in res['dashboards']:
-                dashboard['id'] = str(dashboard['id'])
-
         if format == 'pretty':
             print(pretty_json(res))
         else:
@@ -175,6 +170,22 @@ class DashboardListClient(object):
         dashboards = json.loads(args.dashboards)
 
         res = api.DashboardList.add_dashboards(dashboard_list_id, dashboards=dashboards)
+        report_warnings(res)
+        report_errors(res)
+
+        if format == 'pretty':
+            print(pretty_json(res))
+        else:
+            print(json.dumps(res))
+
+    @classmethod
+    def _update_dashboards(cls, args):
+        api._timeout = args.timeout
+        format = args.format
+        dashboard_list_id = args.dashboard_list_id
+        dashboards = json.loads(args.dashboards)
+
+        res = api.DashboardList.update_dashboards(dashboard_list_id, dashboards=dashboards)
         report_warnings(res)
         report_errors(res)
 

--- a/datadog/dogshell/dashboard_list.py
+++ b/datadog/dogshell/dashboard_list.py
@@ -1,0 +1,201 @@
+# 3p
+from datadog.util.format import pretty_json
+
+# datadog
+from datadog import api
+from datadog.dogshell.common import report_errors, report_warnings
+from datadog.util.compat import json
+
+class DashboardListClient(object):
+
+    @classmethod
+    def setup_parser(cls, subparsers):
+        parser = subparsers.add_parser('dashboard_list', help="Create, edit, and delete dashboard lists")
+        parser.add_argument('--string_ids', action='store_true', dest='string_ids',
+                            help="Represent dashboard list IDs as strings instead of ints in JSON")
+
+        verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
+        verb_parsers.required = True
+
+        # Create Dashboard List parser
+        post_parser = verb_parsers.add_parser('post', help="Create a dashboard list")
+        post_parser.add_argument('name', help="Name for the dashboard list")
+        post_parser.set_defaults(func=cls._post)
+
+        # Update Dashboard List parser
+        update_parser = verb_parsers.add_parser('update', help="Update existing dashboard list")
+        update_parser.add_argument('dashboard_list_id', help="Dashboard list to replace with the new definition")
+        update_parser.add_argument('name', help="Name for the dashboard list")
+        update_parser.set_defaults(func=cls._update)
+
+        # Show Dashboard List parser
+        show_parser = verb_parsers.add_parser('show', help="Show a dashboard list definition")
+        show_parser.add_argument('dashboard_list_id', help="Dashboard list to show")
+        show_parser.set_defaults(func=cls._show)
+
+        # Show All Dashboard Lists parser
+        show_all_parser = verb_parsers.add_parser('show_all', help="Show a list of all dashboard lists")
+        show_all_parser.set_defaults(func=cls._show_all)
+
+        # Delete Dashboard List parser
+        delete_parser = verb_parsers.add_parser('delete', help="Delete existing dashboard list")
+        delete_parser.add_argument('dashboard_list_id', help="Dashboard list to delete")
+        delete_parser.set_defaults(func=cls._delete)
+
+        # Get Dashboards for Dashboard List parser
+        get_dashboards_parser = verb_parsers.add_parser('show_dashboards',
+            help="Show a list of all dashboards for an existing dashboard list")
+        get_dashboards_parser.add_argument('dashboard_list_id', help="Dashboard list to show dashboards from")
+        get_dashboards_parser.set_defaults(func=cls._show_dashboards)
+
+        # Add Dashboards to Dashboard List parser
+        add_dashboards_parser = verb_parsers.add_parser('add_dashboards',
+            help="Add dashboards to an existing dashboard list")
+        add_dashboards_parser.add_argument('dashboard_list_id', help="Dashboard list to add dashboards to")
+        add_dashboards_parser.add_argument('dashboards',
+            help='A JSON list of dashboard dicts, e.g. ' +
+                 '[{"type": "custom_timeboard", "id": 1234}, {"type": "custom_screenboard", "id": 123}]')
+        add_dashboards_parser.set_defaults(func=cls._add_dashboards)
+
+        # Delete Dashboards from Dashboard List parser
+        delete_dashboards_parser = verb_parsers.add_parser('delete_dashboards',
+            help="Delete dashboards from an existing dashboard list")
+        delete_dashboards_parser.add_argument('dashboard_list_id', help="Dashboard list to delete dashboards from")
+        delete_dashboards_parser.add_argument('dashboards',
+            help='A JSON list of dashboard dicts, e.g. ' +
+                 '[{"type": "custom_timeboard", "id": 1234}, {"type": "custom_screenboard", "id": 123}]')
+        delete_dashboards_parser.set_defaults(func=cls._delete_dashboards)
+
+    @classmethod
+    def _post(cls, args):
+        api._timeout = args.timeout
+        format = args.format
+        name = args.name
+
+        res = api.DashboardList.create(name=name)
+        report_warnings(res)
+        report_errors(res)
+
+        if format == 'pretty':
+            print(pretty_json(res))
+        else:
+            print(json.dumps(res))
+
+    @classmethod
+    def _update(cls, args):
+        api._timeout = args.timeout
+        format = args.format
+        dashboard_list_id = args.dashboard_list_id
+        name = args.name
+
+        res = api.DashboardList.update(dashboard_list_id, name=name)
+        report_warnings(res)
+        report_errors(res)
+
+        if format == 'pretty':
+            print(pretty_json(res))
+        else:
+            print(json.dumps(res))
+
+    @classmethod
+    def _show(cls, args):
+        api._timeout = args.timeout
+        format = args.format
+        dashboard_list_id = args.dashboard_list_id
+
+        res = api.DashboardList.get(dashboard_list_id)
+        report_warnings(res)
+        report_errors(res)
+
+        if args.string_ids:
+            res['id'] = str(res['id'])
+
+        if format == 'pretty':
+            print(pretty_json(res))
+        else:
+            print(json.dumps(res))
+
+    @classmethod
+    def _show_all(cls, args):
+        api._timeout = args.timeout
+        format = args.format
+
+        res = api.DashboardList.get_all()
+        report_warnings(res)
+        report_errors(res)
+
+        if args.string_ids:
+            for dashboard_list in res['dashboard_lists']:
+                dashboard_list['id'] = str(dashboard_list['id'])
+
+        if format == 'pretty':
+            print(pretty_json(res))
+        else:
+            print(json.dumps(res))
+
+    @classmethod
+    def _delete(cls, args):
+        api._timeout = args.timeout
+        format = args.format
+        dashboard_list_id = args.dashboard_list_id
+
+        res = api.DashboardList.delete(dashboard_list_id)
+        report_warnings(res)
+        report_errors(res)
+
+        if format == 'pretty':
+            print(pretty_json(res))
+        else:
+            print(json.dumps(res))
+
+    @classmethod
+    def _show_dashboards(cls, args):
+        api._timeout = args.timeout
+        format = args.format
+        dashboard_list_id = args.dashboard_list_id
+
+        res = api.DashboardList.get_dashboards(dashboard_list_id)
+        report_warnings(res)
+        report_errors(res)
+
+        if args.string_ids:
+            for dashboard in res['dashboards']:
+                dashboard['id'] = str(dashboard['id'])
+
+        if format == 'pretty':
+            print(pretty_json(res))
+        else:
+            print(json.dumps(res))
+
+    @classmethod
+    def _add_dashboards(cls, args):
+        api._timeout = args.timeout
+        format = args.format
+        dashboard_list_id = args.dashboard_list_id
+        dashboards = json.loads(args.dashboards)
+
+        res = api.DashboardList.add_dashboards(dashboard_list_id, dashboards=dashboards)
+        report_warnings(res)
+        report_errors(res)
+
+        if format == 'pretty':
+            print(pretty_json(res))
+        else:
+            print(json.dumps(res))
+
+    @classmethod
+    def _delete_dashboards(cls, args):
+        api._timeout = args.timeout
+        format = args.format
+        dashboard_list_id = args.dashboard_list_id
+        dashboards = json.loads(args.dashboards)
+
+        res = api.DashboardList.delete_dashboards(dashboard_list_id, dashboards=dashboards)
+        report_warnings(res)
+        report_errors(res)
+
+        if format == 'pretty':
+            print(pretty_json(res))
+        else:
+            print(json.dumps(res))
+

--- a/datadog/dogshell/dashboard_list.py
+++ b/datadog/dogshell/dashboard_list.py
@@ -6,11 +6,14 @@ from datadog import api
 from datadog.dogshell.common import report_errors, report_warnings
 from datadog.util.compat import json
 
+
 class DashboardListClient(object):
 
     @classmethod
     def setup_parser(cls, subparsers):
-        parser = subparsers.add_parser('dashboard_list', help="Create, edit, and delete dashboard lists")
+        parser = subparsers.add_parser(
+            'dashboard_list', help="Create, edit, and delete dashboard lists"
+        )
         verb_parsers = parser.add_subparsers(title='Verbs', dest='verb')
         verb_parsers.required = True
 
@@ -21,7 +24,9 @@ class DashboardListClient(object):
 
         # Update Dashboard List parser
         update_parser = verb_parsers.add_parser('update', help="Update existing dashboard list")
-        update_parser.add_argument('dashboard_list_id', help="Dashboard list to replace with the new definition")
+        update_parser.add_argument(
+            'dashboard_list_id', help="Dashboard list to replace with the new definition"
+        )
         update_parser.add_argument('name', help="Name for the dashboard list")
         update_parser.set_defaults(func=cls._update)
 
@@ -31,7 +36,9 @@ class DashboardListClient(object):
         show_parser.set_defaults(func=cls._show)
 
         # Show All Dashboard Lists parser
-        show_all_parser = verb_parsers.add_parser('show_all', help="Show a list of all dashboard lists")
+        show_all_parser = verb_parsers.add_parser(
+            'show_all', help="Show a list of all dashboard lists"
+        )
         show_all_parser.set_defaults(func=cls._show_all)
 
         # Delete Dashboard List parser
@@ -40,36 +47,57 @@ class DashboardListClient(object):
         delete_parser.set_defaults(func=cls._delete)
 
         # Get Dashboards for Dashboard List parser
-        get_dashboards_parser = verb_parsers.add_parser('show_dashboards',
-            help="Show a list of all dashboards for an existing dashboard list")
-        get_dashboards_parser.add_argument('dashboard_list_id', help="Dashboard list to show dashboards from")
+        get_dashboards_parser = verb_parsers.add_parser(
+            'show_dashboards', help="Show a list of all dashboards for an existing dashboard list"
+        )
+        get_dashboards_parser.add_argument(
+            'dashboard_list_id', help="Dashboard list to show dashboards from"
+        )
         get_dashboards_parser.set_defaults(func=cls._show_dashboards)
 
         # Add Dashboards to Dashboard List parser
-        add_dashboards_parser = verb_parsers.add_parser('add_dashboards',
-            help="Add dashboards to an existing dashboard list")
-        add_dashboards_parser.add_argument('dashboard_list_id', help="Dashboard list to add dashboards to")
-        add_dashboards_parser.add_argument('dashboards',
+        add_dashboards_parser = verb_parsers.add_parser(
+            'add_dashboards', help="Add dashboards to an existing dashboard list"
+        )
+        add_dashboards_parser.add_argument(
+            'dashboard_list_id', help="Dashboard list to add dashboards to"
+        )
+        add_dashboards_parser.add_argument(
+            'dashboards',
             help='A JSON list of dashboard dicts, e.g. ' +
-                 '[{"type": "custom_timeboard", "id": 1234}, {"type": "custom_screenboard", "id": 123}]')
+                 '[{"type": "custom_timeboard", "id": 1234}, ' +
+                 '{"type": "custom_screenboard", "id": 123}]'
+        )
         add_dashboards_parser.set_defaults(func=cls._add_dashboards)
 
         # Update Dashboards of Dashboard List parser
-        update_dashboards_parser = verb_parsers.add_parser('update_dashboards',
-            help="Update dashboards of an existing dashboard list")
-        update_dashboards_parser.add_argument('dashboard_list_id', help="Dashboard list to update with dashboards")
-        update_dashboards_parser.add_argument('dashboards',
+        update_dashboards_parser = verb_parsers.add_parser(
+            'update_dashboards', help="Update dashboards of an existing dashboard list"
+        )
+        update_dashboards_parser.add_argument(
+            'dashboard_list_id', help="Dashboard list to update with dashboards"
+        )
+        update_dashboards_parser.add_argument(
+            'dashboards',
             help='A JSON list of dashboard dicts, e.g. ' +
-                 '[{"type": "custom_timeboard", "id": 1234}, {"type": "custom_screenboard", "id": 123}]')
+                 '[{"type": "custom_timeboard", "id": 1234}, ' +
+                 '{"type": "custom_screenboard", "id": 123}]'
+        )
         update_dashboards_parser.set_defaults(func=cls._update_dashboards)
 
         # Delete Dashboards from Dashboard List parser
-        delete_dashboards_parser = verb_parsers.add_parser('delete_dashboards',
-            help="Delete dashboards from an existing dashboard list")
-        delete_dashboards_parser.add_argument('dashboard_list_id', help="Dashboard list to delete dashboards from")
-        delete_dashboards_parser.add_argument('dashboards',
+        delete_dashboards_parser = verb_parsers.add_parser(
+            'delete_dashboards', help="Delete dashboards from an existing dashboard list"
+        )
+        delete_dashboards_parser.add_argument(
+            'dashboard_list_id', help="Dashboard list to delete dashboards from"
+        )
+        delete_dashboards_parser.add_argument(
+            'dashboards',
             help='A JSON list of dashboard dicts, e.g. ' +
-                 '[{"type": "custom_timeboard", "id": 1234}, {"type": "custom_screenboard", "id": 123}]')
+                 '[{"type": "custom_timeboard", "id": 1234}, ' +
+                 '{"type": "custom_screenboard", "id": 123}]'
+        )
         delete_dashboards_parser.set_defaults(func=cls._delete_dashboards)
 
     @classmethod
@@ -209,4 +237,3 @@ class DashboardListClient(object):
             print(pretty_json(res))
         else:
             print(json.dumps(res))
-

--- a/tests/unit/api/helper.py
+++ b/tests/unit/api/helper.py
@@ -59,12 +59,12 @@ class MyActionable(ActionAPIResource):
     _class_url = '/actionables'
 
     @classmethod
-    def trigger_class_action(cls, method, name, id=None, **params):
-        super(MyActionable, cls)._trigger_class_action(method, name, id, **params)
+    def trigger_class_action(cls, method, name, id=None, params=None, **body):
+        super(MyActionable, cls)._trigger_class_action(method, name, id, params, **body)
 
     @classmethod
-    def trigger_action(cls, method, name, id=None, **params):
-        super(MyActionable, cls)._trigger_action(method, name, id, **params)
+    def trigger_action(cls, method, name, id=None, **body):
+        super(MyActionable, cls)._trigger_action(method, name, id, **body)
 
 
 # Test classes

--- a/tests/unit/api/helper.py
+++ b/tests/unit/api/helper.py
@@ -8,8 +8,18 @@ import requests
 # datadog
 from datadog import initialize, api
 from datadog.api.exceptions import ApiError
-from datadog.api.resources import CreateableAPIResource, UpdatableAPIResource, DeletableAPIResource,\
-    GetableAPIResource, ListableAPIResource, ActionAPIResource
+from datadog.api.resources import (
+    CreateableAPIResource,
+    UpdatableAPIResource,
+    DeletableAPIResource,
+    GetableAPIResource,
+    ListableAPIResource,
+    ListableAPISubResource,
+    AddableAPISubResource,
+    UpdatableAPISubResource,
+    DeletableAPISubResource,
+    ActionAPIResource
+)
 from datadog.util.compat import iteritems, json
 
 
@@ -36,27 +46,42 @@ class MockResponse(requests.Response):
 
 # A few API Resources
 class MyCreatable(CreateableAPIResource):
-    _class_url = '/creatables'
+    _resource_name = 'creatables'
 
 
 class MyUpdatable(UpdatableAPIResource):
-    _class_url = '/updatables'
+    _resource_name = 'updatables'
 
 
 class MyGetable(GetableAPIResource):
-    _class_url = '/getables'
+    _resource_name = 'getables'
 
 
 class MyListable(ListableAPIResource):
-    _class_url = '/listables'
+    _resource_name = 'listables'
 
 
 class MyDeletable(DeletableAPIResource):
-    _class_url = '/deletables'
+    _resource_name = 'deletables'
 
+class MyListableSubResource(ListableAPISubResource):
+    _resource_name = 'resource_name'
+    _sub_resource_name = 'sub_resource_name'
+
+class MyAddableSubResource(AddableAPISubResource):
+    _resource_name = 'resource_name'
+    _sub_resource_name = 'sub_resource_name'
+
+class MyUpdatableSubResource(UpdatableAPISubResource):
+    _resource_name = 'resource_name'
+    _sub_resource_name = 'sub_resource_name'
+
+class MyDeletableSubResource(DeletableAPISubResource):
+    _resource_name = 'resource_name'
+    _sub_resource_name = 'sub_resource_name'
 
 class MyActionable(ActionAPIResource):
-    _class_url = '/actionables'
+    _resource_name = 'actionables'
 
     @classmethod
     def trigger_class_action(cls, method, name, id=None, params=None, **body):

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -21,6 +21,10 @@ from tests.unit.api.helper import (
     MyDeletable,
     MyGetable,
     MyListable,
+    MyListableSubResource,
+    MyAddableSubResource,
+    MyUpdatableSubResource,
+    MyDeletableSubResource,
     MyActionable,
     API_KEY,
     APP_KEY,
@@ -237,6 +241,57 @@ class TestResources(DatadogAPIWithInitialization):
         MyDeletable.delete(deletable_object_id, otherparam="val")
         self.request_called_with('DELETE', "host/api/v1/deletables/" + str(deletable_object_id),
                                  params={'otherparam': "val"})
+
+    def test_listable_sub_resources(self):
+        """
+        Listable sub-resources logic.
+        """
+        resource_id = 123
+        MyListableSubResource.get_items(resource_id, otherparam="val")
+        self.request_called_with(
+            'GET',
+            'host/api/v1/resource_name/{0}/sub_resource_name'.format(resource_id),
+            params={'otherparam': "val"}
+        )
+
+    def test_addable_sub_resources(self):
+        """
+        Addable sub-resources logic.
+        """
+        resource_id = 123
+        MyAddableSubResource.add_items(resource_id, params={'myparam': 'val1'}, mydata='val2')
+        self.request_called_with(
+            'POST',
+            'host/api/v1/resource_name/{0}/sub_resource_name'.format(resource_id),
+            params={'myparam': 'val1'},
+            data={'mydata': 'val2'}
+        )
+
+    def test_updatable_sub_resources(self):
+        """
+        Updatable sub-resources logic.
+        """
+        resource_id = 123
+        MyUpdatableSubResource.update_items(resource_id, params={'myparam': 'val1'}, mydata='val2')
+        self.request_called_with(
+            'PUT',
+            'host/api/v1/resource_name/{0}/sub_resource_name'.format(resource_id),
+            params={'myparam': 'val1'},
+            data={'mydata': 'val2'}
+        )
+
+    def test_deletable_sub_resources(self):
+        """
+        Deletable sub-resources logic.
+        """
+        resource_id = 123
+        MyDeletableSubResource.delete_items(resource_id, params={'myparam': 'val1'}, mydata='val2')
+        self.request_called_with(
+            'DELETE',
+            'host/api/v1/resource_name/{0}/sub_resource_name'.format(resource_id),
+            params={'myparam': 'val1'},
+            data={'mydata': 'val2'}
+        )
 
     def test_actionable(self):
         """

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -243,14 +243,59 @@ class TestResources(DatadogAPIWithInitialization):
         Actionable resource logic.
         """
         actionable_object_id = 123
-        MyActionable.trigger_class_action('POST', "actionname", id=actionable_object_id,
-                                          mydata="val")
-        self.request_called_with('POST', "host/api/v1/actionables/" + str(actionable_object_id) +
-                                 "/actionname", data={'mydata': "val"})
+        MyActionable.trigger_class_action(
+            'POST',
+            'actionname',
+            id=actionable_object_id,
+            params={'myparam': 'val1'},
+            mydata='val',
+            mydata2='val2'
+        )
+        self.request_called_with(
+            'POST',
+            'host/api/v1/actionables/{0}/actionname'.format(str(actionable_object_id)),
+            params={'myparam': 'val1'},
+            data={'mydata': 'val', 'mydata2': 'val2'}
+        )
 
-        MyActionable.trigger_action('POST', "actionname", id=actionable_object_id, mydata="val")
-        self.request_called_with('POST', "host/api/v1/actionname/" + str(actionable_object_id),
-                                 data={'mydata': "val"})
+        MyActionable.trigger_class_action(
+            'POST',
+            'actionname',
+            id=actionable_object_id,
+            mydata='val',
+            mydata2='val2'
+        )
+        self.request_called_with(
+            'POST',
+            'host/api/v1/actionables/{0}/actionname'.format(str(actionable_object_id)),
+            params={},
+            data={'mydata': 'val', 'mydata2': 'val2'}
+        )
+
+        MyActionable.trigger_class_action(
+            'GET',
+            'actionname',
+            id=actionable_object_id,
+            params={'param1': 'val1', 'param2': 'val2'}
+        )
+        self.request_called_with(
+            'GET',
+            'host/api/v1/actionables/{0}/actionname'.format(str(actionable_object_id)),
+            params={'param1': 'val1', 'param2': 'val2'},
+            data={}
+        )
+
+        MyActionable.trigger_action(
+            'POST',
+            'actionname',
+            id=actionable_object_id,
+            mydata="val"
+        )
+        self.request_called_with(
+            'POST',
+            'host/api/v1/actionname/{0}'.format(actionable_object_id),
+            data={'mydata': "val"}
+        )
 
 
 class TestMetricResource(DatadogAPIWithInitialization):


### PR DESCRIPTION
This PR adds the new API endpoints for managing dashboard lists:

- Get all dashboard lists: `GET dashboard/lists/manual`

- Get dashboard list: `GET dashboard/lists/manual/{dashboard_list_id}`

- Create dashboard list: `POST dashboard/lists/manual`

- Update dashboard list: `PUT dashboard/lists/manual/{dashboard_list_id}`

- Delete dashboard list: `DELETE dashboard/lists/manual/{dashboard_list_id}`

- Get dashboards for dashboard list: `GET dashboard/lists/manual/{dashboard_list_id}/dashboards`

- Add dashboards to dashboard list: `POST dashboard/lists/manual/{dashboard_list_id}/dashboards`

- Update dashboards of dashboard list: `PUT dashboard/lists/manual/{dashboard_list_id}/dashboards`

- Delete dashboards from dashboard list: `DELETE dashboard/lists/manual/{dashboard_list_id}/dashboards`