### PR TITLE
Add deprecation warning to old aws lambda threadstats integration

### DIFF
--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -5,7 +5,7 @@ import os
 import warnings
 
 """
-DEPRECATED use datadog-lambda package instead https://github.com/DataDog/datadog-lambda-layer-python
+DEPRECATED use datadog-lambda package instead https://git.io/fjy8o
 Usage:
 
 from datadog import datadog_lambda_wrapper, lambda_metric

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -5,7 +5,7 @@ import os
 import warnings
 
 """
-DEPRECATED use datadog-lambda package instead https://github.com/DataDog/datadog-lambda-layer-python 
+DEPRECATED use datadog-lambda package instead https://github.com/DataDog/datadog-lambda-layer-python
 Usage:
 
 from datadog import datadog_lambda_wrapper, lambda_metric
@@ -64,7 +64,8 @@ class _LambdaDecorator(object):
 
     def __call__(self, *args, **kw):
         warnings.warn(
-            "datadog_lambda_wrapper() is deprecated; use datadog-lambda package instead https://github.com/DataDog/datadog-lambda-layer-python", DeprecationWarning)
+            "datadog_lambda_wrapper() is deprecated; use datadog-lambda package instead https://git.io/fjy8o",
+            DeprecationWarning)
         _LambdaDecorator._enter()
         try:
             return self.func(*args, **kw)

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -2,9 +2,10 @@ from datadog.threadstats import ThreadStats
 from threading import Lock, Thread
 from datadog import api
 import os
-
+import warnings
 
 """
+DEPRECATED use datadog-lambda package instead https://github.com/DataDog/datadog-lambda-layer-python 
 Usage:
 
 from datadog import datadog_lambda_wrapper, lambda_metric
@@ -16,7 +17,7 @@ def my_lambda_handle(event, context):
 
 
 class _LambdaDecorator(object):
-    """ Decorator to automatically init & flush metrics, created for Lambda functions"""
+    """ DEPRECATED Decorator to automatically init & flush metrics, created for Lambda functions"""
 
     # Number of opened wrappers, flush when 0
     _counter = 0
@@ -29,6 +30,7 @@ class _LambdaDecorator(object):
 
     @classmethod
     def _enter(cls):
+
         with cls._counter_lock:
             if not cls._was_initialized:
                 cls._was_initialized = True
@@ -61,6 +63,8 @@ class _LambdaDecorator(object):
                     _lambda_stats.flush(float("inf"))
 
     def __call__(self, *args, **kw):
+        warnings.warn(
+            "datadog_lambda_wrapper() is deprecated; use datadog-lambda package instead https://github.com/DataDog/datadog-lambda-layer-python", DeprecationWarning)
         _LambdaDecorator._enter()
         try:
             return self.func(*args, **kw)

--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -63,9 +63,7 @@ class _LambdaDecorator(object):
                     _lambda_stats.flush(float("inf"))
 
     def __call__(self, *args, **kw):
-        warnings.warn(
-            "datadog_lambda_wrapper() is deprecated; use datadog-lambda package instead https://git.io/fjy8o",
-            DeprecationWarning)
+        warnings.warn("datadog_lambda_wrapper() is relocated to https://git.io/fjy8o", DeprecationWarning)
         _LambdaDecorator._enter()
         try:
             return self.func(*args, **kw)


### PR DESCRIPTION
The lambda wrapper in the thread stats library is now deprecated for the new [datadog lambda layer](https://github.com/DataDog/datadog-lambda-layer-python), which has the same functionality. We want to introduce a warning so people will know to upgrade.

