### PR TITLE
Force integer division for truncation of stdout/stderr in dogwrap

### DIFF
--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -167,8 +167,8 @@ def trim_text(text, max_len):
         u"*...trimmed...*\n" \
         u"```\n" \
         u"{bottom_two_third}\n".format(
-            top_third=text[:max_len / 3],
-            bottom_two_third=text[len(text) - (2 * max_len) / 3:]
+            top_third=text[:max_len // 3],
+            bottom_two_third=text[len(text) - (2 * max_len) // 3:]
         )
 
     return trimmed_text
@@ -184,7 +184,7 @@ def build_event_body(cmd, returncode, stdout, stderr, notifications):
     fmt_stderr = u""
     fmt_notifications = u""
 
-    max_length = MAX_EVENT_BODY_LENGTH / 2 if stdout and stderr else MAX_EVENT_BODY_LENGTH
+    max_length = MAX_EVENT_BODY_LENGTH // 2 if stdout and stderr else MAX_EVENT_BODY_LENGTH
 
     if stdout:
         fmt_stdout = u"**>>>> STDOUT <<<<**\n```\n{stdout} \n```\n".format(


### PR DESCRIPTION
👋

Observed behaviour: 

When `dogwrap` runs in a Python 3 environment with `submit_mode=all`, and there is both `stdout` and `stderr`, the following error occurred: 

```shell
    ...
    top_third=text[:max_len / 3],
TypeError: slice indices must be integers or None or have an __index__ method
```

Cause: 

This is because in Python 3, `int / int` no longer returns an int, it returns a float. And floats are invalid index values.

Solution: 

This integer division functionality can be forced by using `//` rather than `/` in both Python 3 and Python 2. (Tested in Python 2.7.12, Python 3.5.2; operator introduced in Python 2.2+ ([PEP238](https://docs.python.org/3/whatsnew/2.2.html#pep-238-changing-the-division-operator))

This change has only been tested manually, because it doesn't appear `dogwrap` is currently being tested (please correct me if I'm wrong)