### PR TITLE
DD Initialize now can update the statsd object default namespace

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -16,7 +16,7 @@ import os.path
 from datadog import api
 from datadog.dogstatsd import DogStatsd, statsd  # noqa
 from datadog.threadstats import ThreadStats, datadog_lambda_wrapper, lambda_metric  # noqa
-from datadog.util.compat import iteritems, NullHandler
+from datadog.util.compat import iteritems, NullHandler, text
 from datadog.util.config import get_version
 from datadog.util.hostname import get_hostname
 
@@ -31,7 +31,7 @@ logging.getLogger('datadog.threadstats').addHandler(NullHandler())
 
 def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
                statsd_host=None, statsd_port=None, statsd_use_default_route=False,
-               statsd_socket_path=None, **kwargs):
+               statsd_socket_path=None, statsd_namespace=None, **kwargs):
     """
     Initialize and configure Datadog.api and Datadog.statsd modules
 
@@ -87,6 +87,8 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
             statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)
         if statsd_port:
             statsd.port = int(statsd_port)
+    if statsd_namespace:
+        statsd.namespace = text(statsd_namespace)
 
     # HTTP client and API options
     for key, value in iteritems(kwargs):

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -102,6 +102,13 @@ class TestDogStatsd(unittest.TestCase):
         t.assert_equal(statsd.host, "myhost")
         t.assert_equal(statsd.port, 1234)
 
+        # Add namespace
+        options['statsd_namespace'] = "mynamespace"
+        initialize(**options)
+        t.assert_equal(statsd.host, "myhost")
+        t.assert_equal(statsd.port, 1234)
+        t.assert_equal(statsd.namespace, "mynamespace")
+
         # Set `statsd` host to the system's default route
         initialize(statsd_use_default_route=True, **options)
         t.assert_equal(statsd.host, "172.17.0.1")


### PR DESCRIPTION
Added a new parameter to the Initialize method in order to update the statsd object default namespace.