### PR TITLE
Add init option to add raw response to return values

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -31,7 +31,7 @@ logging.getLogger('datadog.threadstats').addHandler(NullHandler())
 
 def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
                statsd_host=None, statsd_port=None, statsd_use_default_route=False,
-               statsd_socket_path=None, statsd_namespace=None, **kwargs):
+               statsd_socket_path=None, statsd_namespace=None, return_raw_response=False, **kwargs):
     """
     Initialize and configure Datadog.api and Datadog.statsd modules
 
@@ -68,6 +68,10 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
     :param mute: Mute any ApiError or ClientError before they escape \
         from datadog.api.HTTPClient (default: True).
     :type mute: boolean
+
+    :param return_raw_response: Whether or not to return the raw response object in addition \
+        to the decoded response content (default: False)
+    :type return_raw_response: boolean
     """
     # API configuration
     api._api_key = api_key or api._api_key or os.environ.get('DATADOG_API_KEY', os.environ.get('DD_API_KEY'))
@@ -92,6 +96,8 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
             statsd.port = int(statsd_port)
     if statsd_namespace:
         statsd.namespace = text(statsd_namespace)
+
+    api._return_raw_response = return_raw_response
 
     # HTTP client and API options
     for key, value in iteritems(kwargs):

--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -34,4 +34,3 @@ from datadog.api.hosts import Host, Hosts
 from datadog.api.service_checks import ServiceCheck
 from datadog.api.tags import Tag
 from datadog.api.users import User
-from datadog.api.api_client import get_http_response

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -16,19 +16,6 @@ from datadog.api.http_client import resolve_http_client
 from datadog.util.compat import is_p3k
 
 log = logging.getLogger('datadog.api')
-_http_response = None
-
-
-def get_http_response():
-    """
-    Getter for the most recent http request response object
-    """
-    return _http_response
-
-
-def _set_http_response(response):
-    global _http_response
-    _http_response = response
 
 
 class APIClient(object):
@@ -154,7 +141,6 @@ class APIClient(object):
 
             # Format response content
             content = result.content
-            _set_http_response(result)
 
             if content:
                 try:
@@ -169,7 +155,6 @@ class APIClient(object):
                     raise ApiError(response_obj)
             else:
                 response_obj = None
-
             if response_formatter is None:
                 return response_obj
             else:

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -82,7 +82,7 @@ class APIClient(object):
             # Import API, User and HTTP settings
             from datadog.api import _api_key, _application_key, _api_host, \
                 _mute, _host_name, _proxies, _max_retries, _timeout, \
-                _cacert
+                _cacert, _return_raw_response
 
             # Check keys and add then to params
             if _api_key is None:
@@ -155,10 +155,14 @@ class APIClient(object):
                     raise ApiError(response_obj)
             else:
                 response_obj = None
-            if response_formatter is None:
-                return response_obj
+
+            if response_formatter is not None:
+                response_obj = response_formatter(response_obj)
+
+            if _return_raw_response:
+                return (response_obj, result,)
             else:
-                return response_formatter(response_obj)
+                return response_obj
 
         except HttpTimeout:
             cls._timeout_counter += 1

--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -160,7 +160,7 @@ class APIClient(object):
                 response_obj = response_formatter(response_obj)
 
             if _return_raw_response:
-                return (response_obj, result,)
+                return response_obj, result
             else:
                 return response_obj
 

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -129,6 +129,18 @@ class TestInitialization(DatadogAPINoInitialization):
         initialize(api_key=API_KEY, mute=False)
         self.assertRaises(ApiError, MyCreatable.create)
 
+
+    def test_return_raw_response(self):
+        # Test default initialization sets return_raw_response to False
+        initialize()
+        assert not api._return_raw_response
+        # Assert that we can set this to True
+        initialize(return_raw_response=True)
+        assert api._return_raw_response
+        # Assert we get multiple fields back when set to True
+        data, raw = api.Monitor.get_all()
+
+
     def test_default_values(self):
         with EnvVars(ignore=[
             "DATADOG_API_KEY",

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -138,6 +138,7 @@ class TestInitialization(DatadogAPINoInitialization):
         initialize(return_raw_response=True)
         assert api._return_raw_response
         # Assert we get multiple fields back when set to True
+        initialize(api_key="aaaaaaaaaa", app_key="123456", return_raw_response=True)
         data, raw = api.Monitor.get_all()
 
 


### PR DESCRIPTION
Reverts https://github.com/DataDog/datadogpy/pull/412 and re implements in a different way. 

This PR makes the approach threadsafe while keeping backwards compatibility by using a configuration option passed through the global init. `return_raw_response` is set to false by default, but when its explicitly enabled, we return the decoded response as well as the raw response object from the `submit` method. 