### PR TITLE
[Dogwrap] Ignore decode errors

### DIFF
--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -66,7 +66,7 @@ class OutputReader(threading.Thread):
         for line in iter(self._out.readline, b''):
             if self._fwd_out is not None:
                 fwd_out_encoding = self._fwd_out.encoding or 'UTF-8'
-                self._fwd_out.write(line.decode(fwd_out_encoding))
+                self._fwd_out.write(line.decode(fwd_out_encoding, 'ignore'))
             line = line.decode('utf-8')
             self._out_content += line
         self._out.close()


### PR DESCRIPTION
Ignore any decoding errors incurred when the process being run emits content that isn't decode-able by the filesystem's locale. 

Python docs describing the change being made - https://docs.python.org/3/library/stdtypes.html#bytes.decode

Resolves https://github.com/DataDog/datadogpy/issues/371

