### PR TITLE
Better string handling for dogwrap

### DIFF
--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -65,8 +65,7 @@ class OutputReader(threading.Thread):
         '''
         for line in iter(self._out.readline, b''):
             if self._fwd_out is not None:
-                fwd_out_encoding = self._fwd_out.encoding or 'UTF-8'
-                self._fwd_out.write(line.decode(fwd_out_encoding, 'ignore'))
+                self._fwd_out.write(line)
             line = line.decode('utf-8')
             self._out_content += line
         self._out.close()

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -54,7 +54,7 @@ class OutputReader(threading.Thread):
         '''
         threading.Thread.__init__(self)
         self.daemon = True
-        self._out_content = u""
+        self._out_content = ""
         self._out = proc_out
         self._fwd_out = fwd_out
 
@@ -66,7 +66,6 @@ class OutputReader(threading.Thread):
         for line in iter(self._out.readline, b''):
             if self._fwd_out is not None:
                 self._fwd_out.write(line)
-            line = line.decode('utf-8')
             self._out_content += line
         self._out.close()
 
@@ -188,17 +187,17 @@ def build_event_body(cmd, returncode, stdout, stderr, notifications):
 
     if stdout:
         fmt_stdout = u"**>>>> STDOUT <<<<**\n```\n{stdout} \n```\n".format(
-            stdout=trim_text(stdout, max_length)
+            stdout=trim_text(stdout.decode("utf-8", "replace"), max_length)
         )
 
     if stderr:
         fmt_stderr = u"**>>>> STDERR <<<<**\n```\n{stderr} \n```\n".format(
-            stderr=trim_text(stderr, max_length)
+            stderr=trim_text(stderr.decode("utf-8", "replace"), max_length)
         )
 
     if notifications:
         fmt_notifications = u"**>>>> NOTIFICATIONS <<<<**\n\n {notifications}\n".format(
-            notifications=notifications
+            notifications=notifications.decode("utf-8", "replace")
         )
 
     return \

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -18,6 +18,7 @@ dogwrap -n test-job -k $API_KEY --timeout=1 "sleep 3"
 
 '''
 # stdlib
+from __future__ import print_function
 import optparse
 import subprocess
 import sys
@@ -54,7 +55,7 @@ class OutputReader(threading.Thread):
         '''
         threading.Thread.__init__(self)
         self.daemon = True
-        self._out_content = ""
+        self._out_content = b""
         self._out = proc_out
         self._fwd_out = fwd_out
 
@@ -105,7 +106,7 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout,
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE, shell=True)
     except Exception:
-        print >> sys.stderr, u"Failed to execute %s" % (repr(cmd))
+        print(u"Failed to execute %s" % (repr(cmd)), file=sys.stderr)
         raise
     try:
         # Let's that the threads collecting the output from the command in the
@@ -133,12 +134,12 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout,
             proc.terminate()
             sigterm_start = time.time()
             try:
-                print >> sys.stderr, "Command timed out after %.2fs, killing with SIGTERM" \
+                print("Command timed out after %.2fs, killing with SIGTERM", file=sys.stderr) \
                     % (time.time() - start_time)
                 poll_proc(proc, proc_poll_interval, sigterm_timeout)
                 returncode = Timeout
             except Timeout:
-                print >> sys.stderr, "SIGTERM timeout failed after %.2fs, killing with SIGKILL" \
+                print("SIGTERM timeout failed after %.2fs, killing with SIGKILL", file=sys.stderr) \
                     % (time.time() - sigterm_start)
                 proc.kill()
                 poll_proc(proc, proc_poll_interval, sigkill_timeout)
@@ -261,7 +262,7 @@ returned (the command outputs remains buffered in dogwrap meanwhile)")
 
     options, args = parser.parse_args()
 
-    cmd = " ".join(args).decode("utf-8")
+    cmd = b" ".join(args).decode("utf-8")
     # If silent is checked we force the outputs to be buffered (and therefore
     # not forwarded to the Terminal streams) and we just avoid printing the
     # buffers at the end
@@ -310,8 +311,8 @@ returned (the command outputs remains buffered in dogwrap meanwhile)")
     }
 
     if options.buffer_outs:
-        print >> sys.stderr, stderr.strip()
-        print >> sys.stdout, stdout.strip()
+        print(stderr.strip(), file=sys.stderr)
+        print(stdout.strip(), file=sys.stdout)
 
     if options.submit_mode == 'all' or returncode != 0:
         api.Event.create(title=event_title, text=event_body, **event)

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -104,7 +104,7 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout,
     stdout = ''
     stderr = ''
     try:
-        proc = subprocess.Popen(u' '.join(cmd), stdout=subprocess.PIPE,
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE, shell=True)
     except Exception:
         print >> sys.stderr, u"Failed to execute %s" % (repr(cmd))
@@ -210,7 +210,7 @@ def build_event_body(cmd, returncode, stdout, stderr, notifications):
         u"{stderr}" \
         u"{notifications}" \
         u"%%%\n".format(
-            command=u" ".join(cmd),
+            command=cmd,
             returncode=returncode,
             stdout=fmt_stdout,
             stderr=fmt_stderr,
@@ -263,9 +263,7 @@ returned (the command outputs remains buffered in dogwrap meanwhile)")
 
     options, args = parser.parse_args()
 
-    cmd = []
-    for part in args:
-        cmd.extend(part.split(' '))
+    cmd = " ".join(args).decode("utf-8")
     # If silent is checked we force the outputs to be buffered (and therefore
     # not forwarded to the Terminal streams) and we just avoid printing the
     # buffers at the end

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -100,11 +100,10 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout,
     '''
     start_time = time.time()
     returncode = -1
-    stdout = ''
-    stderr = ''
+    stdout = b''
+    stderr = b''
     try:
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE, shell=True)
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     except Exception:
         print(u"Failed to execute %s" % (repr(cmd)), file=sys.stderr)
         raise

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -310,8 +310,8 @@ returned (the command outputs remains buffered in dogwrap meanwhile)")
     }
 
     if options.buffer_outs:
-        print >> sys.stderr, stderr.strip().encode('utf8')
-        print >> sys.stdout, stdout.strip().encode('utf8')
+        print >> sys.stderr, stderr.strip()
+        print >> sys.stdout, stdout.strip()
 
     if options.submit_mode == 'all' or returncode != 0:
         api.Event.create(title=event_title, text=event_body, **event)

--- a/tests/unit/dogwrap/fixtures/proc_out.txt
+++ b/tests/unit/dogwrap/fixtures/proc_out.txt
@@ -1,0 +1,5 @@
+Starting Unicode Test
+From ruby: Michélle
+From ruby: helløøééé
+ Ið pri qūāeqūe periculīs sælutǽtus
+Completed DD Unicode Test

--- a/tests/unit/dogwrap/test_dogwrap.py
+++ b/tests/unit/dogwrap/test_dogwrap.py
@@ -1,0 +1,42 @@
+# coding: utf8
+
+import unittest
+import os
+import tempfile
+
+from datadog.dogshell.wrap import OutputReader, build_event_body
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestDogwrap(unittest.TestCase):
+    def test_output_reader(self):
+        with open(os.path.join(HERE, "fixtures", "proc_out.txt"), 'rb') as cmd_out:
+            content = cmd_out.read()
+
+        with tempfile.TemporaryFile() as fwd_out:
+            reader = OutputReader(open(os.path.join(HERE, "fixtures", "proc_out.txt"), 'rb'), fwd_out)
+            reader.start()
+            reader.join()
+            self.assertIsInstance(reader.content, bytes)
+            self.assertEqual(reader.content, content)
+            fwd_out.seek(0, 0)
+            self.assertEqual(reader.content, fwd_out.read())
+
+    def test_build_event_body(self):
+        # Only cmd is already unicode, the rest is decoded in the function
+        cmd = u"yö dudes"
+        returncode = 0
+        stdout = "sùp\xaa"
+        stderr = "dàwg\xaa"
+        notifications = "@mé\xaa"
+        expected_body = u"%%%\n" \
+            u"**>>>> CMD <<<<**\n```\nyö dudes \n```\n" \
+            u"**>>>> EXIT CODE <<<<**\n\n 0\n\n\n" \
+            u"**>>>> STDOUT <<<<**\n```\nsùp\ufffd \n```\n" \
+            u"**>>>> STDERR <<<<**\n```\ndàwg\ufffd \n```\n" \
+            u"**>>>> NOTIFICATIONS <<<<**\n\n @mé\ufffd\n" \
+            u"%%%\n"
+
+        event_body = build_event_body(cmd, returncode, stdout, stderr, notifications)
+        self.assertEqual(expected_body, event_body)

--- a/tests/unit/dogwrap/test_dogwrap.py
+++ b/tests/unit/dogwrap/test_dogwrap.py
@@ -27,9 +27,9 @@ class TestDogwrap(unittest.TestCase):
         # Only cmd is already unicode, the rest is decoded in the function
         cmd = u"yö dudes"
         returncode = 0
-        stdout = "sùp\xaa"
-        stderr = "dàwg\xaa"
-        notifications = "@mé\xaa"
+        stdout = b"s\xc3\xb9p\xaa"
+        stderr = b"d\xc3\xa0wg\xaa"
+        notifications = b"@m\xc3\xa9\xaa"
         expected_body = u"%%%\n" \
             u"**>>>> CMD <<<<**\n```\nyö dudes \n```\n" \
             u"**>>>> EXIT CODE <<<<**\n\n 0\n\n\n" \


### PR DESCRIPTION
- Arguments are bytes, so the join must be made on a binary string, otherwise python will try to convert and can encounter errors.
- Stop decoding lines before writing to stdout, since `write` expects bytes.
- Move decoding the output to the end of the execution, to make sure we won't raise exceptions while command is still running, which can cause unexpected behavior, like in issue #371 .

Resolves #371, closes #223 