### PR TITLE
Fix error printing to stderr char by char

### DIFF
--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -20,9 +20,9 @@ def report_errors(res):
         errors = res['errors']
         if isinstance(errors, list):
             for error in errors:
-                print_err("ERROR: " + error)
+                print_err("ERROR: {}".format(error))
         else:
-            print_err("ERROR: " + errors)
+            print_err("ERROR: {}".format(errors))
         sys.exit(1)
     return False
 
@@ -32,9 +32,9 @@ def report_warnings(res):
         warnings = res['warnings']
         if isinstance(warnings, list):
             for warning in warnings:
-                print_err("WARNING: " + warning)
+                print_err("WARNING: {}".format(warning))
         else:
-            print_err("WARNING: " + warnings)
+            print_err("WARNING: {}".format(warnings))
         return True
     return False
 

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -17,14 +17,24 @@ def print_err(msg):
 
 def report_errors(res):
     if 'errors' in res:
-        print_err('ERROR: ' + res['errors'])
+        errors = res['errors']
+        if isinstance(errors, str):
+            print_err(errors)
+        elif isinstance(errors, list):
+            for error in errors:
+                print_err(error)
         sys.exit(1)
     return False
 
 
 def report_warnings(res):
     if 'warnings' in res:
-        print_err('WARNING: ' + res['warnings'])
+        warnings = res['warnings']
+        if isinstance(warnings, str):
+            print_err(warnings)
+        elif isinstance(warnings, list):
+            for warning in warnings:
+                print_err(warning)
         return True
     return False
 

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -17,16 +17,14 @@ def print_err(msg):
 
 def report_errors(res):
     if 'errors' in res:
-        for e in res['errors']:
-            print_err('ERROR: ' + e)
+        print_err('ERROR: ' + res['errors'])
         sys.exit(1)
     return False
 
 
 def report_warnings(res):
     if 'warnings' in res:
-        for e in res['warnings']:
-            print_err('WARNING: ' + e)
+        print_err('WARNING: ' + res['warnings'])
         return True
     return False
 

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -10,7 +10,7 @@ from datadog.util.compat import is_p3k, configparser, IterableUserDict,\
 
 def print_err(msg):
     if is_p3k():
-        print('ERROR: ' + msg + '\n', file=sys.stderr)
+        print(msg + '\n', file=sys.stderr)
     else:
         sys.stderr.write(msg + '\n')
 
@@ -19,8 +19,9 @@ def report_errors(res):
     if 'errors' in res:
         errors = res['errors']
         if isinstance(errors, str):
-            print_err(errors)
+            print_err('ERROR: ' + errors)
         elif isinstance(errors, list):
+            print('ERROR:')
             for error in errors:
                 print_err(error)
         sys.exit(1)
@@ -31,8 +32,9 @@ def report_warnings(res):
     if 'warnings' in res:
         warnings = res['warnings']
         if isinstance(warnings, str):
-            print_err(warnings)
+            print_err('WARNING' + warnings)
         elif isinstance(warnings, list):
+            print('WARNING:')
             for warning in warnings:
                 print_err(warning)
         return True

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -18,12 +18,11 @@ def print_err(msg):
 def report_errors(res):
     if 'errors' in res:
         errors = res['errors']
-        if isinstance(errors, str):
-            print_err('ERROR: ' + errors)
-        elif isinstance(errors, list):
-            print('ERROR:')
+        if isinstance(errors, list):
             for error in errors:
-                print_err(error)
+                print_err("ERROR: " + error)
+        else:
+            print_err("ERROR: " + errors)
         sys.exit(1)
     return False
 
@@ -31,12 +30,11 @@ def report_errors(res):
 def report_warnings(res):
     if 'warnings' in res:
         warnings = res['warnings']
-        if isinstance(warnings, str):
-            print_err('WARNING' + warnings)
-        elif isinstance(warnings, list):
-            print('WARNING:')
+        if isinstance(warnings, list):
             for warning in warnings:
-                print_err(warning)
+                print_err("WARNING: " + warning)
+        else:
+            print_err("WARNING: " + warnings)
         return True
     return False
 


### PR DESCRIPTION
The current error handling would result in the errors and warnings from the API JSON response to be printed to `stderr` character by character (when the API would return a string and not a list).