### PR TITLE
Add support for `statsd_socket_path` in initialize function

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -30,7 +30,8 @@ logging.getLogger('datadog.threadstats').addHandler(NullHandler())
 
 
 def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
-               statsd_host=None, statsd_port=None, statsd_use_default_route=False, **kwargs):
+               statsd_host=None, statsd_port=None, statsd_use_default_route=False,
+               statsd_socket_path=None, **kwargs):
     """
     Initialize and configure Datadog.api and Datadog.statsd modules
 
@@ -56,6 +57,9 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     (Useful when running the client in a container)
     :type statsd_use_default_route: boolean
 
+    :param statsd_socket_path: path to the DogStatsd UNIX socket. Supersedes statsd_host
+    and stats_port if provided.
+
     :param cacert: Path to local certificate file used to verify SSL \
         certificates. Can also be set to True (default) to use the systems \
         certificate store, or False to skip SSL verification
@@ -74,10 +78,15 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
 
     # Statsd configuration
     # ...overrides the default `statsd` instance attributes
-    if statsd_host or statsd_use_default_route:
-        statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)
-    if statsd_port:
-        statsd.port = int(statsd_port)
+    if statsd_socket_path:
+        statsd.socket_path = statsd_socket_path
+        statsd.host = None
+        statsd.port = None
+    else:
+        if statsd_host or statsd_use_default_route:
+            statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)
+        if statsd_port:
+            statsd.port = int(statsd_port)
 
     # HTTP client and API options
     for key, value in iteritems(kwargs):

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -106,6 +106,13 @@ class TestDogStatsd(object):
         t.assert_equal(statsd.host, "172.17.0.1")
         t.assert_equal(statsd.port, 1234)
 
+        # Add UNIX socket
+        options['statsd_socket_path'] = '/var/run/dogstatsd.sock'
+        initialize(**options)
+        t.assert_equal(statsd.socket_path, options['statsd_socket_path'])
+        t.assert_equal(statsd.host, None)
+        t.assert_equal(statsd.port, None)
+
     def test_default_route(self):
         """
         Dogstatsd host can be dynamically set to the default route.


### PR DESCRIPTION
Dogstatsd supports handling payloads from a UNIX socket. Combined with origin detection, this makes `dogstatsd` aware of the containers that submit metrics (and therefore add associated tags to those points).