### PR TITLE
Lambda wrapper - Always flush, even on exceptions

### DIFF
--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -62,9 +62,10 @@ class _LambdaDecorator(object):
 
     def __call__(self, *args, **kw):
         _LambdaDecorator._enter()
-        result = self.func(*args, **kw)
-        _LambdaDecorator._close()
-        return result
+        try:
+            return self.func(*args, **kw)
+        finally:
+            _LambdaDecorator._close()
 
 
 _lambda_stats = ThreadStats()


### PR DESCRIPTION
Previously a final flush would not occur if an uncaught exception occurred in the function wrapped by the Lambda wrapper. Now we always flush, just like mommy taught us!