### PR TITLE
Fixes the --tags argument for service_checks in dogshell

### DIFF
--- a/datadog/dogshell/service_check.py
+++ b/datadog/dogshell/service_check.py
@@ -31,9 +31,14 @@ class ServiceCheckClient(object):
     def _check(cls, args):
         api._timeout = args.timeout
         format = args.format
+        if args.tags:
+            tags = sorted(set([t.strip() for t in
+                               args.tags.split(',') if t]))
+        else:
+            tags = None
         res = api.ServiceCheck.check(
             check=args.check, host_name=args.host_name, status=int(args.status),
-            timestamp=args.timestamp, message=args.message, tags=args.tags)
+            timestamp=args.timestamp, message=args.message, tags=tags)
         report_warnings(res)
         report_errors(res)
         if format == 'pretty':

--- a/datadog/dogshell/service_check.py
+++ b/datadog/dogshell/service_check.py
@@ -32,8 +32,7 @@ class ServiceCheckClient(object):
         api._timeout = args.timeout
         format = args.format
         if args.tags:
-            tags = sorted(set([t.strip() for t in
-                               args.tags.split(',') if t]))
+            tags = sorted(set([t.strip() for t in args.tags.split(',') if t.strip()]))
         else:
             tags = None
         res = api.ServiceCheck.check(


### PR DESCRIPTION
The --tags argument was not working, this allows a user to submit a service check with more than just the host tagged.

Based on @gordlea's work, supersedes #348 