### PR TITLE
Remove redundant string conversion to prevent UnicodeEncodeError

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -171,7 +171,7 @@ class APIClient(object):
         except ApiError as e:
             if _mute:
                 for error in e.args[0]['errors']:
-                    log.error(str(error))
+                    log.error(error)
                 if error_formatter is None:
                     return e.args[0]
                 else:


### PR DESCRIPTION
This PR removes a string conversion that causes https://github.com/DataDog/datadogpy/issues/223. It is reasonable to assume that the values of the `errors` Array are strings, so this conversion is unnecessary, and it causes a `UnicodeEncodeError` in Python 2 if the API response contains non-ASCII characters.

Tested with Python 2.7.15 and 3.7.2.