### PR TITLE
Add DD_ prefix from Datadog APM with instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ stats.increment('home.page.hits')
 
 ```
 
+Environment Variables
+---------------------
+
+As an alternate method to using the `initialize` function with the `options` parameters, set the environment variables `DATADOG_API_KEY`, and `DATADOG_APP_KEY` within the context of your application.
+
+If `DATADOG_API_KEY` or `DATADOG_APP_KEY` are not set, the library will attempt to fall back to Datadog's APM environmnent variable prefixes: `DD_API_KEY` and `DD_APP_KEY`.
+
+```python
+from datadog import initialize, api
+
+# Assuming you've set `DD_API_KEY` and `DD_APP_KEY` in your env,
+# initialize() will pick it up automatically
+initialize()
+
+title = "Something big happened!"
+text = 'And let me tell you all about it here!'
+tags = ['version:1', 'application:web']
+
+api.Event.create(title=title, text=text, tags=tags)
+```
+
 Thread Safety
 -------------
 `DogStatsD` and `ThreadStats` are thread-safe.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ stats.increment('home.page.hits')
 Environment Variables
 ---------------------
 
-As an alternate method to using the `initialize` function with the `options` parameters, set the environment variables `DATADOG_API_KEY`, and `DATADOG_APP_KEY` within the context of your application.
+As an alternate method to using the `initialize` function with the `options` parameters, set the environment variables `DATADOG_API_KEY` and `DATADOG_APP_KEY` within the context of your application.
 
 If `DATADOG_API_KEY` or `DATADOG_APP_KEY` are not set, the library will attempt to fall back to Datadog's APM environmnent variable prefixes: `DD_API_KEY` and `DD_APP_KEY`.
 

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -79,7 +79,6 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     api._host_name = host_name or api._host_name or get_hostname()
     api._api_host = api_host or api._api_host or os.environ.get('DATADOG_HOST', 'https://api.datadoghq.com')
 
-
     # Statsd configuration
     # ...overrides the default `statsd` instance attributes
     if statsd_socket_path:

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -70,10 +70,15 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     :type mute: boolean
     """
     # API configuration
-    api._api_key = api_key or api._api_key or os.environ.get('DATADOG_API_KEY')
-    api._application_key = app_key or api._application_key or os.environ.get('DATADOG_APP_KEY')
+    api._api_key = api_key or api._api_key or os.environ.get('DATADOG_API_KEY', os.environ.get('DD_API_KEY'))
+    api._application_key = (
+        app_key or
+        api._application_key or
+        os.environ.get('DATADOG_APP_KEY', os.environ.get('DD_APP_KEY'))
+    )
     api._host_name = host_name or api._host_name or get_hostname()
     api._api_host = api_host or api._api_host or os.environ.get('DATADOG_HOST', 'https://api.datadoghq.com')
+
 
     # Statsd configuration
     # ...overrides the default `statsd` instance attributes

--- a/datadog/dogshell/__init__.py
+++ b/datadog/dogshell/__init__.py
@@ -29,13 +29,13 @@ def main():
     parser.add_argument('--config', help="location of your dogrc file (default ~/.dogrc)",
                         default=os.path.expanduser('~/.dogrc'))
     parser.add_argument('--api-key', help="your API key, from "
-                        "https://app.datadoghq.com/account/settings#api "
-                        "You can also set the environment variable DATADOG_API_KEY",
-                        dest='api_key', default=os.environ.get('DATADOG_API_KEY'))
+                        "https://app.datadoghq.com/account/settings#api. "
+                        "You can also set the environment variables DATADOG_API_KEY or DD_API_KEY",
+                        dest='api_key', default=os.environ.get('DATADOG_API_KEY', os.environ.get('DD_API_KEY')))
     parser.add_argument('--application-key', help="your Application key, from "
-                        "https://app.datadoghq.com/account/settings#api "
-                        "You can also set the environment variable DATADOG_APP_KEY",
-                        dest='app_key', default=os.environ.get('DATADOG_APP_KEY'))
+                        "https://app.datadoghq.com/account/settings#api. "
+                        "You can also set the environment variables DATADOG_APP_KEY or DD_APP_KEY",
+                        dest='app_key', default=os.environ.get('DATADOG_APP_KEY', os.environ.get('DD_APP_KEY')))
     parser.add_argument('--pretty', help="pretty-print output (suitable for human consumption, "
                         "less useful for scripting)", dest='format',
                         action='store_const', const='pretty')

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -32,7 +32,8 @@ class _LambdaDecorator(object):
         with cls._counter_lock:
             if not cls._was_initialized:
                 cls._was_initialized = True
-                api._api_key = os.environ.get('DATADOG_API_KEY')
+                # DD_ is consistent with APM configuration, fall back to it
+                api._api_key = os.environ.get('DATADOG_API_KEY', os.environ.get('DD_API_KEY'))
                 api._api_host = os.environ.get('DATADOG_HOST', 'https://api.datadoghq.com')
 
                 # Async initialization of the TLS connection with our endpoints

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -32,7 +32,6 @@ class _LambdaDecorator(object):
         with cls._counter_lock:
             if not cls._was_initialized:
                 cls._was_initialized = True
-                # DD_ is consistent with APM configuration, fall back to it
                 api._api_key = os.environ.get('DATADOG_API_KEY', os.environ.get('DD_API_KEY'))
                 api._api_host = os.environ.get('DATADOG_HOST', 'https://api.datadoghq.com')
 

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -152,6 +152,16 @@ class TestInitialization(DatadogAPINoInitialization):
         del os.environ["DATADOG_APP_KEY"]
         del os.environ["DATADOG_HOST"]
 
+        os.environ["DD_API_KEY"] = "API_KEY_ENV_DD"
+        os.environ["DD_APP_KEY"] = "APP_KEY_ENV_DD"
+        api._api_key = None
+        api._application_key = None
+
+        initialize()
+
+        self.assertEqual(api._api_key, "API_KEY_ENV_DD")
+        self.assertEqual(api._application_key, "APP_KEY_ENV_DD")
+
     def test_function_param_value(self):
         initialize(api_key="API_KEY", app_key="APP_KEY", api_host="HOST", host_name="HOSTNAME")
 


### PR DESCRIPTION
Adds a check for the `DD_` prefix to environment variables we have in [Datadog APM](https://docs.datadoghq.com/agent/docker/apm/?tab=java#docker-apm-agent-environment-variables).

Also adds an explanation with an example of how to use environment variables in `datadogpy` to README.

