### PR TITLE
Allow listing timeboards with empty descriptions

### DIFF
--- a/datadog/dogshell/timeboard.py
+++ b/datadog/dogshell/timeboard.py
@@ -320,7 +320,7 @@ class TimeboardClient(object):
 
     @classmethod
     def _escape(cls, s):
-        return s.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
+        return s.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t") if s else ""
 
 
 def _template_variables(tpl_var_input):


### PR DESCRIPTION
The `_escape()` method assumed it always would be receiving a string, but if
there is no description set on a timeboard it would instead be set to `None`.

This handles those cases by instead making the function return an empty string
in case the input is False-y - ie. `None`.