### PR TITLE
Fix periodic timer error on interpreter shutdown

### DIFF
--- a/datadog/threadstats/periodic_timer.py
+++ b/datadog/threadstats/periodic_timer.py
@@ -4,6 +4,7 @@ A small class to run a task periodically in a thread.
 
 
 from threading import Thread, Event
+import sys
 
 
 class PeriodicTimer(Thread):
@@ -18,27 +19,15 @@ class PeriodicTimer(Thread):
         self.kwargs = kwargs
         self.finished = Event()
 
-    def _is_alive(self):
-        # HACK: The Python interpreter can start cleaning up objects in the
-        # main thread before killing daemon threads, so these references can be
-        # null result in errors like that in case #18, tagged
-        # "most likely raised during interpreter shutdown". This is hack to
-        # try gracefully fail in these circumstances.
-        #
-        # http://stackoverflow.com/questions/1745232
-        return (
-            bool(self.finished) and
-            bool(self.interval) and
-            bool(self.function)
-        )
-
     def end(self):
-        if self._is_alive():
-            self.finished.set()
+        self.finished.set()
 
     def run(self):
-        while True:
-            if not self._is_alive() or self.finished.isSet():
-                break
-            self.finished.wait(self.interval)
-            self.function(*self.args, **self.kwargs)
+        while not self.finished.wait(self.interval):
+            try:
+                self.function(*self.args, **self.kwargs)
+            except Exception:
+                # If `sys` is None, it means the interpreter is shutting down
+                # and it's very likely the reason why we got an exception.
+                if sys is not None:
+                    raise


### PR DESCRIPTION
The current hack does not work, as I'm still able to see such messages in the
log:

  Exception in thread Thread-1 (most likely raised during interpreter shutdown):
  Traceback (most recent call last):
    File "pyenv/versions/2.7.12/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    File "python/lib/python2.7/site-packages/datadog/threadstats/periodic_timer.py", line 43, in run
    File "pyenv/versions/2.7.12/lib/python2.7/threading.py", line 614, in wait
    File "pyenv/versions/2.7.12/lib/python2.7/threading.py", line 355, in wait
  <type 'exceptions.TypeError'>: 'NoneType' object is not callable

This changes the current code to leverage the same hack that the `threading`
library uses: if the `sys` module is None, there's a good chance that's because
the interpreter is shutdown down.

This change also improves the waiting loop by using the return value from
`Event.wait()` which returns the value of the flag. That makes the thread
faster to quit when `end()` is called.