### PR TITLE
Convert CaseInsensitiveDict response headers to dict

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -159,7 +159,8 @@ class APIClient(object):
 
             if response_obj:
                 for response in response_obj:
-                    response['response_headers'] = response_headers
+                    # Convert response headers from CaseInsensitiveDict to dict so it can be JSON serialized
+                    response['response_headers'] = dict(response_headers)
 
             if response_formatter is None:
                 return response_obj


### PR DESCRIPTION
Requests by default makes the response headers into it's own custom type,
`CaseInsensitiveDict`, which can't be JSON serialized without extra work.
This affects the `dog timeboard show ...` and `dog screenboard show ...`
commands, as they JSON encode the Python data structures and they will give
the following error message without this change:

    TypeError: Object of type CaseInsensitiveDict is not JSON serializable

This fixes it by explictly converting the response headers object to a dict
before being added to the response object.