### PR TITLE
add example of proxy config to docs

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -41,7 +41,7 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     :param app_key: Datadog application key
     :type app_key: string
 
-    :param proxies: Proxy to use to connect to Datadog API; \
+    :param proxies: Proxy to use to connect to Datadog API;
         for example, 'proxies': {'http': "http:<user>:<pass>@<ip>:<port>/"}
     :type proxies: dictionary mapping protocol to the URL of the proxy.
     :param api_host: Datadog API endpoint

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -41,9 +41,9 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     :param app_key: Datadog application key
     :type app_key: string
 
-    :param proxies: Proxy to use to connect to Datadog API
+    :param proxies: Proxy to use to connect to Datadog API; \
+        for example, 'proxies': {'http': "http:<user>:<pass>@<ip>:<port>/"}
     :type proxies: dictionary mapping protocol to the URL of the proxy.
-
     :param api_host: Datadog API endpoint
     :type api_host: url
 

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -42,7 +42,7 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     :type app_key: string
 
     :param proxies: Proxy to use to connect to Datadog API;
-        for example, 'proxies': {'http': "http:<user>:<pass>@<ip>:<port>/"}
+                    for example, 'proxies': {'http': "http:<user>:<pass>@<ip>:<port>/"}
     :type proxies: dictionary mapping protocol to the URL of the proxy.
     :param api_host: Datadog API endpoint
     :type api_host: url


### PR DESCRIPTION
Just adds a line to spell out how proxies should be configured. This was requested by a customer.