### PR TITLE
Add monitor and monitor groups search API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 CHANGELOG
 =========
-# 0.23.0 / 2018-10-13
+# 0.23.0 / Unreleased
 
 Add [monitor search](https://docs.datadoghq.com/api/?lang=python#monitors-search) and [monitor groups search](https://docs.datadoghq.com/api/?lang=python#monitors-group-search) API endpoints.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 CHANGELOG
 =========
+# 0.23.0 / 2018-10-13
+
+Add [monitor search](https://docs.datadoghq.com/api/?lang=python#monitors-search) and [monitor groups search](https://docs.datadoghq.com/api/?lang=python#monitors-group-search) API endpoints.
 
 # 0.22.0 / 2018-06-27
 

--- a/datadog/api/monitors.py
+++ b/datadog/api/monitors.py
@@ -106,18 +106,18 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
         return super(Monitor, cls)._trigger_class_action('POST', 'unmute_all')
 
     @classmethod
-    def search_monitors(cls, **params):
+    def search(cls, **params):
         """
-        Search monitors
+        Search monitors.
 
         :returns: Dictionary representing the API's JSON response
         """
         return super(Monitor, cls)._trigger_class_action('GET', 'search', params=params)
 
     @classmethod
-    def search_monitor_groups(cls, **params):
+    def search_groups(cls, **params):
         """
-        Search monitor monitor groups
+        Search monitor groups.
 
         :returns: Dictionary representing the API's JSON response
         """

--- a/datadog/api/monitors.py
+++ b/datadog/api/monitors.py
@@ -104,3 +104,21 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
         :returns: Dictionary representing the API's JSON response
         """
         return super(Monitor, cls)._trigger_class_action('POST', 'unmute_all')
+
+    @classmethod
+    def search_monitors(cls, **params):
+        """
+        Search monitors
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        return super(Monitor, cls)._trigger_class_action('GET', 'search', params=params)
+
+    @classmethod
+    def search_monitor_groups(cls, **params):
+        """
+        Search monitor monitor groups
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        return super(Monitor, cls)._trigger_class_action('GET', 'groups/search', params=params)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if [sys.version_info[0], sys.version_info[1]] < [2, 7]:
 
 setup(
     name="datadog",
-    version="0.22.0",
+    version="0.23.0",
     install_requires=install_reqs,
     tests_require=["nose", "mock"],
     packages=[


### PR DESCRIPTION
Adds monitor search and monitor groups search API endpoints.

Docs:
https://docs.datadoghq.com/api/?lang=python#monitors-search
https://docs.datadoghq.com/api/?lang=python#monitors-group-search