### PR TITLE
origin detection documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,15 @@ Thread Safety
 
 Origin detection over UDP
 -------------
-Origin detection is a method to detect which pod DogStatsD packets are coming from in order to add the pod's tags to the tag list.
+Origin detection is a method to detect which pod `DogStatsD` packets are coming from in order to add the pod's tags to the tag list.
+The `DogStatsD` client attaches an internal tag, `entity_id`. The value of this tag is the content of the `DD_ENTITY_ID` environment variable if found, which is the pod’s UID.
+This tag will be used by the Datadog Agent to insert container tags to the metrics. You should only `append` to the `constant_tags` list to avoid overwriting this global tag.
 
 To enable origin detection over UDP, add the following lines to your application manifest
-```
+```yaml
 env:
   - name: DD_ENTITY_ID
     valueFrom:
       fieldRef:
         fieldPath: metadata.uid
 ```
-The DogStatsD client attaches an internal tag, `entity_id`. The value of this tag is the content of the `DD_ENTITY_ID` environment variable, which is the pod’s UID.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,17 @@ stats.increment('home.page.hits')
 Thread Safety
 -------------
 `DogStatsD` and `ThreadStats` are thread-safe.
+
+Origin detection over UDP
+-------------
+Origin detection is a method to detect which pod DogStatsD packets are coming from in order to add the pod's tags to the tag list.
+
+To enable origin detection over UDP, add the following lines to your application manifest
+```
+env:
+  - name: DD_ENTITY_ID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.uid
+```
+The DogStatsD client attaches an internal tag, `entity_id`. The value of this tag is the content of the `DD_ENTITY_ID` environment variable, which is the pod’s UID.


### PR DESCRIPTION
Document the origin detection feature introduced by https://github.com/DataDog/datadogpy/pull/363 with an example of how to set up the `DD_ENTITY_ID` env var.