### PR TITLE
adding Hosts endpoint to docs

### DIFF
--- a/datadog/api/infrastructure.py
+++ b/datadog/api/infrastructure.py
@@ -12,7 +12,7 @@ class Infrastructure(SearchableAPIResource):
         """
         Search for entities in Datadog.
 
-        :param q: a query to serch for host and metrics
+        :param q: a query to search for host and metrics
         :type q: string query
 
         :returns: Dictionary representing the API's JSON response

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -44,6 +44,10 @@ Datadog.api client requires to run :mod:`datadog` `initialize` method first.
     :members:
     :inherited-members:
 
+.. autoclass:: datadog.api.Hosts
+    :members:
+    :inherited-members:
+
 .. autoclass:: datadog.api.Infrastructure
     :members:
     :inherited-members:


### PR DESCRIPTION
Adds `Hosts` to `index.rst` so that we can get documentation of `Hosts.search()`, which is the preferred method over the sort-of-deprecated `Infrastructure.search(q="hosts:")` method. Also fixes a spelling error in `Infrastructure`.