### PR TITLE
Add hosts API

### DIFF
--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -28,7 +28,7 @@ from datadog.api.metrics import Metric
 from datadog.api.monitors import Monitor
 from datadog.api.screenboards import Screenboard
 from datadog.api.graphs import Graph, Embed
-from datadog.api.hosts import Host
+from datadog.api.hosts import Host, Hosts
 from datadog.api.service_checks import ServiceCheck
 from datadog.api.tags import Tag
 from datadog.api.users import User

--- a/datadog/api/hosts.py
+++ b/datadog/api/hosts.py
@@ -1,4 +1,4 @@
-from datadog.api.resources import ActionAPIResource
+from datadog.api.resources import ActionAPIResource, ListableAPIResource
 
 
 class Host(ActionAPIResource):
@@ -42,3 +42,19 @@ class Host(ActionAPIResource):
 
         """
         return super(Host, cls)._trigger_class_action('POST', 'unmute', host_name)
+
+class Hosts(ActionAPIResource, ListableAPIResource):
+    """
+    A wrapper around Hosts HTTP API.
+    """
+    _resource_name = 'hosts'
+
+    @classmethod
+    def totals(cls):
+        """
+        Get total number of hosts active and up.
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        return super(Hosts, cls)._trigger_class_action('GET', 'totals')
+


### PR DESCRIPTION
Adds `Hosts.get_all` and `Hosts.totals` to Datadogpy.