### PR TITLE
Fix graph snapshot status endpoint

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -13,7 +13,8 @@ from datadog.api.exceptions import (
     ApiNotInitialized
 )
 from datadog.api.http_client import resolve_http_client
-from datadog.util.compat import is_p3k, urljoin
+from datadog.util.compat import is_p3k
+from datadog.util.format import construct_url
 
 
 log = logging.getLogger('datadog.api')
@@ -120,8 +121,7 @@ class APIClient(object):
                 headers['Content-Type'] = 'application/json'
 
             # Construct the URL
-            start_url = urljoin(_api_host, 'api/{}/'.format(api_version))
-            url = urljoin(start_url, path)
+            url = construct_url(_api_host, api_version, path)
 
             # Process requesting
             start_time = time.time()

--- a/datadog/api/graphs.py
+++ b/datadog/api/graphs.py
@@ -47,7 +47,8 @@ class Graph(CreateableAPIResource, ActionAPIResource):
         """
         snap_path = urlparse(snapshot_url).path
         snap_path = snap_path.split('/snapshot/view/')[1].split('.png')[0]
-        snapshot_status_url = '/graph/snapshot_status/{0}'.format(snap_path)
+
+        snapshot_status_url = 'graph/snapshot_status/{0}'.format(snap_path)
 
         return super(Graph, cls)._trigger_action('GET', snapshot_status_url)
 

--- a/datadog/util/format.py
+++ b/datadog/util/format.py
@@ -4,3 +4,7 @@ import json
 
 def pretty_json(obj):
     return json.dumps(obj, sort_keys=True, indent=2)
+
+
+def construct_url(host, api_version, path):
+    return "{}/api/{}/{}".format(host.strip("/"), api_version.strip("/"), path.strip("/"))

--- a/tests/unit/util/test_format.py
+++ b/tests/unit/util/test_format.py
@@ -1,0 +1,29 @@
+import pytest
+
+from datadog.util.format import construct_url
+
+
+class TestConstructURL:
+    expected = "https://api.datadoghq.com/api/v1/graph/snapshot"
+    test_data = [
+        ("https://api.datadoghq.com", "v1", "graph/snapshot", expected),
+        ("https://api.datadoghq.com/", "v1", "graph/snapshot", expected),
+        ("https://api.datadoghq.com", "/v1", "graph/snapshot", expected),
+        ("https://api.datadoghq.com/", "/v1", "graph/snapshot", expected),
+        ("https://api.datadoghq.com", "v1/", "graph/snapshot", expected),
+        ("https://api.datadoghq.com/", "v1/", "graph/snapshot", expected),
+        ("https://api.datadoghq.com", "/v1/", "graph/snapshot", expected),
+        ("https://api.datadoghq.com/", "/v1/", "graph/snapshot", expected),
+        ("https://api.datadoghq.com", "v1", "/graph/snapshot", expected),
+        ("https://api.datadoghq.com/", "v1", "/graph/snapshot", expected),
+        ("https://api.datadoghq.com", "/v1", "/graph/snapshot", expected),
+        ("https://api.datadoghq.com/", "/v1", "/graph/snapshot", expected),
+        ("https://api.datadoghq.com", "v1/", "/graph/snapshot", expected),
+        ("https://api.datadoghq.com/", "v1/", "/graph/snapshot", expected),
+        ("https://api.datadoghq.com", "/v1/", "/graph/snapshot", expected),
+        ("https://api.datadoghq.com/", "/v1/", "/graph/snapshot", expected),
+    ]
+
+    @pytest.mark.parametrize("host,api_version,path,expected", test_data)
+    def test_construct_url(self, host, api_version, path, expected):
+        assert construct_url(host, api_version, path) == expected


### PR DESCRIPTION
Using `urljoin` led to some unexpected results depending on whether there are leading `/`.
Now uses a well defined and tested utility method, so no surprises