### PR TITLE
Extend response headers to response

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -158,7 +158,7 @@ class APIClient(object):
                 response_obj = None
 
             if response_obj:
-                response_obj['response_headers'] = response_headers
+                response_obj.append({'response_headers': response_headers})
 
             if response_formatter is None:
                 return response_obj

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -158,7 +158,8 @@ class APIClient(object):
                 response_obj = None
 
             if response_obj:
-                response_obj.append({'response_headers': response_headers})
+                for response in response_obj:
+                    response['response_headers'] = response_headers
 
             if response_formatter is None:
                 return response_obj


### PR DESCRIPTION
Properly extend the response headers to the response object list. 

Resolves:

```
Traceback (most recent call last):
  File "test.py", line 14, in <module>
    print (api.Monitor.get_all())
  File "/usr/local/lib/python3.7/site-packages/datadog/api/monitors.py", line 57, in get_all
    return super(Monitor, cls).get_all(**params)
  File "/usr/local/lib/python3.7/site-packages/datadog/api/resources.py", line 181, in get_all
    return APIClient.submit('GET', cls._resource_name, api_version, **params)
  File "/usr/local/lib/python3.7/site-packages/datadog/api/api_client.py", line 161, in submit
    response_obj['response_headers'] = response_headers
TypeError: list indices must be integers or slices, not str
```

issues on endpoints that had response headers returned. 

Fixes https://github.com/DataDog/datadogpy/issues/393