### PR TITLE
Add project URLs to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,11 @@ setup(
     license="BSD",
     keywords="datadog",
     url="https://www.datadoghq.com",
+    project_urls={
+        "Bug Tracker": "https://github.com/DataDog/datadogpy/issues",
+        "Documentation": "https://datadogpy.readthedocs.io/en/latest/",
+        "Source Code": "https://github.com/DataDog/datadogpy",
+    },
     entry_points={"console_scripts": ["dog = datadog.dogshell:main", "dogwrap = datadog.dogshell.wrap:main"]},
     test_suite="tests",
     classifiers=[


### PR DESCRIPTION
This will add more links in the "Project links" section in the left hand
sidebar on the PyPI page, liking to the bug tracker, documentation and source
code. It will make it easier for users of the library and automated package
updating tools to figure out what's changed, where to report issues and where
to find the documentation for the package.