### PR TITLE
[dogshell] Fix dogwrap unicode option parsing on python 3

### DIFF
--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -219,6 +219,7 @@ def build_event_body(cmd, returncode, stdout, stderr, notifications):
             notifications=fmt_notifications,
         )
 
+
 def parse_options(raw_args=None):
     '''
     Parse the raw command line options into an options object and the remaining command string
@@ -273,6 +274,7 @@ returned (the command outputs remains buffered in dogwrap meanwhile)")
         cmd = ' '.join(args)
 
     return options, cmd
+
 
 def main():
     options, cmd = parse_options()

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -28,14 +28,13 @@ import time
 # datadog
 from datadog import initialize, api
 from datadog.util.config import get_version
+from datadog.util.compat import is_p3k
 
 
 SUCCESS = 'success'
 ERROR = 'error'
 
 MAX_EVENT_BODY_LENGTH = 3000
-
-PYTHON2 = sys.version_info < (3,)
 
 
 class Timeout(Exception):
@@ -112,8 +111,8 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout,
     try:
         # Let's that the threads collecting the output from the command in the
         # background
-        stdout = sys.stdout if PYTHON2 else sys.stdout.buffer
-        stderr = sys.stderr if PYTHON2 else sys.stderr.buffer
+        stdout = sys.stdout.buffer if is_p3k() else sys.stdout
+        stderr = sys.stderr.buffer if is_p3k() else sys.stderr
         out_reader = OutputReader(proc.stdout, stdout if not buffer_outs else None)
         err_reader = OutputReader(proc.stderr, stderr if not buffer_outs else None)
         out_reader.start()
@@ -268,10 +267,10 @@ returned (the command outputs remains buffered in dogwrap meanwhile)")
 
     options, args = parser.parse_args(args=raw_args)
 
-    if PYTHON2:
-        cmd = b' '.join(args).decode('utf-8')
-    else:
+    if is_p3k():
         cmd = ' '.join(args)
+    else:
+        cmd = b' '.join(args).decode('utf-8')
 
     return options, cmd
 
@@ -327,7 +326,7 @@ def main():
     }
 
     if options.buffer_outs:
-        if not PYTHON2:
+        if is_p3k():
             stderr = stderr.decode('utf-8')
             stdout = stdout.decode('utf-8')
 

--- a/tests/unit/dogwrap/test_dogwrap.py
+++ b/tests/unit/dogwrap/test_dogwrap.py
@@ -6,6 +6,8 @@ import sys
 import tempfile
 
 from datadog.dogshell.wrap import OutputReader, build_event_body, parse_options
+from datadog.util.compat import is_p3k
+
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -47,10 +49,10 @@ class TestDogwrap(unittest.TestCase):
         self.assertEqual(cmd, '')
 
         # The output of parse_args is already unicode in python 3, so don't encode the input
-        if sys.version_info < (3,):
-            arg = u'helløøééé'.encode('utf-8')
-        else:
+        if is_p3k():
             arg = u'helløøééé'
+        else:
+            arg = u'helløøééé'.encode('utf-8')
 
         options, cmd = parse_options(['-n', 'name', '-k', 'key', '-m', 'all', '-p', 'low', '-t', '123',
                                       '--sigterm_timeout', '456', '--sigkill_timeout', '789',

--- a/tests/unit/dogwrap/test_dogwrap.py
+++ b/tests/unit/dogwrap/test_dogwrap.py
@@ -2,9 +2,10 @@
 
 import unittest
 import os
+import sys
 import tempfile
 
-from datadog.dogshell.wrap import OutputReader, build_event_body
+from datadog.dogshell.wrap import OutputReader, build_event_body, parse_options
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -40,3 +41,50 @@ class TestDogwrap(unittest.TestCase):
 
         event_body = build_event_body(cmd, returncode, stdout, stderr, notifications)
         self.assertEqual(expected_body, event_body)
+
+    def test_parse_options(self):
+        options, cmd = parse_options([])
+        self.assertEqual(cmd, '')
+
+        # The output of parse_args is already unicode in python 3, so don't encode the input
+        if sys.version_info < (3,):
+            arg = u'helløøééé'.encode('utf-8')
+        else:
+            arg = u'helløøééé'
+
+        options, cmd = parse_options(['-n', 'name', '-k', 'key', '-m', 'all', '-p', 'low', '-t', '123',
+                                      '--sigterm_timeout', '456', '--sigkill_timeout', '789',
+                                      '--proc_poll_interval', '1.5', '--notify_success', 'success',
+                                      '--notify_error', 'error', '-b', '--tags', 'k1:v1,k2:v2',
+                                      'echo', arg])
+        self.assertEqual(cmd, u'echo helløøééé')
+        self.assertEqual(options.name, 'name')
+        self.assertEqual(options.api_key, 'key')
+        self.assertEqual(options.submit_mode, 'all')
+        self.assertEqual(options.priority, 'low')
+        self.assertEqual(options.timeout, 123)
+        self.assertEqual(options.sigterm_timeout, 456)
+        self.assertEqual(options.sigkill_timeout, 789)
+        self.assertEqual(options.proc_poll_interval, 1.5)
+        self.assertEqual(options.notify_success, 'success')
+        self.assertEqual(options.notify_error, 'error')
+        self.assertTrue(options.buffer_outs)
+        self.assertEqual(options.tags, 'k1:v1,k2:v2')
+
+        with self.assertRaises(SystemExit):
+            parse_options(['-m', 'invalid'])
+
+        with self.assertRaises(SystemExit):
+            parse_options(['-p', 'invalid'])
+
+        with self.assertRaises(SystemExit):
+            parse_options(['-t', 'invalid'])
+
+        with self.assertRaises(SystemExit):
+            parse_options(['--sigterm_timeout', 'invalid'])
+
+        with self.assertRaises(SystemExit):
+            parse_options(['--sigkill_timeout', 'invalid'])
+
+        with self.assertRaises(SystemExit):
+            parse_options(['--proc_poll_interval', 'invalid'])


### PR DESCRIPTION
The options parser returns a list of `str`, which was getting joined with a `bytes` string. There were also two places where `bytes` were being written to stdout and stderr.

Fixes #394 