### PR TITLE
Check if there are packets to send before sending an empty UDP packet

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -146,7 +146,10 @@ class DogStatsd(object):
         Flush the buffer and switch back to single metric packets.
         """
         self._send = self._send_to_server
-        self._flush_buffer()
+
+        if self.buffer:
+            # Only send packets if there are packets to send
+            self._flush_buffer()
 
     def gauge(self, metric, value, tags=None, sample_rate=1):
         """


### PR DESCRIPTION
This avoid cases where the buffer is initialised but then doesn't receive any
packets to send before it's flushed. That can either be because of conditional
sending of metrics or because a sample rate is used which means no packets has
been generated this time around. In those cases an empty UDP packet is still
sent when the buffer is flushed.

This fixes that by checking if there are any packets to send before attempting
to send them off.