### PR TITLE
Add ability to not attach_host_name to metrics, events and distributions

### DIFF
--- a/datadog/api/distributions.py
+++ b/datadog/api/distributions.py
@@ -8,7 +8,7 @@ class Distribution(SendableAPIResource):
     _resource_name = 'distribution_points'
 
     @classmethod
-    def send(cls, distributions=None, **distribution):
+    def send(cls, distributions=None, attach_host_name=True, **distribution):
         """
         Submit a distribution metric or a list of distribution metrics to the distribution metric
         API
@@ -33,4 +33,4 @@ class Distribution(SendableAPIResource):
             # One distribution is sent
             distribution['points'] = format_points(distribution['points'])
             series_dict = {"series": [distribution]}
-        return super(Distribution, cls).send(attach_host_name=True, **series_dict)
+        return super(Distribution, cls).send(attach_host_name=attach_host_name, **series_dict)

--- a/datadog/api/events.py
+++ b/datadog/api/events.py
@@ -11,7 +11,7 @@ class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource, De
     _timestamp_keys = set(['start', 'end'])
 
     @classmethod
-    def create(cls, **params):
+    def create(cls, attach_host_name=True, **params):
         """
         Post an event.
 
@@ -58,7 +58,7 @@ class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource, De
 
         >>> api.Event.create(title=title, text=text, tags=tags)
         """
-        return super(Event, cls).create(attach_host_name=True, **params)
+        return super(Event, cls).create(attach_host_name=attach_host_name, **params)
 
     @classmethod
     def query(cls, **params):

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -47,7 +47,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
             metric['type'] = metric.pop('metric_type')
 
     @classmethod
-    def send(cls, metrics=None, **single_metric):
+    def send(cls, metrics=None, attach_host_name=True, **single_metric):
         """
         Submit a metric or a list of metrics to the metric API
 
@@ -88,7 +88,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
         except KeyError:
             raise KeyError("'points' parameter is required")
 
-        return super(Metric, cls).send(attach_host_name=True, **metrics_dict)
+        return super(Metric, cls).send(attach_host_name=attach_host_name, **metrics_dict)
 
     @classmethod
     def query(cls, **params):

--- a/tests/unit/api/helper.py
+++ b/tests/unit/api/helper.py
@@ -3,7 +3,7 @@ import unittest
 import json
 
 # 3p
-from mock import patch, Mock
+from mock import Mock
 import requests
 
 # datadog
@@ -85,21 +85,26 @@ class MyListable(ListableAPIResource):
 class MyDeletable(DeletableAPIResource):
     _resource_name = 'deletables'
 
+
 class MyListableSubResource(ListableAPISubResource):
     _resource_name = 'resource_name'
     _sub_resource_name = 'sub_resource_name'
+
 
 class MyAddableSubResource(AddableAPISubResource):
     _resource_name = 'resource_name'
     _sub_resource_name = 'sub_resource_name'
 
+
 class MyUpdatableSubResource(UpdatableAPISubResource):
     _resource_name = 'resource_name'
     _sub_resource_name = 'sub_resource_name'
 
+
 class MyDeletableSubResource(DeletableAPISubResource):
     _resource_name = 'resource_name'
     _sub_resource_name = 'sub_resource_name'
+
 
 class MyActionable(ActionAPIResource):
     _resource_name = 'actionables'

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -73,7 +73,7 @@ class TestInitialization(DatadogAPINoInitialization):
         # Finally, initialize with an API key
         initialize(api_key=API_KEY, api_host=API_HOST)
         MyCreatable.create()
-        self.assertEquals(self.request_mock.call_count(), 1)
+        self.assertEqual(self.request_mock.call_count(), 1)
 
     @mock.patch('datadog.util.config.get_config_path')
     def test_get_hostname(self, mock_config_path):
@@ -93,7 +93,7 @@ class TestInitialization(DatadogAPINoInitialization):
         mock_config_path.return_value = tmpfilepath
 
         initialize()
-        self.assertEquals(api._host_name, HOST_NAME, api._host_name)
+        self.assertEqual(api._host_name, HOST_NAME, api._host_name)
 
     def test_request_parameters(self):
         """
@@ -111,12 +111,12 @@ class TestInitialization(DatadogAPINoInitialization):
         self.assertIn('params', options)
 
         self.assertIn('api_key', options['params'])
-        self.assertEquals(options['params']['api_key'], API_KEY)
+        self.assertEqual(options['params']['api_key'], API_KEY)
         self.assertIn('application_key', options['params'])
-        self.assertEquals(options['params']['application_key'], APP_KEY)
+        self.assertEqual(options['params']['application_key'], APP_KEY)
 
         self.assertIn('headers', options)
-        self.assertEquals(options['headers'], {'Content-Type': 'application/json'})
+        self.assertEqual(options['headers'], {'Content-Type': 'application/json'})
 
     def test_initialize_options(self):
         """
@@ -132,10 +132,10 @@ class TestInitialization(DatadogAPINoInitialization):
 
         # Assert `requests` parameters
         self.assertIn('proxies', options)
-        self.assertEquals(options['proxies'], FAKE_PROXY)
+        self.assertEqual(options['proxies'], FAKE_PROXY)
 
         self.assertIn('verify', options)
-        self.assertEquals(options['verify'], False)
+        self.assertEqual(options['verify'], False)
 
         # Arm the `requests` to raise
         self.arm_requests_to_raise()
@@ -159,7 +159,7 @@ class TestInitialization(DatadogAPINoInitialization):
             """
             os.environ[env_name] = env_value
             initialize()
-            self.assertEquals(getattr(api, attr_name), env_value)
+            self.assertEqual(getattr(api, attr_name), env_value)
 
         @preserve_environ_datadog
         def test_api_params_default(env_name, attr_name, expected_value):
@@ -170,10 +170,10 @@ class TestInitialization(DatadogAPINoInitialization):
             if os.environ.get(env_name):
                 del os.environ[env_name]
             initialize()
-            self.assertEquals(getattr(api, attr_name), expected_value)
+            self.assertEqual(getattr(api, attr_name), expected_value)
 
         @preserve_environ_datadog
-        def test_api_params_from_params(env_name, parameter, attr_name, value ):
+        def test_api_params_from_params(env_name, parameter, attr_name, value):
             """
             Unset env_name environment variable
             Initialize API with parameter=value
@@ -182,7 +182,7 @@ class TestInitialization(DatadogAPINoInitialization):
             if os.environ.get(env_name):
                 del os.environ[env_name]
             initialize(api_host='http://localhost')
-            self.assertEquals(api._api_host, 'http://localhost')
+            self.assertEqual(api._api_host, 'http://localhost')
 
         # Default values
         test_api_params_default("DATADOG_API_KEY", "_api_key", None)
@@ -360,63 +360,70 @@ class TestResources(DatadogAPIWithInitialization):
 
 class TestMetricResource(DatadogAPIWithInitialization):
 
-    def submit_and_assess_metric_payload(self, serie):
+    def submit_and_assess_metric_payload(self, serie, attach_host_name=True):
         """
         Helper to assess the metric payload format.
         """
         now = time()
 
         if isinstance(serie, dict):
-            Metric.send(**deepcopy(serie))
+            Metric.send(attach_host_name=attach_host_name, **deepcopy(serie))
             serie = [serie]
         else:
-            Metric.send(deepcopy(serie))
+            Metric.send(deepcopy(serie), attach_host_name=attach_host_name)
 
         payload = self.get_request_data()
 
         for i, metric in enumerate(payload['series']):
-            self.assertEquals(set(metric.keys()), set(['metric', 'points', 'host']))
+            if attach_host_name:
+                self.assertEqual(set(metric.keys()), set(['metric', 'points', 'host']))
+                self.assertEqual(metric['host'], api._host_name)
+            else:
+                self.assertEqual(set(metric.keys()), set(['metric', 'points']))
 
-            self.assertEquals(metric['metric'], serie[i]['metric'])
-            self.assertEquals(metric['host'], api._host_name)
+            self.assertEqual(metric['metric'], serie[i]['metric'])
 
             # points is a list of 1 point
             self.assertTrue(isinstance(metric['points'], list))
-            self.assertEquals(len(metric['points']), 1)
+            self.assertEqual(len(metric['points']), 1)
             # it consists of a [time, value] pair
-            self.assertEquals(len(metric['points'][0]), 2)
+            self.assertEqual(len(metric['points'][0]), 2)
             # its value == value we sent
-            self.assertEquals(metric['points'][0][1], float(serie[i]['points']))
+            self.assertEqual(metric['points'][0][1], float(serie[i]['points']))
             # it's time not so far from current time
             assert now - 1 < metric['points'][0][0] < now + 1
 
-    def submit_and_assess_dist_payload(self, serie):
+    def submit_and_assess_dist_payload(self, serie, attach_host_name=True):
         """
         Helper to assess the metric payload format.
         """
         now = time()
 
         if isinstance(serie, dict):
-            Distribution.send(**deepcopy(serie))
+            Distribution.send(attach_host_name=attach_host_name, **deepcopy(serie))
             serie = [serie]
         else:
-            Distribution.send(deepcopy(serie))
+            Distribution.send(deepcopy(serie), attach_host_name=attach_host_name)
 
         payload = self.get_request_data()
+        print payload
 
         for i, metric in enumerate(payload['series']):
-            self.assertEquals(set(metric.keys()), set(['metric', 'points', 'host']))
+            if attach_host_name:
+                self.assertEqual(set(metric.keys()), set(['metric', 'points', 'host']))
+                self.assertEqual(metric['host'], api._host_name)
+            else:
+                self.assertEqual(set(metric.keys()), set(['metric', 'points']))
 
-            self.assertEquals(metric['metric'], serie[i]['metric'])
-            self.assertEquals(metric['host'], api._host_name)
+            self.assertEqual(metric['metric'], serie[i]['metric'])
 
             # points is a list of 1 point
             self.assertTrue(isinstance(metric['points'], list))
-            self.assertEquals(len(metric['points']), 1)
+            self.assertEqual(len(metric['points']), 1)
             # it consists of a [time, value] pair
-            self.assertEquals(len(metric['points'][0]), 2)
+            self.assertEqual(len(metric['points'][0]), 2)
             # its value == value we sent
-            self.assertEquals(metric['points'][0][1], serie[i]['points'][0][1])
+            self.assertEqual(metric['points'][0][1], serie[i]['points'][0][1])
             # it's time not so far from current time
             assert now - 1 < metric['points'][0][0] < now + 1
 
@@ -445,6 +452,15 @@ class TestMetricResource(DatadogAPIWithInitialization):
                  dict(metric='metric.2', points=19)]
         self.submit_and_assess_metric_payload(serie)
 
+        # Single point no hostname
+        serie = dict(metric='metric.1', points=13)
+        self.submit_and_assess_metric_payload(serie, attach_host_name=False)
+
+        # Multiple point no hostname
+        serie = [dict(metric='metric.1', points=13),
+                 dict(metric='metric.2', points=19)]
+        self.submit_and_assess_metric_payload(serie, attach_host_name=False)
+
     def test_dist_points_submission(self):
         """
         Assess the distribution data payload format, when submitting a single or multiple points.
@@ -457,6 +473,15 @@ class TestMetricResource(DatadogAPIWithInitialization):
         serie = [dict(metric='metric.1', points=[[time(), [13]]]),
                  dict(metric='metric.2', points=[[time(), [19]]])]
         self.submit_and_assess_dist_payload(serie)
+
+        # Single point no hostname
+        serie = dict(metric='metric.1', points=[[time(), [13]]])
+        self.submit_and_assess_dist_payload(serie, attach_host_name=False)
+
+        # Multiple point no hostname
+        serie = [dict(metric='metric.1', points=[[time(), [13]]]),
+                 dict(metric='metric.2', points=[[time(), [19]]])]
+        self.submit_and_assess_dist_payload(serie, attach_host_name=False)
 
     def test_data_type_support(self):
         """
@@ -475,6 +500,7 @@ class TestMetricResource(DatadogAPIWithInitialization):
         for point in supported_data_types:
             serie = dict(metric='metric.numerical', points=point)
             self.submit_and_assess_metric_payload(serie)
+
 
 class TestServiceCheckResource(DatadogAPIWithInitialization):
 

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -406,7 +406,6 @@ class TestMetricResource(DatadogAPIWithInitialization):
             Distribution.send(deepcopy(serie), attach_host_name=attach_host_name)
 
         payload = self.get_request_data()
-        print payload
 
         for i, metric in enumerate(payload['series']):
             if attach_host_name:


### PR DESCRIPTION
Add ability to set `attach_host_name` to false when sending metrics, events and distributions
Also adds some tests and fixes a bunch of flake8 while I was there
Resolves #325 
