### PR TITLE
Silence deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
   - pip install flake8==3.4.1
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then flake8 --max-line-length=100 datadog; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then python setup.py test; else python setup.py test -s tests.unit; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then python -Wall setup.py test; else python -Wall setup.py test -s tests.unit; fi

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -303,7 +303,7 @@ class DogStatsd(object):
         return string.replace('\n', '\\n')
 
     def _escape_service_check_message(self, string):
-        return string.replace('\n', '\\n').replace('m:', 'm\:')
+        return string.replace('\n', '\\n').replace('m:', 'm\\:')
 
     def event(self, title, text, alert_type=None, aggregation_key=None,
               source_type_name=None, date_happened=None, priority=None,


### PR DESCRIPTION
Warning was raised while running tests against my library with `-Wall` using `datadogpy==0.22.0`. It seems like the intention was to escape the `\`.

```
/tox/py36-django20/lib/python3.6/site-packages/datadog/dogstatsd/base.py:306: DeprecationWarning: invalid escape sequence \:
  return string.replace('\n', '\\n').replace('m:', 'm\:')
```