### PR TITLE
Do not override API parameters with default when calling initialize if they are already set

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -70,11 +70,10 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     :type mute: boolean
     """
     # API configuration
-    api._api_key = api_key if api_key is not None else os.environ.get('DATADOG_API_KEY')
-    api._application_key = app_key if app_key is not None else os.environ.get('DATADOG_APP_KEY')
-    api._host_name = host_name if host_name is not None else get_hostname()
-    api._api_host = api_host if api_host is not None else \
-        os.environ.get('DATADOG_HOST', 'https://api.datadoghq.com')
+    api._api_key = api_key or api._api_key or os.environ.get('DATADOG_API_KEY')
+    api._application_key = app_key or api._application_key or os.environ.get('DATADOG_APP_KEY')
+    api._host_name = host_name or api._host_name or get_hostname()
+    api._api_host = api_host or api._api_host or os.environ.get('DATADOG_HOST', 'https://api.datadoghq.com')
 
     # Statsd configuration
     # ...overrides the default `statsd` instance attributes
@@ -90,5 +89,5 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
 
     # HTTP client and API options
     for key, value in iteritems(kwargs):
-        attribute = "_{0}".format(key)
+        attribute = "_{}".format(key)
         setattr(api, attribute, value)

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -9,7 +9,7 @@ from time import time
 import mock
 
 # datadog
-from datadog import initialize, api
+from datadog import initialize, api, util
 from datadog.api import (
     Distribution,
     Metric,
@@ -147,57 +147,73 @@ class TestInitialization(DatadogAPINoInitialization):
         initialize(api_key=API_KEY, mute=False)
         self.assertRaises(ApiError, MyCreatable.create)
 
-    def test_initialization_from_env(self):
-        """
-        Set API parameters in `initialize` from environment variables.
-        """
-        @preserve_environ_datadog
-        def test_api_params_from_env(env_name, attr_name, env_value):
-            """
-            Set env_name environment variable to env_value
-            Assert api.attr_name = env_value
-            """
-            os.environ[env_name] = env_value
-            initialize()
-            self.assertEqual(getattr(api, attr_name), env_value)
+    def test_default_values(self):
+        initialize()
 
-        @preserve_environ_datadog
-        def test_api_params_default(env_name, attr_name, expected_value):
-            """
-            Unset env_name environment variable
-            Assert api.attr_name = expected_value
-            """
-            if os.environ.get(env_name):
-                del os.environ[env_name]
-            initialize()
-            self.assertEqual(getattr(api, attr_name), expected_value)
+        self.assertIsNone(api._api_key)
+        self.assertIsNone(api._application_key)
+        self.assertEqual(api._api_host, "https://api.datadoghq.com")
+        self.assertEqual(api._host_name, util.hostname.get_hostname())
 
-        @preserve_environ_datadog
-        def test_api_params_from_params(env_name, parameter, attr_name, value):
-            """
-            Unset env_name environment variable
-            Initialize API with parameter=value
-            Assert api.attr_name = value
-            """
-            if os.environ.get(env_name):
-                del os.environ[env_name]
-            initialize(api_host='http://localhost')
-            self.assertEqual(api._api_host, 'http://localhost')
+    def test_env_var_values(self):
+        os.environ["DATADOG_API_KEY"] = "API_KEY_ENV"
+        os.environ["DATADOG_APP_KEY"] = "APP_KEY_ENV"
+        os.environ["DATADOG_HOST"] = "HOST_ENV"
 
-        # Default values
-        test_api_params_default("DATADOG_API_KEY", "_api_key", None)
-        test_api_params_default("DATADOG_APP_KEY", "_application_key", None)
-        test_api_params_default("DATADOG_HOST", "_api_host", "https://api.datadoghq.com")
+        initialize()
 
-        # From environment
-        test_api_params_from_env("DATADOG_API_KEY", "_api_key", env_value="apikey")
-        test_api_params_from_env("DATADOG_APP_KEY", "_application_key", env_value="appkey")
-        test_api_params_from_env("DATADOG_HOST", "_api_host", env_value="http://localhost")
+        self.assertEqual(api._api_key, "API_KEY_ENV")
+        self.assertEqual(api._application_key, "APP_KEY_ENV")
+        self.assertEqual(api._api_host, "HOST_ENV")
+        self.assertEqual(api._host_name, util.hostname.get_hostname())
 
-        # From parameters
-        test_api_params_from_params("DATADOG_API_KEY", "api_key", "_api_key", "apikey2")
-        test_api_params_from_params("DATADOG_APP_KEY", "app_key", "_application_key", "appkey2")
-        test_api_params_from_params("DATADOG_HOST", "api_host", "_api_host", "http://127.0.0.1")
+        del os.environ["DATADOG_API_KEY"]
+        del os.environ["DATADOG_APP_KEY"]
+        del os.environ["DATADOG_HOST"]
+
+    def test_function_param_value(self):
+        initialize(api_key="API_KEY", app_key="APP_KEY", api_host="HOST", host_name="HOSTNAME")
+
+        self.assertEqual(api._api_key, "API_KEY")
+        self.assertEqual(api._application_key, "APP_KEY")
+        self.assertEqual(api._api_host, "HOST")
+        self.assertEqual(api._host_name, "HOSTNAME")
+
+    def test_additional_call(self):
+        initialize(api_key="API_KEY", app_key="APP_KEY", api_host="HOST", host_name="HOSTNAME")
+
+        self.assertEqual(api._api_key, "API_KEY")
+        self.assertEqual(api._application_key, "APP_KEY")
+        self.assertEqual(api._api_host, "HOST")
+        self.assertEqual(api._host_name, "HOSTNAME")
+
+        initialize(api_key="API_KEY2")
+
+        self.assertEqual(api._api_key, "API_KEY2")
+        self.assertEqual(api._application_key, "APP_KEY")
+        self.assertEqual(api._api_host, "HOST")
+        self.assertEqual(api._host_name, "HOSTNAME")
+
+        initialize(app_key="APP_KEY2")
+
+        self.assertEqual(api._api_key, "API_KEY2")
+        self.assertEqual(api._application_key, "APP_KEY2")
+        self.assertEqual(api._api_host, "HOST")
+        self.assertEqual(api._host_name, "HOSTNAME")
+
+        initialize(api_host="HOST2")
+
+        self.assertEqual(api._api_key, "API_KEY2")
+        self.assertEqual(api._application_key, "APP_KEY2")
+        self.assertEqual(api._api_host, "HOST2")
+        self.assertEqual(api._host_name, "HOSTNAME")
+
+        initialize(host_name="HOSTNAME2")
+
+        self.assertEqual(api._api_key, "API_KEY2")
+        self.assertEqual(api._application_key, "APP_KEY2")
+        self.assertEqual(api._api_host, "HOST2")
+        self.assertEqual(api._host_name, "HOSTNAME2")
 
 
 class TestResources(DatadogAPIWithInitialization):


### PR DESCRIPTION
Resolves #369