### PR TITLE
Lambda wrapper - start TLS connection on init & RequestClientKeptAlive

### DIFF
--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -37,7 +37,7 @@ class _LambdaDecorator(object):
 
                 # Async initialization of the TLS connection with our endpoints
                 # This avoids adding execution time at the end of the lambda run
-                t = Thread(target=init_connection)
+                t = Thread(target=_init_api_client)
                 t.start()
             cls._counter = cls._counter + 1
 
@@ -77,8 +77,8 @@ def lambda_metric(*args, **kw):
     _lambda_stats.distribution(*args, **kw)
 
 
-def init_connection():
-    """ No-op POST to initialize the requests connection with DD's endpoints
+def _init_api_client():
+    """ No-op GET to initialize the requests connection with DD's endpoints
 
     The goal here is to make the final flush faster:
     we keep alive the Requests session, this means that we can re-use the connection
@@ -87,4 +87,7 @@ def init_connection():
 
     By making the initial request async, we spare a lot of execution time in the lambdas.
     """
-    api.api_client.APIClient.submit('GET', 'validate')
+    try:
+        _ = api.api_client.APIClient.submit('GET', 'validate')
+    except Exception:
+        pass

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -88,6 +88,6 @@ def _init_api_client():
     By making the initial request async, we spare a lot of execution time in the lambdas.
     """
     try:
-        _ = api.api_client.APIClient.submit('GET', 'validate')
+        api.api_client.APIClient.submit('GET', 'validate')
     except Exception:
         pass

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -73,7 +73,7 @@ class TestInitialization(DatadogAPINoInitialization):
         # Finally, initialize with an API key
         initialize(api_key=API_KEY, api_host=API_HOST)
         MyCreatable.create()
-        self.assertEquals(self.request_mock.request.call_count, 1)
+        self.assertEquals(self.request_mock.call_count(), 1)
 
     @mock.patch('datadog.util.config.get_config_path')
     def test_get_hostname(self, mock_config_path):
@@ -105,7 +105,7 @@ class TestInitialization(DatadogAPINoInitialization):
         # Make a simple API call
         MyCreatable.create()
 
-        _, options = self.request_mock.request.call_args
+        _, options = self.request_mock.call_args()
 
         # Assert `requests` parameters
         self.assertIn('params', options)
@@ -128,7 +128,7 @@ class TestInitialization(DatadogAPINoInitialization):
         # Make a simple API call
         MyCreatable.create()
 
-        _, options = self.request_mock.request.call_args
+        _, options = self.request_mock.call_args()
 
         # Assert `requests` parameters
         self.assertIn('proxies', options)


### PR DESCRIPTION
Adds a new HTTPClient: `RequestClientKeptAlive`. It keeps the `requests` session alive.

Adds a no-op POST request on lambda_wrapper initialization: this initializes `RequestClientKeptAlive`'s connection to our endpoint at the beginning of the lambda executions instead of at the end: this enables to us to use an async initialization.

Note: the connection to our endpoint is kept alive across multiple invocations of the same lambda thanks to AWS's context reuse.