### PR TITLE
Add support for distributions to threadstats and the API

### DIFF
--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -76,7 +76,6 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
 
         return rec_parse(points_lst)
 
-
     @classmethod
     def list(cls, from_epoch):
         """
@@ -126,7 +125,8 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
     @classmethod
     def send_dist(cls, metrics=None, **single_metric):
         """
-        Submit a distribution metric or a list of distribution metrics to the distribution metric API
+        Submit a distribution metric or a list of distribution metrics to the distribution metric
+        API
 
         :param metric: the name of the time series
         :type metric: string

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -1,5 +1,6 @@
 # stdlib
 import time
+from collections import Iterable
 from numbers import Number
 
 # datadog
@@ -49,7 +50,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
                 # Distributions contain a list of points
                 else:
                     timestamp = point[0]
-                    if isinstance(point[1], list):
+                    if isinstance(point[1], Iterable):
                         value = [float(p) for p in point[1]]
                     else:
                         value = float(point[1])

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -50,10 +50,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
                 else:
                     timestamp = point[0]
                     if isinstance(point[1], list):
-                        float_points = []
-                        for p in point[1]:
-                            float_points.append(float(p))
-                        value = float_points
+                        value = [float(p) for p in point[1]]
                     else:
                         value = float(point[1])
 

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -210,7 +210,7 @@ class ThreadStats(object):
 
     def distribution(self, metric_name, value, timestamp=None, tags=None, sample_rate=1, host=None):
         """
-        Sample a distirbution value. Distributions will produce metrics that
+        Sample a distribution value. Distributions will produce metrics that
         describe the distribution of the recorded values, namely the maximum,
         median, average, count and the 50/75/90/95/99 percentiles. Optionally,
         specify a list of ``tags`` to associate with the metric.
@@ -374,10 +374,10 @@ class ThreadStats(object):
                 'tags': metric_tags,
                 'interval': interval
             }
-            if metric_type != MetricType.Distribution:
-                metrics.append(metric)
-            else:
+            if metric_type == MetricType.Distribution:
                 dists.append(metric)
+            else:
+                metrics.append(metric)
         return (metrics, dists)
 
     def _get_aggregate_events(self):

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -16,7 +16,8 @@ import os
 from datadog.api.exceptions import ApiNotInitialized
 from datadog.threadstats.constants import MetricType
 from datadog.threadstats.events import EventsAggregator
-from datadog.threadstats.metrics import MetricsAggregator, Counter, Gauge, Histogram, Timing, Distribution
+from datadog.threadstats.metrics import (MetricsAggregator, Counter, Gauge, Histogram, Timing,
+                                         Distribution)
 from datadog.threadstats.reporters import HttpReporter
 
 # Loggers

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -14,6 +14,7 @@ import os
 
 # datadog
 from datadog.api.exceptions import ApiNotInitialized
+from datadog.threadstats.constants import MetricType
 from datadog.threadstats.events import EventsAggregator
 from datadog.threadstats.metrics import MetricsAggregator, Counter, Gauge, Histogram, Timing, Distribution
 from datadog.threadstats.reporters import HttpReporter

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -304,7 +304,7 @@ class ThreadStats(object):
             self._is_flush_in_progress = True
 
             # Process metrics
-            (metrics, dists) = self._get_aggregate_metrics_and_dists(timestamp or time())
+            metrics, dists = self._get_aggregate_metrics_and_dists(timestamp or time())
             count_metrics = len(metrics)
             if count_metrics:
                 self.flush_count += 1

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -16,8 +16,8 @@ import os
 from datadog.api.exceptions import ApiNotInitialized
 from datadog.threadstats.constants import MetricType
 from datadog.threadstats.events import EventsAggregator
-from datadog.threadstats.metrics import (MetricsAggregator, Counter, Gauge, Histogram, Timing,
-                                         Distribution)
+from datadog.threadstats.metrics import MetricsAggregator, Counter, Gauge, Histogram, Timing,\
+    Distribution
 from datadog.threadstats.reporters import HttpReporter
 
 # Loggers

--- a/datadog/threadstats/constants.py
+++ b/datadog/threadstats/constants.py
@@ -3,6 +3,7 @@ class MetricType(object):
     Counter = "counter"
     Histogram = "histogram"
     Rate = "rate"
+    Distribution = "distribution"
 
 
 class MonitorType(object):

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -62,6 +62,23 @@ class Counter(Metric):
         return [(timestamp, count/float(interval), self.name,
                 self.tags, self.host, MetricType.Rate, interval)]
 
+class Distribution(Metric):
+    """ A distribution metric. """
+
+    stats_tag = 'd'
+
+    def __init__(self, name, tags, host):
+        self.name = name
+        self.tags = tags
+        self.host = host
+        self.value = []
+
+    def add_point(self, value):
+        self.value.append(value)
+
+    def flush(self, timestamp, interval):
+        return [(timestamp, self.value, self.name, self.tags,
+                self.host, MetricType.Distribution, interval)]
 
 class Histogram(Metric):
     """ A histogram metric. """

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -62,6 +62,7 @@ class Counter(Metric):
         return [(timestamp, count/float(interval), self.name,
                 self.tags, self.host, MetricType.Rate, interval)]
 
+
 class Distribution(Metric):
     """ A distribution metric. """
 
@@ -79,6 +80,7 @@ class Distribution(Metric):
     def flush(self, timestamp, interval):
         return [(timestamp, self.value, self.name, self.tags,
                 self.host, MetricType.Distribution, interval)]
+
 
 class Histogram(Metric):
     """ A histogram metric. """

--- a/datadog/threadstats/reporters.py
+++ b/datadog/threadstats/reporters.py
@@ -14,6 +14,9 @@ class Reporter(object):
 
 class HttpReporter(Reporter):
 
+    def flush_distributions(self, distributions):
+        api.Metric.send_dist(distributions)
+
     def flush_metrics(self, metrics):
         api.Metric.send(metrics)
 


### PR DESCRIPTION
This PR adds support for the distribution metrics API, which is very similar to the metrics API except it accepts a list of points per timestamp rather than a single point. Also add support in the threadstats library to accumulate distribution values and send them on flush.