### PR TITLE
Completely include tests/ in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include tests/ *.py
+graft tests


### PR DESCRIPTION
As of now, `tests/unit/dogstatsd/fixtures/route` is missing.

Follow-up to https://github.com/DataDog/datadogpy/pull/259.