### PR TITLE
[dogshell] enable proxy

### DIFF
--- a/datadog/api/exceptions.py
+++ b/datadog/api/exceptions.py
@@ -3,6 +3,18 @@ API & HTTP Clients exceptions.
 """
 
 
+class ProxyError(Exception):
+    """
+    HTTP connection to the configured proxy server failed.
+    """
+    def __init__(self, method, url, exception):
+        message = u"Could not request {method} {url}: Unable to connect to proxy. "\
+                  u"Please check the proxy configuration and try again.".format(
+                      method=method, url=url
+                  )
+        super(ProxyError, self).__init__(message)
+
+
 class ClientError(Exception):
     """
     HTTP connection to Datadog endpoint is not possible.

--- a/datadog/api/http_client.py
+++ b/datadog/api/http_client.py
@@ -23,7 +23,7 @@ except ImportError:
     urlfetch, urlfetch_errors = None, None
 
 # datadog
-from datadog.api.exceptions import ClientError, HTTPError, HttpTimeout
+from datadog.api.exceptions import ProxyError, ClientError, HTTPError, HttpTimeout
 
 
 log = logging.getLogger('datadog.api')
@@ -85,6 +85,8 @@ class RequestClient(HTTPClient):
 
             result.raise_for_status()
 
+        except requests.exceptions.ProxyError as e:
+            raise _remove_context(ProxyError(method, url, e))
         except requests.ConnectionError as e:
             raise _remove_context(ClientError(method, url, e))
         except requests.exceptions.Timeout:

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -78,7 +78,7 @@ class DogshellConfig(IterableUserDict):
             self['api_key'] = config.get('Connection', 'apikey')
             self['app_key'] = config.get('Connection', 'appkey')
             if config.has_section('Proxy'):
-                self['proxies'] = config._sections['Proxy']
+                self['proxies'] = dict(config.items('Proxy'))
             if config.has_option('Connection', 'host_name'):
                 self['host_name'] = config.get('Connection', 'host_name')
             if config.has_option('Connection', 'api_host'):

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -77,6 +77,8 @@ class DogshellConfig(IterableUserDict):
 
             self['api_key'] = config.get('Connection', 'apikey')
             self['app_key'] = config.get('Connection', 'appkey')
+            if config.has_section('Proxy'):
+                self['proxies'] = config._sections['Proxy']
             if config.has_option('Connection', 'host_name'):
                 self['host_name'] = config.get('Connection', 'host_name')
             if config.has_option('Connection', 'api_host'):


### PR DESCRIPTION
### What does this PR do

Allows for configuring a proxy for Dogshell.

sample ~/.dogrc that utilizes a proxy

```
[Connection]
apikey = xxx
appkey = yyy
api_host = https://api.datadoghq.com

[Proxy]
http = http://localhost:3128/
https = http://localhost:3128/
```

### Motivation

Someone asked in public slack how to use dogshell with a proxy.
Told him he could set `api_host` to a reverse proxy. Then, I looked at the code and found that dogshell uses `datadog.api.initialize` [here](https://github.com/DataDog/datadogpy/blob/master/datadog/dogshell/__init__.py#L72-L73)

...and that `initialize` already takes in proxies as a parameter [here](https://github.com/DataDog/datadogpy/blob/master/datadog/__init__.py#L44-L46)

... so I figured I could just find a way pass the information from dogrc



