### PR TITLE
updated reqs and test

### DIFF
--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -7,9 +7,8 @@ from datadog.util.format import pretty_json
 
 # datadog
 from datadog import api
-from datadog.dogshell.common import report_errors, report_warnings
+from datadog.dogshell.common import report_errors, report_warnings, print_err
 import warnings
-
 
 class MonitorClient(object):
     @classmethod
@@ -167,20 +166,20 @@ class MonitorClient(object):
         to_update = {}
         if args.type:
             if args.type_opt:
-                msg = '[WARNING] Duplicate arguments for `type`. Using optional value --type'
-                print(msg)
+                msg = 'Duplicate arguments for `type`. Using optional value --type'
+                print_err("WARNING: {}".format(msg))
             else:
                 to_update['type'] = args.type
             msg = "[DEPRECATION] `type` is no longer required to `update` and may be omitted"
-            warnings.warn(msg, DeprecationWarning)
+            print_err("WARNING: {}".format(msg))
         if args.query:
             if args.query_opt:
-                msg = '[WARNING] Duplicate arguments for `query`. Using optional value --query'
-                print(msg)
+                msg = 'Duplicate arguments for `query`. Using optional value --query'
+                print_err("WARNING: {}".format(msg))
             else:
                 to_update['query'] = args.query
             msg = "[DEPRECATION] `query` is no longer required to `update` and may be omitted"
-            warnings.warn(msg, DeprecationWarning)
+            print_err("WARNING: {}".format(msg))
         if args.name:
             to_update['name'] = args.name
         if args.message:

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -8,6 +8,7 @@ from datadog.util.format import pretty_json
 # datadog
 from datadog import api
 from datadog.dogshell.common import report_errors, report_warnings
+import warnings
 
 
 class MonitorClient(object):
@@ -39,10 +40,20 @@ class MonitorClient(object):
 
         update_parser = verb_parsers.add_parser('update', help="Update existing monitor")
         update_parser.add_argument('monitor_id', help="monitor to replace with the new definition")
-        update_parser.add_argument('type', nargs='?', help="[Deprecated] optional argument preferred"
-                                    "type of the monitor, e.g. 'metric alert' 'service check'", default=None)
-        update_parser.add_argument('query', nargs='?', help="[Deprecated] optional argument preferred"
-                                    "query to notify on with syntax varying depending on monitor type", default=None)
+        update_parser.add_argument(
+            'type',
+            nargs='?',
+            help="[Deprecated] optional argument preferred"
+                 "type of the monitor, e.g. 'metric alert' 'service check'",
+            default=None
+        )
+        update_parser.add_argument(
+            'query',
+            nargs='?',
+            help="[Deprecated] optional argument preferred"
+                 "query to notify on with syntax varying depending on monitor type",
+            default=None
+        )
         update_parser.add_argument('--type', help="type of the monitor, e.g. "
                                    "'metric alert' 'service check'", default=None)
         update_parser.add_argument('--query', help="query to notify on with syntax varying"
@@ -152,26 +163,26 @@ class MonitorClient(object):
     def _update(cls, args):
         api._timeout = args.timeout
         format = args.format
-        options = None
-        if args.options is not None:
-            try:
-                options = json.loads(args.options)
-            except:
-                raise Exception('bad json parameter')
 
         to_update = {}
         if args.type:
             to_update['type'] = args.type
-            print("[DEPRECATION] `type` is no longer a required arg for `monitor update` and may be omitted")
+            msg = "[DEPRECATION] `type` is no longer required to `update` and may be omitted"
+            warnings.warn(msg, DeprecationWarning)
         if args.query:
             to_update['query'] = args.query
-            print("[DEPRECATION] `query` is no longer a required arg for `monitor update` and may be omitted")
+            msg = "[DEPRECATION] `query` is no longer required to `update` and may be omitted"
+            warnings.warn(msg, DeprecationWarning)
         if args.name:
             to_update['name'] = args.name
         if args.message:
             to_update['message'] = args.message
-        if args.options:
-            to_update['options'] = args.options
+
+        if args.options is not None:
+            try:
+                to_update['options'] = json.loads(args.options)
+            except:
+                raise Exception('bad json parameter')
 
         res = api.Monitor.update(args.monitor_id, **to_update)
 

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -55,9 +55,9 @@ class MonitorClient(object):
             default=None
         )
         update_parser.add_argument('--type', help="type of the monitor, e.g. "
-                                   "'metric alert' 'service check'", default=None)
+                                   "'metric alert' 'service check'", default=None, dest='type_opt')
         update_parser.add_argument('--query', help="query to notify on with syntax varying"
-                                   " depending on monitor type", default=None)
+                                   " depending on monitor type", default=None, dest='query_opt')
         update_parser.add_argument('--name', help="name of the alert", default=None)
         update_parser.add_argument('--message', help="message to include with "
                                    "notifications for this monitor", default=None)
@@ -166,17 +166,29 @@ class MonitorClient(object):
 
         to_update = {}
         if args.type:
-            to_update['type'] = args.type
+            if args.type_opt:
+                msg = '[WARNING] Duplicate arguments for `type`. Using optional value --type'
+                print(msg)
+            else:
+                to_update['type'] = args.type
             msg = "[DEPRECATION] `type` is no longer required to `update` and may be omitted"
             warnings.warn(msg, DeprecationWarning)
         if args.query:
-            to_update['query'] = args.query
+            if args.query_opt:
+                msg = '[WARNING] Duplicate arguments for `query`. Using optional value --query'
+                print(msg)
+            else:
+                to_update['query'] = args.query
             msg = "[DEPRECATION] `query` is no longer required to `update` and may be omitted"
             warnings.warn(msg, DeprecationWarning)
         if args.name:
             to_update['name'] = args.name
         if args.message:
             to_update['message'] = args.message
+        if args.type_opt:
+            to_update['type'] = args.type_opt
+        if args.query_opt:
+            to_update['query'] = args.query_opt
 
         if args.options is not None:
             try:

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -39,10 +39,10 @@ class MonitorClient(object):
 
         update_parser = verb_parsers.add_parser('update', help="Update existing monitor")
         update_parser.add_argument('monitor_id', help="monitor to replace with the new definition")
-        update_parser.add_argument('type', help="type of the monitor, e.g. "
-                                   "'metric alert' 'service check'")
-        update_parser.add_argument('query', help="query to notify on with syntax varying"
-                                   " depending on what type of monitor you are creating")
+        update_parser.add_argument('--type', help="type of the monitor, e.g. "
+                                   "'metric alert' 'service check'", default=None)
+        update_parser.add_argument('--query', help="query to notify on with syntax varying"
+                                   " depending on what type of monitor you are creating", default=None)
         update_parser.add_argument('--name', help="name of the alert", default=None)
         update_parser.add_argument('--message', help="message to include with "
                                    "notifications for this monitor", default=None)

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -39,10 +39,14 @@ class MonitorClient(object):
 
         update_parser = verb_parsers.add_parser('update', help="Update existing monitor")
         update_parser.add_argument('monitor_id', help="monitor to replace with the new definition")
+        update_parser.add_argument('type', nargs='?', help="[Deprecated] optional argument preferred"
+                                    "type of the monitor, e.g. 'metric alert' 'service check'", default=None)
+        update_parser.add_argument('query', nargs='?', help="[Deprecated] optional argument preferred"
+                                    "query to notify on with syntax varying depending on monitor type", default=None)
         update_parser.add_argument('--type', help="type of the monitor, e.g. "
                                    "'metric alert' 'service check'", default=None)
         update_parser.add_argument('--query', help="query to notify on with syntax varying"
-                                   " depending on what type of monitor you are creating", default=None)
+                                   " depending on monitor type", default=None)
         update_parser.add_argument('--name', help="name of the alert", default=None)
         update_parser.add_argument('--message', help="message to include with "
                                    "notifications for this monitor", default=None)
@@ -154,8 +158,23 @@ class MonitorClient(object):
                 options = json.loads(args.options)
             except:
                 raise Exception('bad json parameter')
-        res = api.Monitor.update(args.monitor_id, type=args.type, query=args.query,
-                                 name=args.name, message=args.message, options=options)
+
+        to_update = {}
+        if args.type:
+            to_update['type'] = args.type
+            print("[DEPRECATION] `type` is no longer a required arg for `monitor update` and may be omitted")
+        if args.query:
+            to_update['query'] = args.query
+            print("[DEPRECATION] `query` is no longer a required arg for `monitor update` and may be omitted")
+        if args.name:
+            to_update['name'] = args.name
+        if args.message:
+            to_update['message'] = args.message
+        if args.options:
+            to_update['options'] = args.options
+
+        res = api.Monitor.update(args.monitor_id, **to_update)
+
         report_warnings(res)
         report_errors(res)
         if format == 'pretty':

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -8,7 +8,6 @@ from datadog.util.format import pretty_json
 # datadog
 from datadog import api
 from datadog.dogshell.common import report_errors, report_warnings, print_err
-import warnings
 
 class MonitorClient(object):
     @classmethod

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -9,6 +9,7 @@ from datadog.util.format import pretty_json
 from datadog import api
 from datadog.dogshell.common import report_errors, report_warnings, print_err
 
+
 class MonitorClient(object):
     @classmethod
     def setup_parser(cls, subparsers):

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -314,6 +314,19 @@ class TestDogshell:
         assert out["options"]["notify_no_data"] == options["notify_no_data"]
         assert out["options"]["no_data_timeframe"] == options["no_data_timeframe"]
 
+        # Update message only
+        updated_message = "monitor updated"
+        out, err, return_code = self.dogshell(
+            ["monitor", "update", "--message", updated_message])
+
+        assert "id" in out, out
+        assert "message" in out, out
+        out = json.loads(out)
+        self.assertEquals(out["message"], 'updated_message')
+        #confirming no other changes but message
+        self.assertEquals(out['query'], query)
+        self.assertEquals(out['type_alert'], type_alert)
+
         # Mute monitor
         out, _, _ = self.dogshell(["monitor", "mute", str(out["id"])])
         out = json.loads(out)

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -310,7 +310,7 @@ class TestDogshell:
         )
 
         out = json.loads(out)
-        assert out["query"] == query
+        assert query in out['query']
         assert out["options"]["notify_no_data"] == options["notify_no_data"]
         assert out["options"]["no_data_timeframe"] == options["no_data_timeframe"]
 
@@ -319,13 +319,14 @@ class TestDogshell:
         out, err, return_code = self.dogshell(
             ["monitor", "update", "--message", updated_message])
 
-        assert "id" in out, out
-        assert "message" in out, out
+        assert "id" in out
+        assert "message" in out
         out = json.loads(out)
-        self.assertEquals(out["message"], updated_message)
+        assert updated_message in out["message"]
+
         #confirming no other changes but message
-        self.assertEquals(out['query'], query)
-        self.assertEquals(out['type_alert'], type_alert)
+        assert query in out['query']
+        assert type_alert in out['type_alert']
 
         # Mute monitor
         out, _, _ = self.dogshell(["monitor", "mute", str(out["id"])])

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -305,14 +305,17 @@ class TestDogshell:
 
         # Update options
         options = {"notify_no_data": True, "no_data_timeframe": 20}
-        out, _, _ = self.dogshell(
-            ["monitor", "update", monitor_id, type_alert, query, "--options", json.dumps(options)]
+        out, err, return_code = self.dogshell(
+            ["monitor", "update", monitor_id, type_alert, query, "--options", json.dumps(options)],
+            check_return_code=False
         )
 
         out = json.loads(out)
         assert query in out['query']
         assert out["options"]["notify_no_data"] == options["notify_no_data"]
         assert out["options"]["no_data_timeframe"] == options["no_data_timeframe"]
+        assert 'DEPRECATION' in err
+        assert return_code == 0
 
         # Update message only
         updated_message = "monitor updated"
@@ -324,20 +327,21 @@ class TestDogshell:
         out = json.loads(out)
         assert updated_message == out["message"]
         assert query == out['query']
-        assert monitor_name == out ['name']
+        assert monitor_name == out['name']
         assert current_options == out['options']
 
-        # Updating query only
+        # Updating optional type and query
         updated_query = "avg(last_15m):sum:system.net.bytes_rcvd{*} by {env} > 222"
+        updated_type = 'query alert'
 
         out, err, return_code = self.dogshell(
-            ["monitor", "update", monitor_id, "--query", updated_query]
+            ["monitor", "update", monitor_id, "--type", updated_type, "--query", updated_query]
         )
 
         out = json.loads(out)
         assert updated_query in out["query"]
         assert updated_message in out['message'] # updated_message updated in previous step
-        assert monitor_name in out ['name']
+        assert monitor_name in out['name']
         assert current_options == out['options']
 
         # Mute monitor
@@ -355,13 +359,16 @@ class TestDogshell:
         # Unmute all scopes of a monitor
         options = {"silenced": {"host:abcd1234": None, "host:abcd1235": None}}
 
-        out, _, _ = self.dogshell(
-            ["monitor", "update", monitor_id, type_alert, query, "--options", json.dumps(options)]
+        out, err, return_code = self.dogshell(
+            ["monitor", "update", monitor_id, type_alert, query, "--options", json.dumps(options)],
+            check_return_code=False
         )
 
         out = json.loads(out)
         assert out["query"] == query
         assert out["options"]["silenced"] == {"host:abcd1234": None, "host:abcd1235": None}
+        assert 'DEPRECATION' in err
+        assert return_code == 0
 
         out, _, _ = self.dogshell(["monitor", "unmute", str(out["id"]), "--all_scopes"])
         out = json.loads(out)

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -322,7 +322,7 @@ class TestDogshell:
         assert "id" in out, out
         assert "message" in out, out
         out = json.loads(out)
-        self.assertEquals(out["message"], 'updated_message')
+        self.assertEquals(out["message"], updated_message)
         #confirming no other changes but message
         self.assertEquals(out['query'], query)
         self.assertEquals(out['type_alert'], type_alert)

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -311,7 +311,7 @@ class TestDogshell:
         )
 
         out = json.loads(out)
-        assert query in out['query']
+        assert query in out["query"]
         assert out["options"]["notify_no_data"] == options["notify_no_data"]
         assert out["options"]["no_data_timeframe"] == options["no_data_timeframe"]
         assert 'DEPRECATION' in err
@@ -319,20 +319,20 @@ class TestDogshell:
 
         # Update message only
         updated_message = "monitor updated"
-        current_options = out['options']
+        current_options = out["options"]
         out, err, return_code = self.dogshell(
             ["monitor", "update", monitor_id, "--message", updated_message]
         )
 
         out = json.loads(out)
         assert updated_message == out["message"]
-        assert query == out['query']
-        assert monitor_name == out['name']
-        assert current_options == out['options']
+        assert query == out["query"]
+        assert monitor_name == out["name"]
+        assert current_options == out["options"]
 
         # Updating optional type and query
         updated_query = "avg(last_15m):sum:system.net.bytes_rcvd{*} by {env} > 222"
-        updated_type = 'query alert'
+        updated_type = "query alert"
 
         out, err, return_code = self.dogshell(
             ["monitor", "update", monitor_id, "--type", updated_type, "--query", updated_query]
@@ -340,9 +340,10 @@ class TestDogshell:
 
         out = json.loads(out)
         assert updated_query in out["query"]
-        assert updated_message in out['message'] # updated_message updated in previous step
-        assert monitor_name in out['name']
-        assert current_options == out['options']
+        assert updated_type in out["type"]
+        assert updated_message in out["message"] # updated_message updated in previous step
+        assert monitor_name in out["name"]
+        assert current_options == out["options"]
 
         # Mute monitor
         out, _, _ = self.dogshell(["monitor", "mute", str(out["id"])])
@@ -367,7 +368,7 @@ class TestDogshell:
         out = json.loads(out)
         assert out["query"] == query
         assert out["options"]["silenced"] == {"host:abcd1234": None, "host:abcd1235": None}
-        assert 'DEPRECATION' in err
+        assert "DEPRECATION" in err
         assert return_code == 0
 
         out, _, _ = self.dogshell(["monitor", "unmute", str(out["id"]), "--all_scopes"])


### PR DESCRIPTION
The `api.Monitor.update` endpoint doesn't actually require `query` or `type` so removing restrictions from the clients and updating the docs (based on a customer request).  

I updated the test in `test_dogshell.py` but wasn't able to get the test to run based on directions.  Happy to test more thoroughly but could use some guidance.