### PR TITLE
add env vars support for dogstatsd host, port and entity id

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -89,17 +89,21 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
         statsd.host = None
         statsd.port = None
     else:
-        # Check host and port env vars, override arguments if env vars exist
-        DD_AGENT_HOST = os.environ.get('DD_AGENT_HOST', '')
-        if DD_AGENT_HOST != '':
-            statsd_host = DD_AGENT_HOST
+        # If statsd_host argument is not set, try to get host from DD_AGENT_HOST env var
+        if statsd_host is None:
+            DD_AGENT_HOST = os.environ.get('DD_AGENT_HOST', '')
+            if DD_AGENT_HOST != '':
+                statsd_host = DD_AGENT_HOST
 
-        DD_DOGSTATSD_PORT = os.environ.get('DD_DOGSTATSD_PORT', '')
-        if DD_DOGSTATSD_PORT != '':
-            try:
-                statsd_port = int(DD_DOGSTATSD_PORT)
-            except ValueError:
-                pass
+        # If statsd_port argument is not set, try to get port from DD_DOGSTATSD_PORT env var
+        if statsd_port is None:
+            DD_DOGSTATSD_PORT = os.environ.get('DD_DOGSTATSD_PORT', '')
+            if DD_DOGSTATSD_PORT != '':
+                try:
+                    statsd_port = int(DD_DOGSTATSD_PORT)
+                except ValueError:
+                    pass
+        
         if statsd_host or statsd_use_default_route:
             statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)
         if statsd_port:

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -47,6 +47,12 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     :param api_host: Datadog API endpoint
     :type api_host: url
 
+    :envvar DD_AGENT_HOST: the host of the DogStatsd server.
+    :type DD_AGENT_HOST: string
+
+    :envvar DD_DOGSTATSD_PORT: the port of the DogStatsd server.
+    :type DD_DOGSTATSD_PORT: integer
+
     :param statsd_host: Host of DogStatsd server or statsd daemon
     :type statsd_host: address
 
@@ -83,6 +89,18 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
         statsd.host = None
         statsd.port = None
     else:
+        # Check host and port env vars, override arguments if env vars exist
+        DD_AGENT_HOST = os.environ.get('DD_AGENT_HOST', '')
+        if DD_AGENT_HOST != '':
+            statsd_host = DD_AGENT_HOST
+
+        DD_DOGSTATSD_PORT = os.environ.get('DD_DOGSTATSD_PORT', '')
+        if DD_DOGSTATSD_PORT != '':
+            try:
+                statsd_port = int(DD_DOGSTATSD_PORT)
+            except ValueError:
+                log.warning("Port number provided in DD_DOGSTATSD_PORT env var is not an integer: %s, using %s as port number", DD_DOGSTATSD_PORT, port)
+                pass
         if statsd_host or statsd_use_default_route:
             statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)
         if statsd_port:

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -47,12 +47,6 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     :param api_host: Datadog API endpoint
     :type api_host: url
 
-    :envvar DD_AGENT_HOST: the host of the DogStatsd server.
-    :type DD_AGENT_HOST: string
-
-    :envvar DD_DOGSTATSD_PORT: the port of the DogStatsd server.
-    :type DD_DOGSTATSD_PORT: integer
-
     :param statsd_host: Host of DogStatsd server or statsd daemon
     :type statsd_host: address
 
@@ -89,21 +83,6 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
         statsd.host = None
         statsd.port = None
     else:
-        # If statsd_host argument is not set, try to get host from DD_AGENT_HOST env var
-        if statsd_host is None:
-            DD_AGENT_HOST = os.environ.get('DD_AGENT_HOST', '')
-            if DD_AGENT_HOST != '':
-                statsd_host = DD_AGENT_HOST
-
-        # If statsd_port argument is not set, try to get port from DD_DOGSTATSD_PORT env var
-        if statsd_port is None:
-            DD_DOGSTATSD_PORT = os.environ.get('DD_DOGSTATSD_PORT', '')
-            if DD_DOGSTATSD_PORT != '':
-                try:
-                    statsd_port = int(DD_DOGSTATSD_PORT)
-                except ValueError:
-                    pass
-
         if statsd_host or statsd_use_default_route:
             statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)
         if statsd_port:

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -103,7 +103,7 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
                     statsd_port = int(DD_DOGSTATSD_PORT)
                 except ValueError:
                     pass
-        
+
         if statsd_host or statsd_use_default_route:
             statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)
         if statsd_port:

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -99,7 +99,6 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
             try:
                 statsd_port = int(DD_DOGSTATSD_PORT)
             except ValueError:
-                log.warning("Port number provided in DD_DOGSTATSD_PORT env var is not an integer: %s, using %s as port number", DD_DOGSTATSD_PORT, port)
                 pass
         if statsd_host or statsd_use_default_route:
             statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -30,19 +30,17 @@ class DogStatsd(object):
         >>> statsd = DogStatsd()
 
         :envvar DD_AGENT_HOST: the host of the DogStatsd server.
+        If set, it overrides default value.
         :type DD_AGENT_HOST: string
 
         :envvar DD_DOGSTATSD_PORT: the port of the DogStatsd server.
+        If set, it overrides default value.
         :type DD_DOGSTATSD_PORT: integer
 
-        :param host: the host of the DogStatsd server. If the environment variable
-        "DD_AGENT_HOST" is set, this parameter is overwritten by the environment
-        variable value
+        :param host: the host of the DogStatsd server.
         :type host: string
 
-        :param port: the port of the DogStatsd server. If the environment variable
-        "DD_DOGSTATSD_PORT" is set, this parameter is overwritten by the environment
-        variable value.
+        :param port: the port of the DogStatsd server.
         :type port: integer
 
         :param max_buffer_size: Maximum number of metrics to buffer before sending to the server
@@ -77,15 +75,16 @@ class DogStatsd(object):
 
         # Check host and port env vars
         DD_AGENT_HOST = os.environ.get('DD_AGENT_HOST', '')
-        if DD_AGENT_HOST != '':
+        if DD_AGENT_HOST != '' and host == 'localhost':
             host = DD_AGENT_HOST
 
         DD_DOGSTATSD_PORT = os.environ.get('DD_DOGSTATSD_PORT', '')
-        if DD_DOGSTATSD_PORT != '':
+        if DD_DOGSTATSD_PORT != '' and port == 8125:
             try:
                 port = int(DD_DOGSTATSD_PORT)
             except ValueError:
-                log.warning("Port number provided in DD_DOGSTATSD_PORT env var is not an integer: %s, using %s as port number", DD_DOGSTATSD_PORT, port)
+                log.warning("Port number provided in DD_DOGSTATSD_PORT env var is not an integer: \
+                %s, using %s as port number", DD_DOGSTATSD_PORT, port)
                 pass
 
         # Connection

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -97,6 +97,15 @@ class TestDogStatsd(unittest.TestCase):
         t.assert_equal(statsd.host, "localhost")
         t.assert_equal(statsd.port, 8125)
 
+        # Set `statsd` host and port using env vars
+        with preserve_environment_variable('DD_AGENT_HOST'):
+            os.environ['DD_AGENT_HOST'] = 'myenvvarhost'
+            with preserve_environment_variable('DD_DOGSTATSD_PORT'):
+                os.environ['DD_DOGSTATSD_PORT'] = '4321'
+                initialize()
+        t.assert_equal(statsd.host, "myenvvarhost")
+        t.assert_equal(statsd.port, 4321)
+
         # After initialization
         initialize(**options)
         t.assert_equal(statsd.host, "myhost")
@@ -106,15 +115,6 @@ class TestDogStatsd(unittest.TestCase):
         initialize(statsd_use_default_route=True, **options)
         t.assert_equal(statsd.host, "172.17.0.1")
         t.assert_equal(statsd.port, 1234)
-
-        # Set `statsd` host and port using env vars
-        with preserve_environment_variable('DD_AGENT_HOST'):
-            os.environ['DD_AGENT_HOST'] = 'myenvvarhost'
-            with preserve_environment_variable('DD_DOGSTATSD_PORT'):
-                os.environ['DD_DOGSTATSD_PORT'] = '4321'
-                initialize(**options)
-        t.assert_equal(statsd.host, "myenvvarhost")
-        t.assert_equal(statsd.port, 4321)
 
         # Add UNIX socket
         options['statsd_socket_path'] = '/var/run/dogstatsd.sock'

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -97,15 +97,6 @@ class TestDogStatsd(unittest.TestCase):
         t.assert_equal(statsd.host, "localhost")
         t.assert_equal(statsd.port, 8125)
 
-        # Set `statsd` host and port using env vars
-        with preserve_environment_variable('DD_AGENT_HOST'):
-            os.environ['DD_AGENT_HOST'] = 'myenvvarhost'
-            with preserve_environment_variable('DD_DOGSTATSD_PORT'):
-                os.environ['DD_DOGSTATSD_PORT'] = '4321'
-                initialize()
-        t.assert_equal(statsd.host, "myenvvarhost")
-        t.assert_equal(statsd.port, 4321)
-
         # After initialization
         initialize(**options)
         t.assert_equal(statsd.host, "myhost")
@@ -122,6 +113,22 @@ class TestDogStatsd(unittest.TestCase):
         t.assert_equal(statsd.socket_path, options['statsd_socket_path'])
         t.assert_equal(statsd.host, None)
         t.assert_equal(statsd.port, None)
+    
+    def test_dogstatsd_initialization_with_env_vars(self):
+        """
+        Dogstatsd can retrieve its config from env vars when
+        not provided in constructor.
+        """
+        # Setup
+        with preserve_environment_variable('DD_AGENT_HOST'):
+            os.environ['DD_AGENT_HOST'] = 'myenvvarhost'
+            with preserve_environment_variable('DD_DOGSTATSD_PORT'):
+                os.environ['DD_DOGSTATSD_PORT'] = '4321'
+                statsd = DogStatsd()
+
+        # Assert
+        t.assert_equal(statsd.host, "myenvvarhost")
+        t.assert_equal(statsd.port, 4321)
 
     def test_default_route(self):
         """


### PR DESCRIPTION
Add environment variables support for Client configuration

Support of 3 environment variables for Client configuration:

`"DD_AGENT_HOST"` used to provide the Agent hostname.
`"DD_DOGSTATSD_PORT"` used to provide the DogStatsD port.
`"DD_ENTITY_ID"` used to provide an identifier to the Client.


If Client constructor's arguments are not set, prioritize `"DD_AGENT_HOST"` and `"DD_DOGSTATSD_PORT"` over default values.
Add `"DD_ENTITY_ID"` to tags with the tag name `dd.internal.entity_id`.