### PR TITLE
Update type definition for api.Metric.send(...)

### DIFF
--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -102,7 +102,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
         :type tags: string list
 
         :param type: type of the metric
-        :type type: 'gauge' or 'counter' string
+        :type type: 'gauge' or 'count' or 'rate' string
 
         :returns: Dictionary representing the API's JSON response
         """


### PR DESCRIPTION
This updates the [datadogpy docs](http://datadogpy.readthedocs.io/en/latest/#datadog.api.Metric.send) to reflect the correct metric types that are available in the `api.Metric.send()` API: `gauge` `count` and `rate`. I incorrectly passed in `counter` which silently uses `gauge` instead.

As far as I can tell this is correct because of these documents:
- https://docs.datadoghq.com/developers/metrics/#how-do-submission-types-relate-to-datadog-in-app-types
- https://docs.datadoghq.com/api/?lang=python#post-time-series-points