### PR TITLE
[users] Updated users resource name to match new plural endpoints

### DIFF
--- a/datadog/api/users.py
+++ b/datadog/api/users.py
@@ -7,7 +7,7 @@ class User(ActionAPIResource, GetableAPIResource, CreateableAPIResource,
            UpdatableAPIResource, ListableAPIResource,
            DeletableAPIResource):
 
-    _resource_name = 'user'
+    _resource_name = 'users'
 
     """
     A wrapper around User HTTP API.


### PR DESCRIPTION
Updated the users resource name to be pluralized, matching the newly encouraged plural version of the endpoint