### PR TITLE
Add decorator for AWS lambda

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -15,7 +15,7 @@ import os.path
 # datadog
 from datadog import api
 from datadog.dogstatsd import DogStatsd, statsd  # noqa
-from datadog.threadstats import ThreadStats  # noqa
+from datadog.threadstats import ThreadStats, datadog_lambda_wrapper, lambda_stats  # noqa
 from datadog.util.compat import iteritems, NullHandler
 from datadog.util.config import get_version
 from datadog.util.hostname import get_hostname

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -15,7 +15,7 @@ import os.path
 # datadog
 from datadog import api
 from datadog.dogstatsd import DogStatsd, statsd  # noqa
-from datadog.threadstats import ThreadStats, datadog_lambda_wrapper, lambda_stats  # noqa
+from datadog.threadstats import ThreadStats, datadog_lambda_wrapper, lambda_metric  # noqa
 from datadog.util.compat import iteritems, NullHandler
 from datadog.util.config import get_version
 from datadog.util.hostname import get_hostname

--- a/datadog/threadstats/__init__.py
+++ b/datadog/threadstats/__init__.py
@@ -1,2 +1,2 @@
 from datadog.threadstats.base import ThreadStats  # noqa
-from datadog.threadstats.aws_lambda import lambda_stats, datadog_lambda_wrapper  # noqa
+from datadog.threadstats.aws_lambda import lambda_metric, datadog_lambda_wrapper  # noqa

--- a/datadog/threadstats/__init__.py
+++ b/datadog/threadstats/__init__.py
@@ -1,1 +1,2 @@
 from datadog.threadstats.base import ThreadStats  # noqa
+from datadog.threadstats.aws_lambda import lambda_stats, datadog_lambda_wrapper  # noqa

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -1,0 +1,54 @@
+from datadog.threadstats import ThreadStats
+from threading import Lock
+
+
+"""
+Usage:
+
+from datadog import datadog_lambda_wrapper, lambda_stats
+
+@datadog_lambda_wrapper
+def my_lambda_handle(event, context):
+    lambda_stats.increment("some_metric", 10)
+"""
+
+
+class _LambdaDecorator(object):
+    _counter = 0  # Number of opened wrappers, flush when 0
+    _counter_lock = Lock()
+    _was_initialized = False
+
+    def __init__(self, func):
+        self.func = func
+
+    @classmethod
+    def _enter(cls):
+        with cls._counter_lock:
+            if not cls._was_initialized:
+                cls._was_initialized = True
+                from datadog import initialize  # Got blood on my hands now
+                initialize()
+                lambda_stats.start(flush_in_greenlet=False, flush_in_thread=False)
+            cls._counter = cls._counter + 1
+
+    @classmethod
+    def _close(cls):
+        should_flush = False
+        with cls._counter_lock:
+            cls._counter = cls._counter - 1
+
+            if cls._counter <= 0:  # Flush only when all wrappers are closed
+                should_flush = True
+
+        if should_flush:
+            lambda_stats.flush(float("inf"))
+
+    def __call__(self, *args, **kw):
+        _LambdaDecorator._enter()
+        result = self.func(*args, **kw)
+        _LambdaDecorator._close()
+        return result
+
+
+lambda_stats = ThreadStats()
+datadog_lambda_wrapper = _LambdaDecorator

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -48,7 +48,7 @@ class _LambdaDecorator(object):
                     if cls._counter > 0:
                         should_flush = False
                 if should_flush:
-                    lambda_stats.flush(float("inf"))
+                    _lambda_stats.flush(float("inf"))
 
     def __call__(self, *args, **kw):
         _LambdaDecorator._enter()
@@ -57,6 +57,11 @@ class _LambdaDecorator(object):
         return result
 
 
-lambda_stats = ThreadStats()
-lambda_stats.start(flush_in_greenlet=False, flush_in_thread=False)
+_lambda_stats = ThreadStats()
+_lambda_stats.start(flush_in_greenlet=False, flush_in_thread=False)
 datadog_lambda_wrapper = _LambdaDecorator
+
+
+def lambda_stats(*args, **kw):
+    """ Alias to expose only distributions for lambda functions"""
+    _lambda_stats.distribution(*args, **kw)

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -7,11 +7,11 @@ import os
 """
 Usage:
 
-from datadog import datadog_lambda_wrapper, lambda_stats
+from datadog import datadog_lambda_wrapper, lambda_metric
 
 @datadog_lambda_wrapper
 def my_lambda_handle(event, context):
-    lambda_stats.increment("some_metric", 10)
+    lambda_metric("some_metric", 10)
 """
 
 
@@ -67,6 +67,6 @@ _lambda_stats.start(flush_in_greenlet=False, flush_in_thread=False)
 datadog_lambda_wrapper = _LambdaDecorator
 
 
-def lambda_stats(*args, **kw):
+def lambda_metric(*args, **kw):
     """ Alias to expose only distributions for lambda functions"""
     _lambda_stats.distribution(*args, **kw)

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -1,5 +1,7 @@
 from datadog.threadstats import ThreadStats
 from threading import Lock
+from datadog import api
+import os
 
 
 """
@@ -26,9 +28,7 @@ class _LambdaDecorator(object):
         with cls._counter_lock:
             if not cls._was_initialized:
                 cls._was_initialized = True
-                from datadog import initialize  # Got blood on my hands now
-                initialize()
-                lambda_stats.start(flush_in_greenlet=False, flush_in_thread=False)
+                api._api_key = os.environ.get('DATADOG_API_KEY')
             cls._counter = cls._counter + 1
 
     @classmethod
@@ -51,4 +51,5 @@ class _LambdaDecorator(object):
 
 
 lambda_stats = ThreadStats()
+lambda_stats.start(flush_in_greenlet=False, flush_in_thread=False)
 datadog_lambda_wrapper = _LambdaDecorator

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -33,6 +33,7 @@ class _LambdaDecorator(object):
             if not cls._was_initialized:
                 cls._was_initialized = True
                 api._api_key = os.environ.get('DATADOG_API_KEY')
+                api._api_host = os.environ.get('DATADOG_HOST', 'https://api.datadoghq.com')
             cls._counter = cls._counter + 1
 
     @classmethod

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -16,7 +16,10 @@ def my_lambda_handle(event, context):
 
 
 class _LambdaDecorator(object):
-    _counter = 0  # Number of opened wrappers, flush when 0
+    """ Decorator to automatically init & flush metrics, created for Lambda functions"""
+
+    # Number of opened wrappers, flush when 0
+    _counter = 0
     _counter_lock = Lock()
     _flush_lock = Lock()
     _was_initialized = False
@@ -38,7 +41,8 @@ class _LambdaDecorator(object):
         with cls._counter_lock:
             cls._counter = cls._counter - 1
 
-            if cls._counter <= 0:  # Flush only when all wrappers are closed
+            # Flush only when all wrappers are closed
+            if cls._counter <= 0:
                 should_flush = True
 
         if should_flush:

--- a/tests/performance/test_lambda_wrapper_thread_safety.py
+++ b/tests/performance/test_lambda_wrapper_thread_safety.py
@@ -1,5 +1,5 @@
 import time
-import unittest
+# import unittest
 import threading
 
 from datadog import lambda_stats, datadog_lambda_wrapper
@@ -30,7 +30,7 @@ def wrapped_function(id):
     lambda_stats("common_dist", 42)
 
 
-class TestWrapperThreadSafety(unittest.TestCase):
+class TestWrapperThreadSafety(object):
 
     def test_wrapper_thread_safety(self):
         _lambda_stats.reporter = MemoryReporter()

--- a/tests/performance/test_lambda_wrapper_thread_safety.py
+++ b/tests/performance/test_lambda_wrapper_thread_safety.py
@@ -24,7 +24,8 @@ class MemoryReporter(object):
 @datadog_lambda_wrapper
 def wrapped_function(id):
     lambda_stats("dist_" + str(id), 42)
-    time.sleep(0.001)  # sleep makes the os continue another thread
+    # sleep makes the os continue another thread
+    time.sleep(0.001)
 
     lambda_stats("common_dist", 42)
 

--- a/tests/performance/test_lambda_wrapper_thread_safety.py
+++ b/tests/performance/test_lambda_wrapper_thread_safety.py
@@ -41,16 +41,9 @@ def wrapped_function(id):
     lambda_stats.event("title", "content")
 
 
-@datadog_lambda_wrapper
-def wrapped_init():
-    pass
-
-
 class TestWrapperThreadSafety(object):
 
     def test_wrapper_thread_safety(self):
-
-        wrapped_init()  # Empty run to make the initialization
         lambda_stats.reporter = MemoryReporter()
         datadog_lambda_wrapper._counter = 1
 

--- a/tests/performance/test_lambda_wrapper_thread_safety.py
+++ b/tests/performance/test_lambda_wrapper_thread_safety.py
@@ -2,7 +2,7 @@ import time
 # import unittest
 import threading
 
-from datadog import lambda_stats, datadog_lambda_wrapper
+from datadog import lambda_metric, datadog_lambda_wrapper
 from datadog.threadstats.aws_lambda import _lambda_stats
 
 
@@ -23,11 +23,11 @@ class MemoryReporter(object):
 
 @datadog_lambda_wrapper
 def wrapped_function(id):
-    lambda_stats("dist_" + str(id), 42)
+    lambda_metric("dist_" + str(id), 42)
     # sleep makes the os continue another thread
     time.sleep(0.001)
 
-    lambda_stats("common_dist", 42)
+    lambda_metric("common_dist", 42)
 
 
 class TestWrapperThreadSafety(object):

--- a/tests/performance/test_lambda_wrapper_thread_safety.py
+++ b/tests/performance/test_lambda_wrapper_thread_safety.py
@@ -1,0 +1,101 @@
+import re
+import time
+# import unittest
+import threading
+from nose import tools as t
+
+from datadog import lambda_stats, datadog_lambda_wrapper
+
+
+class MemoryReporter(object):
+    """ A reporting class that reports to memory for testing. """
+
+    def __init__(self):
+        self.metrics = []
+        self.events = []
+
+    def flush_metrics(self, metrics):
+        self.metrics += metrics
+
+    def flush_events(self, events):
+        self.events += events
+
+
+@datadog_lambda_wrapper
+def wrapped_function(id):
+
+    t.assert_greater(datadog_lambda_wrapper._counter, 1)
+    # Increment
+    lambda_stats.increment("counter", timestamp=12345)
+    time.sleep(0.001)  # sleep makes the os continue another thread
+
+    # Gauge
+    lambda_stats.gauge("gauge_" + str(id), 42)
+    time.sleep(0.001)  # sleep makes the os continue another thread
+
+    # Histogram
+    lambda_stats.histogram("histogram", id, timestamp=12345)
+    time.sleep(0.001)  # sleep makes the os continue another thread
+
+    # Event
+    lambda_stats.event("title", "content")
+
+
+@datadog_lambda_wrapper
+def wrapped_init():
+    pass
+
+
+class TestWrapperThreadSafety(object):
+
+    def test_wrapper_thread_safety(self):
+
+        wrapped_init()  # Empty run to make the initialization
+        lambda_stats.reporter = MemoryReporter()
+        datadog_lambda_wrapper._counter = 1
+
+        for i in range(10000):
+            threading.Thread(target=wrapped_function, args=[i]).start()
+        # Wait all threads to finish
+        time.sleep(10)
+
+        # Flush and check
+        t.assert_equal(datadog_lambda_wrapper._counter, 1)
+        lambda_stats.flush(float("inf"))
+
+        metrics = lambda_stats.reporter.metrics
+        events = lambda_stats.reporter.events
+
+        # Overview
+        t.assert_equal(len(metrics), 10009, len(metrics))
+
+        # Sort metrics
+        counter_metrics = []
+        gauge_metrics = []
+        histogram_metrics = []
+
+        for m in metrics:
+            if re.match("gauge_.*", m['metric']):
+                gauge_metrics.append(m)
+            elif re.match("histogram.*", m['metric']):
+                histogram_metrics.append(m)
+            else:
+                counter_metrics.append(m)
+
+        # Counter
+        t.assert_equal(len(counter_metrics), 1, len(counter_metrics))
+        counter = counter_metrics[0]
+        t.assert_equal(counter['points'][0][1], 10000, counter['points'][0][1])
+
+        # Gauge
+        t.assert_equal(len(gauge_metrics), 10000, len(gauge_metrics))
+
+        # Histogram
+        t.assert_equal(len(histogram_metrics), 8, len(histogram_metrics))
+        count_histogram = filter(lambda x: x['metric'] == "histogram.count", histogram_metrics)[0]
+        t.assert_equal(count_histogram['points'][0][1], 10000, count_histogram['points'][0][1])
+        sum_histogram = filter(lambda x: x['metric'] == "histogram.avg", histogram_metrics)[0]
+        t.assert_equal(sum_histogram['points'][0][1], 4999.5, sum_histogram['points'][0][1])
+
+        # Events
+        t.assert_equal(10000, len(events), len(events))

--- a/tests/performance/test_lambda_wrapper_thread_safety.py
+++ b/tests/performance/test_lambda_wrapper_thread_safety.py
@@ -1,94 +1,46 @@
-import re
 import time
-# import unittest
+import unittest
 import threading
-from nose import tools as t
 
 from datadog import lambda_stats, datadog_lambda_wrapper
+from datadog.threadstats.aws_lambda import _lambda_stats
+
+
+TOTAL_NUMBER_OF_THREADS = 1000
 
 
 class MemoryReporter(object):
     """ A reporting class that reports to memory for testing. """
 
     def __init__(self):
-        self.metrics = []
-        self.events = []
+        self.distributions = []
+        self.dist_flush_counter = 0
 
-    def flush_metrics(self, metrics):
-        self.metrics += metrics
-
-    def flush_events(self, events):
-        self.events += events
+    def flush_distributions(self, dists):
+        self.distributions += dists
+        self.dist_flush_counter = self.dist_flush_counter + 1
 
 
 @datadog_lambda_wrapper
 def wrapped_function(id):
-
-    t.assert_greater(datadog_lambda_wrapper._counter, 1)
-    # Increment
-    lambda_stats.increment("counter", timestamp=12345)
+    lambda_stats("dist_" + str(id), 42)
     time.sleep(0.001)  # sleep makes the os continue another thread
 
-    # Gauge
-    lambda_stats.gauge("gauge_" + str(id), 42)
-    time.sleep(0.001)  # sleep makes the os continue another thread
-
-    # Histogram
-    lambda_stats.histogram("histogram", id, timestamp=12345)
-    time.sleep(0.001)  # sleep makes the os continue another thread
-
-    # Event
-    lambda_stats.event("title", "content")
+    lambda_stats("common_dist", 42)
 
 
-class TestWrapperThreadSafety(object):
+class TestWrapperThreadSafety(unittest.TestCase):
 
     def test_wrapper_thread_safety(self):
-        lambda_stats.reporter = MemoryReporter()
-        datadog_lambda_wrapper._counter = 1
+        _lambda_stats.reporter = MemoryReporter()
 
-        for i in range(10000):
+        for i in range(TOTAL_NUMBER_OF_THREADS):
             threading.Thread(target=wrapped_function, args=[i]).start()
         # Wait all threads to finish
         time.sleep(10)
 
-        # Flush and check
-        t.assert_equal(datadog_lambda_wrapper._counter, 1)
-        lambda_stats.flush(float("inf"))
+        # Check that at least one flush happened
+        self.assertGreater(_lambda_stats.reporter.dist_flush_counter, 0)
 
-        metrics = lambda_stats.reporter.metrics
-        events = lambda_stats.reporter.events
-
-        # Overview
-        t.assert_equal(len(metrics), 10009, len(metrics))
-
-        # Sort metrics
-        counter_metrics = []
-        gauge_metrics = []
-        histogram_metrics = []
-
-        for m in metrics:
-            if re.match("gauge_.*", m['metric']):
-                gauge_metrics.append(m)
-            elif re.match("histogram.*", m['metric']):
-                histogram_metrics.append(m)
-            else:
-                counter_metrics.append(m)
-
-        # Counter
-        t.assert_equal(len(counter_metrics), 1, len(counter_metrics))
-        counter = counter_metrics[0]
-        t.assert_equal(counter['points'][0][1], 10000, counter['points'][0][1])
-
-        # Gauge
-        t.assert_equal(len(gauge_metrics), 10000, len(gauge_metrics))
-
-        # Histogram
-        t.assert_equal(len(histogram_metrics), 8, len(histogram_metrics))
-        count_histogram = filter(lambda x: x['metric'] == "histogram.count", histogram_metrics)[0]
-        t.assert_equal(count_histogram['points'][0][1], 10000, count_histogram['points'][0][1])
-        sum_histogram = filter(lambda x: x['metric'] == "histogram.avg", histogram_metrics)[0]
-        t.assert_equal(sum_histogram['points'][0][1], 4999.5, sum_histogram['points'][0][1])
-
-        # Events
-        t.assert_equal(10000, len(events), len(events))
+        dists = _lambda_stats.reporter.distributions
+        self.assertEqual(len(dists), TOTAL_NUMBER_OF_THREADS + 1)

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -14,7 +14,7 @@ from mock import patch
 import nose.tools as nt
 
 # datadog
-from datadog import ThreadStats, lambda_stats, datadog_lambda_wrapper
+from datadog import ThreadStats, lambda_metric, datadog_lambda_wrapper
 from datadog.threadstats.aws_lambda import _lambda_stats
 from tests.util.contextmanagers import preserve_environment_variable
 
@@ -750,7 +750,7 @@ class TestUnitThreadStats(unittest.TestCase):
 
         @datadog_lambda_wrapper
         def basic_wrapped_function():
-            lambda_stats("lambda.somemetric", 100)
+            lambda_metric("lambda.somemetric", 100)
 
         _lambda_stats.reporter = self.reporter
         basic_wrapped_function()
@@ -766,12 +766,12 @@ class TestUnitThreadStats(unittest.TestCase):
 
         @datadog_lambda_wrapper
         def wrapped_function_1():
-            lambda_stats("lambda.dist.1", 10)
+            lambda_metric("lambda.dist.1", 10)
 
         @datadog_lambda_wrapper
         def wrapped_function_2():
             wrapped_function_1()
-            lambda_stats("lambda.dist.2", 30)
+            lambda_metric("lambda.dist.2", 30)
 
         _lambda_stats.reporter = self.reporter
         wrapped_function_2()

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -42,12 +42,6 @@ class MemoryReporter(object):
         self.events += events
 
 
-@datadog_lambda_wrapper
-def wrapped_init():
-    """The first opened wrapper calls the "start" method, which would override the MemoryReporter"""
-    pass
-
-
 class TestUnitThreadStats(unittest.TestCase):
     """
     Unit tests for ThreadStats.
@@ -755,8 +749,6 @@ class TestUnitThreadStats(unittest.TestCase):
         def basic_wrapped_function():  # Test custom_metric function
             lambda_stats.distribution("lambda.somemetric", 100, 300)
 
-        wrapped_init()  # Empty run to make the initialization
-
         lambda_stats.reporter = self.reporter
         basic_wrapped_function()
 
@@ -784,8 +776,6 @@ class TestUnitThreadStats(unittest.TestCase):
 
             lambda_stats.gauge("lambda.gauge.2", 30, 200)
             nt.assert_equal(datadog_lambda_wrapper._counter, 1)
-
-        wrapped_init()  # Empty run to make the initialization
 
         lambda_stats.reporter = self.reporter
 

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -15,6 +15,7 @@ import nose.tools as nt
 
 # datadog
 from datadog import ThreadStats, lambda_stats, datadog_lambda_wrapper
+from datadog.threadstats.aws_lambda import _lambda_stats
 from tests.util.contextmanagers import preserve_environment_variable
 
 # Silence the logger.
@@ -31,9 +32,11 @@ class MemoryReporter(object):
         self.distributions = []
         self.metrics = []
         self.events = []
+        self.dist_flush_counter = 0
 
     def flush_distributions(self, distributions):
         self.distributions += distributions
+        self.dist_flush_counter = self.dist_flush_counter + 1
 
     def flush_metrics(self, metrics):
         self.metrics += metrics
@@ -747,14 +750,14 @@ class TestUnitThreadStats(unittest.TestCase):
 
         @datadog_lambda_wrapper
         def basic_wrapped_function():  # Test custom_metric function
-            lambda_stats.distribution("lambda.somemetric", 100, 300)
+            lambda_stats("lambda.somemetric", 100)
 
-        lambda_stats.reporter = self.reporter
+        _lambda_stats.reporter = self.reporter
         basic_wrapped_function()
 
-        dists = self.sort_metrics(lambda_stats.reporter.distributions)
+        nt.assert_equal(_lambda_stats.reporter.dist_flush_counter, 1)
+        dists = self.sort_metrics(_lambda_stats.reporter.distributions)
         nt.assert_equal(len(dists), 1)
-        lambda_stats.reporter.distributions = []
 
     def test_embedded_lambda_decorator(self):
         """
@@ -763,33 +766,16 @@ class TestUnitThreadStats(unittest.TestCase):
 
         @datadog_lambda_wrapper
         def wrapped_function_1():
-            lambda_stats.gauge("lambda.gauge.1", 10, 100)
-            nt.assert_equal(datadog_lambda_wrapper._counter, 2)
+            lambda_stats("lambda.dist.1", 10)
 
         @datadog_lambda_wrapper
         def wrapped_function_2():
-            wrapped_function_1()  # Embedded wrappers
+            wrapped_function_1()
+            lambda_stats("lambda.dist.2", 30)
 
-            # Check that wrapper_function_1() didn't flush
-            metrics = self.sort_metrics(lambda_stats.reporter.metrics)
-            nt.assert_equal(len(metrics), 0)
-
-            lambda_stats.gauge("lambda.gauge.2", 30, 200)
-            nt.assert_equal(datadog_lambda_wrapper._counter, 1)
-
-        lambda_stats.reporter = self.reporter
-
-        nt.assert_equal(datadog_lambda_wrapper._counter, 0)
+        _lambda_stats.reporter = self.reporter
         wrapped_function_2()
-        nt.assert_equal(datadog_lambda_wrapper._counter, 0)
+        nt.assert_equal(_lambda_stats.reporter.dist_flush_counter, 1)
 
-        metrics = self.sort_metrics(lambda_stats.reporter.metrics)
-        nt.assert_equal(len(metrics), 2)
-
-        (first, second) = metrics
-        nt.assert_equal(first['metric'], 'lambda.gauge.1')
-        nt.assert_equal(first['points'][0][0], 100)
-        nt.assert_equal(first['points'][0][1], 10)
-        nt.assert_equal(second['metric'], 'lambda.gauge.2')
-        nt.assert_equal(second['points'][0][0], 200)
-        nt.assert_equal(second['points'][0][1], 30)
+        dists = self.sort_metrics(_lambda_stats.reporter.distributions)
+        nt.assert_equal(len(dists), 2)

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -749,7 +749,7 @@ class TestUnitThreadStats(unittest.TestCase):
     def test_basic_lambda_decorator(self):
 
         @datadog_lambda_wrapper
-        def basic_wrapped_function():  # Test custom_metric function
+        def basic_wrapped_function():
             lambda_stats("lambda.somemetric", 100)
 
         _lambda_stats.reporter = self.reporter


### PR DESCRIPTION
Wrapper to automatically initialize & flush in AWS lambda functions.

Example of a lambda:
```
from datadog import datadog_lambda_wrapper, lambda_stats

@datadog_lambda_wrapper
def my_lambda_handle(event, context):
    lambda_metrc("some_metric", 10)

```