### PR TITLE
Add new top level `api` function to get the response object of last request

### DIFF
--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -34,3 +34,4 @@ from datadog.api.hosts import Host, Hosts
 from datadog.api.service_checks import ServiceCheck
 from datadog.api.tags import Tag
 from datadog.api.users import User
+from datadog.api.api_client import get_response

--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -34,4 +34,4 @@ from datadog.api.hosts import Host, Hosts
 from datadog.api.service_checks import ServiceCheck
 from datadog.api.tags import Tag
 from datadog.api.users import User
-from datadog.api.api_client import get_response
+from datadog.api.api_client import get_http_response

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -32,6 +32,20 @@ class APIClient(object):
     # Plugged HTTP client
     _http_client = None
 
+    @staticmethod
+    def add_response_field(response_obj, key, field):
+        """
+        Adds the response field to the response object.
+        Response_obj may either be a list or a dictionary, or some unknown type
+        """
+        if isinstance(response_obj, dict):
+            response_obj[key] = field
+        elif isinstance(response_obj, list):
+            for resp in response_obj:
+                APIClient.add_response_field(resp, key, field)
+        else:
+            pass
+
     @classmethod
     def _get_http_client(cls):
         """
@@ -141,6 +155,8 @@ class APIClient(object):
 
             # Format response content
             content = result.content
+            response_headers = result.headers
+            status_code = result.status_code
 
             if content:
                 try:
@@ -155,6 +171,11 @@ class APIClient(object):
                     raise ApiError(response_obj)
             else:
                 response_obj = None
+
+            if response_obj:
+                APIClient.add_response_field(response_obj, "response_headers", response_headers)
+                APIClient.add_response_field(response_obj, "status_code", status_code)
+
             if response_formatter is None:
                 return response_obj
             else:

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -149,7 +149,6 @@ class APIClient(object):
             # Format response content
             content = result.content
             _set_http_response(result)
-            response_headers = result.headers
 
             if content:
                 try:

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -18,12 +18,18 @@ from datadog.util.compat import is_p3k
 log = logging.getLogger('datadog.api')
 _http_response = None
 
+
 def get_http_response():
+    """
+    Getter for the most recent http request
+    """
     return _http_response
+
 
 def _set_http_response(response):
     global _http_response
     _http_response = response
+
 
 class APIClient(object):
     """

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -21,7 +21,7 @@ _http_response = None
 
 def get_http_response():
     """
-    Getter for the most recent http request
+    Getter for the most recent http request response object
     """
     return _http_response
 

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -16,7 +16,14 @@ from datadog.api.http_client import resolve_http_client
 from datadog.util.compat import is_p3k
 
 log = logging.getLogger('datadog.api')
+_http_response = None
 
+def get_http_response():
+    return _http_response
+
+def _set_http_response(response):
+    global _http_response
+    _http_response = response
 
 class APIClient(object):
     """
@@ -31,20 +38,6 @@ class APIClient(object):
 
     # Plugged HTTP client
     _http_client = None
-
-    @staticmethod
-    def add_response_field(response_obj, key, field):
-        """
-        Adds the response field to the response object.
-        Response_obj may either be a list or a dictionary, or some unknown type
-        """
-        if isinstance(response_obj, dict):
-            response_obj[key] = field
-        elif isinstance(response_obj, list):
-            for resp in response_obj:
-                APIClient.add_response_field(resp, key, field)
-        else:
-            pass
 
     @classmethod
     def _get_http_client(cls):
@@ -155,8 +148,8 @@ class APIClient(object):
 
             # Format response content
             content = result.content
+            _set_http_response(result)
             response_headers = result.headers
-            status_code = result.status_code
 
             if content:
                 try:
@@ -171,10 +164,6 @@ class APIClient(object):
                     raise ApiError(response_obj)
             else:
                 response_obj = None
-
-            if response_obj:
-                APIClient.add_response_field(response_obj, "response_headers", response_headers)
-                APIClient.add_response_field(response_obj, "status_code", status_code)
 
             if response_formatter is None:
                 return response_obj


### PR DESCRIPTION
This PR adds a new `get_http_respone` top level function to the `api` module. The primary goal is to allow users to call this after any other api call to see the response of the previous call. This allows you to inspect things like status_code, headers, etc and currently just returns the `requests` response - https://2.python-requests.org/en/master/api/#requests.Response

This approach also has the benefit of not adding response metadata to the actual data object returned by the client. 

The code would look something like this:

```
api.Monitor.get_all()
resp = api.get_http_response()
```