### PR TITLE
Alias `dog` script names as `dogshell`

### DIFF
--- a/datadog/dogshell/__init__.py
+++ b/datadog/dogshell/__init__.py
@@ -3,6 +3,8 @@
 # Copyright 2015-Present Datadog, Inc
 # stdlib
 import os
+import warnings
+import sys
 
 # 3p
 import argparse
@@ -28,6 +30,9 @@ from datadog.util.config import get_version
 
 
 def main():
+    if sys.argv[0].endswith("dog"):
+        warnings.warn("dog is pending deprecation. Please use dogshell instead.", PendingDeprecationWarning)
+
     parser = argparse.ArgumentParser(description="Interact with the Datadog API",
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--config', help="location of your dogrc file (default ~/.dogrc)",

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -28,6 +28,7 @@ import subprocess
 import sys
 import threading
 import time
+import warnings
 
 # datadog
 from datadog import initialize, api
@@ -405,4 +406,6 @@ def main():
 
 
 if __name__ == '__main__':
+    if sys.argv[0].endswith("dogwrap"):
+        warnings.warn("dogwrap is pending deprecation. Please use dogshellwrap instead.", PendingDeprecationWarning)
     main()

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,14 @@ setup(
         "Documentation": "https://datadogpy.readthedocs.io/en/latest/",
         "Source Code": "https://github.com/DataDog/datadogpy",
     },
-    entry_points={"console_scripts": ["dog = datadog.dogshell:main", "dogwrap = datadog.dogshell.wrap:main"]},
+    entry_points={
+        "console_scripts": [
+            "dog = datadog.dogshell:main",
+            "dogwrap = datadog.dogshell.wrap:main"
+            "dogshell = datadog.dogshell:main",
+            "dogshellwrap = datadog.dogshell.wrap:main"
+        ]
+    },
     test_suite="tests",
     classifiers=[
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
/usr/bin/dog conflicts with the existing sheepdog package in common
Linux distributions. dogshell seems like a sensible choice since
it's already called that in the source module.