### PR TITLE
Add note about the Agent running for StatsD

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The Datadog Python library
 
 Datadogpy is a collection of tools suitable for inclusion in existing Python projects or for development of standalone scripts. It provides an abstraction on top of Datadog's raw HTTP interface and the Agent's StatsD metrics aggregation server, to interact with Datadog and efficiently report events and metrics.
 
+For usage of StatsD metrics, the Agent must be [running and available](https://docs.datadoghq.com/developers/dogstatsd/).
+
 - Library Documentation: http://datadogpy.readthedocs.org/en/latest/
 - HTTP API Documentation: http://docs.datadoghq.com/api/
 - DatadogHQ: http://datadoghq.com


### PR DESCRIPTION
Customer got stuck trying to configure StatsD, because they didn't realize the Agent needed to be running in order to get library working.

Adds one line note, referring back to documentation where we show how StatsD works, along with further instructions for configuration.