### PR TITLE
Replace non-ASCII apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Thread Safety
 Origin detection over UDP
 -------------
 Origin detection is a method to detect which pod `DogStatsD` packets are coming from in order to add the pod's tags to the tag list.
-The `DogStatsD` client attaches an internal tag, `entity_id`. The value of this tag is the content of the `DD_ENTITY_ID` environment variable if found, which is the pod’s UID.
+The `DogStatsD` client attaches an internal tag, `entity_id`. The value of this tag is the content of the `DD_ENTITY_ID` environment variable if found, which is the pod's UID.
 This tag will be used by the Datadog Agent to insert container tags to the metrics. You should only `append` to the `constant_tags` list to avoid overwriting this global tag.
 
 To enable origin detection over UDP, add the following lines to your application manifest


### PR DESCRIPTION
In some environments, a non-ASCII character causes a failure when pip installing datadog.
I could not replicate on my local OSX machine, but I have a Docker image based on Ubuntu 14.04.5 LTS that fails reliably with the character in the README.

I would add a test, but the tests already fail in my Docker environment for the same reason, I'm not sure what exactly in the environment causes it.

Edit: I spent some time looking at the logic used to determine an encoding for `open()` when none is specified.
On a Unix system, without `CODESET` available, it looks for four environment variables `'LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE'`. If none of those are set, it defaults to `ascii`. The container where the build fails has none of those four set.
While this is an environment issue, I still think it's worth changing the character, to match the other apostrophes in the file which all use the ASCII character.


```
root@9248effa1077:/data/datadogpy# python3.6 setup.py test
Traceback (most recent call last):
  File "setup.py", line 24, in <module>
    long_description=get_readme_md_contents(),
  File "setup.py", line 8, in get_readme_md_contents
    long_description = f.read()
  File "/usr/local/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3377: ordinal not in range(128)
```