### PR TITLE
No annoying hostname output

### DIFF
--- a/datadog/util/hostname.py
+++ b/datadog/util/hostname.py
@@ -70,7 +70,7 @@ def get_hostname():
         def _get_hostname_unix():
             try:
                 # try fqdn
-                p = subprocess.Popen(['/bin/hostname', '-f'], stdout=subprocess.PIPE)
+                p = subprocess.Popen(['/bin/hostname', '-f'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
                 out, err = p.communicate()
                 if p.returncode == 0:
                     if is_p3k():


### PR DESCRIPTION
This fixes an issue we're seeing in ECS, where every time a new container starts, we get something like this printed to stderr:

> hostname: 91d9cd0c1b70: Host not found

Since Datadog's log UI treats everything on stderr as ERROR level by default, that means we get output like this (for a job that runs every minute):

![Screenshot from 2019-04-08 13-06-12](https://user-images.githubusercontent.com/1447206/55742964-1aa40480-59ff-11e9-8b3c-63221f22722e.png)

I have no idea _why_ `hostname` is printing this error, but I can confirm that this change fixes it.