### PR TITLE
add monitor subcommands that work from file

### DIFF
--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -33,7 +33,7 @@ class MonitorClient(object):
 
         file_post_parser = verb_parsers.add_parser('fpost', help="Create a monitor from file")
         file_post_parser.add_argument('file', help='json file holding all details',
-                                        type=argparse.FileType('r'))
+                                      type=argparse.FileType('r'))
         file_post_parser.set_defaults(func=cls._file_post)
 
         update_parser = verb_parsers.add_parser('update', help="Update existing monitor")

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -48,7 +48,8 @@ class MonitorClient(object):
         update_parser.add_argument('--options', help="json options for the monitor", default=None)
         update_parser.set_defaults(func=cls._update)
 
-        file_update_parser = verb_parsers.add_parser('fupdate', help="Update existing monitor from file")
+        file_update_parser = verb_parsers.add_parser('fupdate', help="Update existing"
+                                                     " monitor from file")
         file_update_parser.add_argument('file', help='json file holding all details',
                                         type=argparse.FileType('r'))
         file_update_parser.set_defaults(func=cls._file_update)
@@ -126,8 +127,9 @@ class MonitorClient(object):
         api._timeout = args.timeout
         format = args.format
         monitor = json.load(args.file)
-        res = api.Monitor.create( type=monitor['type'], query=monitor['query'], name=monitor['name'],
-                                  message=monitor['message'], options=monitor['options'])
+        res = api.Monitor.create(type=monitor['type'], query=monitor['query'],
+                                 name=monitor['name'], message=monitor['message'],
+                                 options=monitor['options'])
         report_warnings(res)
         report_errors(res)
         if format == 'pretty':
@@ -160,7 +162,8 @@ class MonitorClient(object):
         format = args.format
         monitor = json.load(args.file)
         res = api.Monitor.update(monitor['id'], type=monitor['type'], query=monitor['query'],
-                                 name=monitor['name'], message=monitor['message'], options=monitor['options'])
+                                 name=monitor['name'], message=monitor['message'],
+                                 options=monitor['options'])
         report_warnings(res)
         report_errors(res)
         if format == 'pretty':


### PR DESCRIPTION
These subcommands read a filename from the command line, and then use
specified file for all values.  These features allow a workflow of `dog
monitor show <id> > monitor_id.json && dog monitor fupdate
monitor_id.json`.  This workflow allows version control of all monitors,
as well as repo-driven updates.