### PR TITLE
Fix Dogwrap to support Python3 integer division

### DIFF
--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -167,8 +167,8 @@ def trim_text(text, max_len):
         u"*...trimmed...*\n" \
         u"```\n" \
         u"{bottom_two_third}\n".format(
-            top_third=text[:max_len / 3],
-            bottom_two_third=text[len(text) - (2 * max_len) / 3:]
+            top_third=text[:max_len // 3],
+            bottom_two_third=text[len(text) - (2 * max_len) // 3:]
         )
 
     return trimmed_text


### PR DESCRIPTION
In Python3, the `/` operator does a floating point division whereas
Python2 does an integer one.

Since the length of the content can yield a decimal number when
divided by 3 it throws the following error in Python3:

```
...
slice indices must be integers or None or have an __index__ method
```

The recommended way to do integer division is by using the `//` operator.
Based on the Python2 and Python3 specs, this ensures that this will do a
proper integer division (see link below).

I've personally tested this fix in both Python2 and Python3 and I've
been able to confirm that no errors are being thrown and that the event
get properly created in DataDog.

https://www.python.org/dev/peps/pep-0238/