### PR TITLE
 Add support for distributions to threadstats and the API

### DIFF
--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -19,6 +19,7 @@ _mute = True
 # Resources
 from datadog.api.comments import Comment
 from datadog.api.dashboard_lists import DashboardList
+from datadog.api.distributions import Distribution
 from datadog.api.downtimes import Downtime
 from datadog.api.timeboards import Timeboard
 from datadog.api.events import Event

--- a/datadog/api/distributions.py
+++ b/datadog/api/distributions.py
@@ -14,7 +14,8 @@ class Distribution(SendableAPIResource):
         API
         :param metric: the name of the time series
         :type metric: string
-        :param points: a (timestamp, [list of values]) pair or list of (timestamp, [list of values]) pairs
+        :param points: a (timestamp, [list of values]) pair or
+        list of (timestamp, [list of values]) pairs
         :type points: list
         :param host: host name that produced the metric
         :type host: string

--- a/datadog/api/distributions.py
+++ b/datadog/api/distributions.py
@@ -21,8 +21,6 @@ class Distribution(SendableAPIResource):
         :type host: string
         :param tags:  list of tags associated with the metric.
         :type tags: string list
-        :param type: type of the metric
-        :type type: 'gauge' or 'count' or 'rate' string
         :returns: Dictionary representing the API's JSON response
         """
         if distributions:

--- a/datadog/api/distributions.py
+++ b/datadog/api/distributions.py
@@ -1,0 +1,37 @@
+# datadog
+from datadog.api.format import format_points
+from datadog.api.resources import SendableAPIResource
+
+
+class Distribution(SendableAPIResource):
+    """A wrapper around Distribution HTTP API"""
+    _resource_name = 'distribution_points'
+
+    @classmethod
+    def send(cls, distributions=None, **distribution):
+        """
+        Submit a distribution metric or a list of distribution metrics to the distribution metric
+        API
+        :param metric: the name of the time series
+        :type metric: string
+        :param points: a (timestamp, [list of values]) pair or list of (timestamp, [list of values]) pairs
+        :type points: list
+        :param host: host name that produced the metric
+        :type host: string
+        :param tags:  list of tags associated with the metric.
+        :type tags: string list
+        :param type: type of the metric
+        :type type: 'gauge' or 'count' or 'rate' string
+        :returns: Dictionary representing the API's JSON response
+        """
+        if distributions:
+            # Multiple distributions are sent
+            for d in distributions:
+                if isinstance(d, dict):
+                    d['points'] = format_points(d['points'])
+            series_dict = {"series": distributions}
+        else:
+            # One distribution is sent
+            distribution['points'] = format_points(distribution['points'])
+            series_dict = {"series": [distribution]}
+        return super(Distribution, cls).send(attach_host_name=True, **series_dict)

--- a/datadog/api/format.py
+++ b/datadog/api/format.py
@@ -1,0 +1,58 @@
+from collections import Iterable
+from numbers import Number
+import time
+
+
+def format_points(points):
+    """
+    Format `points` parameter.
+
+    Input:
+        a value or (timestamp, value) pair or a list of value or (timestamp, value) pairs
+
+    Returns:
+        list of (timestamp, float value) pairs
+
+    """
+    now = time.time()
+    points_lst = points if isinstance(points, list) else [points]
+
+    def rec_parse(points_lst):
+        """
+        Recursively parse a list of values or a list of (timestamp, value) pairs to a list of
+        (timestamp, `float` value) pairs.
+        """
+        try:
+            if not points_lst:
+                return []
+
+            point = points_lst.pop()
+            if isinstance(point, Number):
+                timestamp = now
+                value = float(point)
+            # Distributions contain a list of points
+            else:
+                timestamp = point[0]
+                if isinstance(point[1], Iterable):
+                    value = [float(p) for p in point[1]]
+                else:
+                    value = float(point[1])
+
+            point = [(timestamp, value)]
+
+            return point + rec_parse(points_lst)
+
+        except TypeError as e:
+            raise TypeError(
+                u"{0}: "
+                "`points` parameter must use real numerical values.".format(e)
+            )
+
+        except IndexError as e:
+            raise IndexError(
+                u"{0}: "
+                u"`points` must be a list of values or "
+                u"a list of (timestamp, value) pairs".format(e)
+            )
+
+    return rec_parse(points_lst)

--- a/datadog/api/format.py
+++ b/datadog/api/format.py
@@ -15,44 +15,22 @@ def format_points(points):
 
     """
     now = time.time()
-    points_lst = points if isinstance(points, list) else [points]
+    if not isinstance(points, list):
+        points = [points]
 
-    def rec_parse(points_lst):
-        """
-        Recursively parse a list of values or a list of (timestamp, value) pairs to a list of
-        (timestamp, `float` value) pairs.
-        """
-        try:
-            if not points_lst:
-                return []
-
-            point = points_lst.pop()
-            if isinstance(point, Number):
-                timestamp = now
-                value = float(point)
-            # Distributions contain a list of points
+    formatted_points = []
+    for point in points:
+        if isinstance(point, Number):
+            timestamp = now
+            value = float(point)
+        # Distributions contain a list of points
+        else:
+            timestamp = point[0]
+            if isinstance(point[1], Iterable):
+                value = [float(p) for p in point[1]]
             else:
-                timestamp = point[0]
-                if isinstance(point[1], Iterable):
-                    value = [float(p) for p in point[1]]
-                else:
-                    value = float(point[1])
+                value = float(point[1])
 
-            point = [(timestamp, value)]
+        formatted_points.append((timestamp, value))
 
-            return point + rec_parse(points_lst)
-
-        except TypeError as e:
-            raise TypeError(
-                u"{0}: "
-                "`points` parameter must use real numerical values.".format(e)
-            )
-
-        except IndexError as e:
-            raise IndexError(
-                u"{0}: "
-                u"`points` must be a list of values or "
-                u"a list of (timestamp, value) pairs".format(e)
-            )
-
-    return rec_parse(points_lst)
+    return formatted_points

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -76,7 +76,6 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
 
         return rec_parse(points_lst)
 
-
     @classmethod
     def list(cls, from_epoch):
         """
@@ -126,7 +125,8 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
     @classmethod
     def send_dist(cls, metrics=None, **single_metric):
         """
-        Submit a distribution metric or a list of distribution metrics to the distribution metric API
+        Submit a distribution metric or a list of distribution metrics to the distribution metric
+        API
 
         :param metric: the name of the time series
         :type metric: string

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -1,5 +1,6 @@
 # stdlib
 import time
+from collections import Iterable
 from numbers import Number
 
 # datadog
@@ -49,7 +50,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
                 # Distributions contain a list of points
                 else:
                     timestamp = point[0]
-                    if isinstance(point[1], list):
+                    if isinstance(point[1], Iterable):
                         value = [float(p) for p in point[1]]
                     else:
                         value = float(point[1])

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -50,10 +50,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
                 else:
                     timestamp = point[0]
                     if isinstance(point[1], list):
-                        float_points = []
-                        for p in point[1]:
-                            float_points.append(float(p))
-                        value = float_points
+                        value = [float(p) for p in point[1]]
                     else:
                         value = float(point[1])
 

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -1,10 +1,6 @@
-# stdlib
-import time
-from collections import Iterable
-from numbers import Number
-
 # datadog
 from datadog.api.exceptions import ApiError
+from datadog.api.format import format_points
 from datadog.api.resources import SearchableAPIResource, SendableAPIResource, ListableAPIResource
 
 
@@ -17,62 +13,6 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
     _METRIC_QUERY_ENDPOINT = 'query'
     _METRIC_SUBMIT_ENDPOINT = 'series'
     _METRIC_LIST_ENDPOINT = 'metrics'
-    _METRIC_DIST_ENDPOINT = 'distribution_points'
-
-    @classmethod
-    def _process_points(cls, points):
-        """
-        Format `points` parameter.
-
-        Input:
-            a value or (timestamp, value) pair or a list of value or (timestamp, value) pairs
-
-        Returns:
-            list of (timestamp, float value) pairs
-
-        """
-        now = time.time()
-        points_lst = points if isinstance(points, list) else [points]
-
-        def rec_parse(points_lst):
-            """
-            Recursively parse a list of values or a list of (timestamp, value) pairs to a list of
-            (timestamp, `float` value) pairs.
-            """
-            try:
-                if not points_lst:
-                    return []
-
-                point = points_lst.pop()
-                if isinstance(point, Number):
-                    timestamp = now
-                    value = float(point)
-                # Distributions contain a list of points
-                else:
-                    timestamp = point[0]
-                    if isinstance(point[1], Iterable):
-                        value = [float(p) for p in point[1]]
-                    else:
-                        value = float(point[1])
-
-                point = [(timestamp, value)]
-
-                return point + rec_parse(points_lst)
-
-            except TypeError as e:
-                raise TypeError(
-                    u"{0}: "
-                    "`points` parameter must use real numerical values.".format(e)
-                )
-
-            except IndexError as e:
-                raise IndexError(
-                    u"{0}: "
-                    u"`points` must be a list of values or "
-                    u"a list of (timestamp, value) pairs".format(e)
-                )
-
-        return rec_parse(points_lst)
 
     @classmethod
     def list(cls, from_epoch):
@@ -93,6 +33,18 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
             raise ApiError("Parameter 'from_epoch' must be an integer")
 
         return super(Metric, cls).get_all(**params)
+
+    @staticmethod
+    def _rename_metric_type(metric):
+        """
+        FIXME DROPME in 1.0:
+
+        API documentation was illegitimately promoting usage of `metric_type` parameter
+        instead of `type`.
+        To be consistent and avoid 'backward incompatibilities', properly rename this parameter.
+        """
+        if 'metric_type' in metric:
+            metric['type'] = metric.pop('metric_type')
 
     @classmethod
     def send(cls, metrics=None, **single_metric):
@@ -118,59 +70,18 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
         """
         # Set the right endpoint
         cls._resource_name = cls._METRIC_SUBMIT_ENDPOINT
-        cls._send_common(metrics, **single_metric)
-
-    @classmethod
-    def send_dist(cls, metrics=None, **single_metric):
-        """
-        Submit a distribution metric or a list of distribution metrics to the distribution metric
-        API
-
-        :param metric: the name of the time series
-        :type metric: string
-
-        :param points: a (timestamp, value) pair or list of (timestamp, value) pairs
-        :type points: list
-
-        :param host: host name that produced the metric
-        :type host: string
-
-        :param tags:  list of tags associated with the metric.
-        :type tags: string list
-
-        :param type: type of the metric
-        :type type: 'gauge' or 'count' or 'rate' string
-
-        :returns: Dictionary representing the API's JSON response
-        """
-        # Set the right endpoint
-        cls._resource_name = cls._METRIC_DIST_ENDPOINT
-        cls._send_common(metrics, **single_metric)
-
-    @classmethod
-    def _send_common(cls, metrics=None, **single_metric):
-        def rename_metric_type(metric):
-            """
-            FIXME DROPME in 1.0:
-
-            API documentation was illegitimately promoting usage of `metric_type` parameter
-            instead of `type`.
-            To be consistent and avoid 'backward incompatibilities', properly rename this parameter.
-            """
-            if 'metric_type' in metric:
-                metric['type'] = metric.pop('metric_type')
 
         # Format the payload
         try:
             if metrics:
                 for metric in metrics:
                     if isinstance(metric, dict):
-                        rename_metric_type(metric)
-                        metric['points'] = cls._process_points(metric['points'])
+                        cls._rename_metric_type(metric)
+                        metric['points'] = format_points(metric['points'])
                 metrics_dict = {"series": metrics}
             else:
-                rename_metric_type(single_metric)
-                single_metric['points'] = cls._process_points(single_metric['points'])
+                cls._rename_metric_type(single_metric)
+                single_metric['points'] = format_points(single_metric['points'])
                 metrics = [single_metric]
                 metrics_dict = {"series": metrics}
 

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -210,7 +210,7 @@ class ThreadStats(object):
 
     def distribution(self, metric_name, value, timestamp=None, tags=None, sample_rate=1, host=None):
         """
-        Sample a distirbution value. Distributions will produce metrics that
+        Sample a distribution value. Distributions will produce metrics that
         describe the distribution of the recorded values, namely the maximum,
         median, average, count and the 50/75/90/95/99 percentiles. Optionally,
         specify a list of ``tags`` to associate with the metric.
@@ -374,10 +374,10 @@ class ThreadStats(object):
                 'tags': metric_tags,
                 'interval': interval
             }
-            if metric_type != MetricType.Distribution:
-                metrics.append(metric)
-            else:
+            if metric_type == MetricType.Distribution:
                 dists.append(metric)
+            else:
+                metrics.append(metric)
         return (metrics, dists)
 
     def _get_aggregate_events(self):

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -16,7 +16,8 @@ import os
 from datadog.api.exceptions import ApiNotInitialized
 from datadog.threadstats.constants import MetricType
 from datadog.threadstats.events import EventsAggregator
-from datadog.threadstats.metrics import MetricsAggregator, Counter, Gauge, Histogram, Timing, Distribution
+from datadog.threadstats.metrics import (MetricsAggregator, Counter, Gauge, Histogram, Timing,
+                                         Distribution)
 from datadog.threadstats.reporters import HttpReporter
 
 # Loggers

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -14,6 +14,7 @@ import os
 
 # datadog
 from datadog.api.exceptions import ApiNotInitialized
+from datadog.threadstats.constants import MetricType
 from datadog.threadstats.events import EventsAggregator
 from datadog.threadstats.metrics import MetricsAggregator, Counter, Gauge, Histogram, Timing, Distribution
 from datadog.threadstats.reporters import HttpReporter

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -304,7 +304,7 @@ class ThreadStats(object):
             self._is_flush_in_progress = True
 
             # Process metrics
-            (metrics, dists) = self._get_aggregate_metrics_and_dists(timestamp or time())
+            metrics, dists = self._get_aggregate_metrics_and_dists(timestamp or time())
             count_metrics = len(metrics)
             if count_metrics:
                 self.flush_count += 1

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -16,8 +16,8 @@ import os
 from datadog.api.exceptions import ApiNotInitialized
 from datadog.threadstats.constants import MetricType
 from datadog.threadstats.events import EventsAggregator
-from datadog.threadstats.metrics import (MetricsAggregator, Counter, Gauge, Histogram, Timing,
-                                         Distribution)
+from datadog.threadstats.metrics import MetricsAggregator, Counter, Gauge, Histogram, Timing,\
+    Distribution
 from datadog.threadstats.reporters import HttpReporter
 
 # Loggers

--- a/datadog/threadstats/constants.py
+++ b/datadog/threadstats/constants.py
@@ -3,6 +3,7 @@ class MetricType(object):
     Counter = "counter"
     Histogram = "histogram"
     Rate = "rate"
+    Distribution = "distribution"
 
 
 class MonitorType(object):

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -62,6 +62,23 @@ class Counter(Metric):
         return [(timestamp, count/float(interval), self.name,
                 self.tags, self.host, MetricType.Rate, interval)]
 
+class Distribution(Metric):
+    """ A distribution metric. """
+
+    stats_tag = 'd'
+
+    def __init__(self, name, tags, host):
+        self.name = name
+        self.tags = tags
+        self.host = host
+        self.value = []
+
+    def add_point(self, value):
+        self.value.append(value)
+
+    def flush(self, timestamp, interval):
+        return [(timestamp, self.value, self.name, self.tags,
+                self.host, MetricType.Distribution, interval)]
 
 class Histogram(Metric):
     """ A histogram metric. """

--- a/datadog/threadstats/metrics.py
+++ b/datadog/threadstats/metrics.py
@@ -62,6 +62,7 @@ class Counter(Metric):
         return [(timestamp, count/float(interval), self.name,
                 self.tags, self.host, MetricType.Rate, interval)]
 
+
 class Distribution(Metric):
     """ A distribution metric. """
 
@@ -79,6 +80,7 @@ class Distribution(Metric):
     def flush(self, timestamp, interval):
         return [(timestamp, self.value, self.name, self.tags,
                 self.host, MetricType.Distribution, interval)]
+
 
 class Histogram(Metric):
     """ A histogram metric. """

--- a/datadog/threadstats/reporters.py
+++ b/datadog/threadstats/reporters.py
@@ -15,7 +15,7 @@ class Reporter(object):
 class HttpReporter(Reporter):
 
     def flush_distributions(self, distributions):
-        api.Metric.send_dist(distributions)
+        api.Distribution.send(distributions)
 
     def flush_metrics(self, metrics):
         api.Metric.send(metrics)

--- a/datadog/threadstats/reporters.py
+++ b/datadog/threadstats/reporters.py
@@ -14,6 +14,9 @@ class Reporter(object):
 
 class HttpReporter(Reporter):
 
+    def flush_distributions(self, distributions):
+        api.Metric.send_dist(distributions)
+
     def flush_metrics(self, metrics):
         api.Metric.send(metrics)
 

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -10,7 +10,11 @@ import mock
 
 # datadog
 from datadog import initialize, api
-from datadog.api import Metric, ServiceCheck
+from datadog.api import (
+    Distribution,
+    Metric,
+    ServiceCheck
+)
 from datadog.api.exceptions import ApiError, ApiNotInitialized
 from datadog.util.compat import is_p3k
 from tests.unit.api.helper import (
@@ -30,7 +34,8 @@ from tests.unit.api.helper import (
     APP_KEY,
     API_HOST,
     HOST_NAME,
-    FAKE_PROXY)
+    FAKE_PROXY
+)
 
 
 def preserve_environ_datadog(func):
@@ -392,10 +397,10 @@ class TestMetricResource(DatadogAPIWithInitialization):
         now = time()
 
         if isinstance(serie, dict):
-            Metric.send_dist(**deepcopy(serie))
+            Distribution.send(**deepcopy(serie))
             serie = [serie]
         else:
-            Metric.send_dist(deepcopy(serie))
+            Distribution.send(deepcopy(serie))
 
         payload = self.get_request_data()
 
@@ -452,7 +457,6 @@ class TestMetricResource(DatadogAPIWithInitialization):
         serie = [dict(metric='metric.1', points=[[time(), [13]]]),
                  dict(metric='metric.2', points=[[time(), [19]]])]
         self.submit_and_assess_dist_payload(serie)
-
 
     def test_data_type_support(self):
         """


### PR DESCRIPTION
Based on https://github.com/DataDog/datadogpy/pull/308. 
Move distributions to its own `api.Distribution` resource.

Thanks again @jbarciauskas 