### PR TITLE
Make start time optional for downtime creation

### DIFF
--- a/datadog/dogshell/downtime.py
+++ b/datadog/dogshell/downtime.py
@@ -19,7 +19,7 @@ class DowntimeClient(object):
 
         post_parser = verb_parsers.add_parser('post', help="Create a downtime")
         post_parser.add_argument('scope', help="scope to apply downtime to")
-        post_parser.add_argument('start', help="POSIX timestamp to start the downtime",
+        post_parser.add_argument('--start', help="POSIX timestamp to start the downtime",
                                  default=None)
         post_parser.add_argument('--end', help="POSIX timestamp to end the downtime", default=None)
         post_parser.add_argument('--message', help="message to include with notifications"

--- a/datadog/dogshell/downtime.py
+++ b/datadog/dogshell/downtime.py
@@ -62,7 +62,7 @@ class DowntimeClient(object):
         if format == 'pretty':
             print(pretty_json(res))
         else:
-            print(json.dumps(res))
+            print(res['id'])
 
     @classmethod
     def _update_downtime(cls, args):


### PR DESCRIPTION
The current API does not require `start` per the [API Reference](https://docs.datadoghq.com/api/?lang=python#schedule-monitor-downtime). It appears this is noted in the current code by the `default=None` inclusion. I've added the `--` to make the arg optional.