### PR TITLE
Fix MacOS agent config file path

### DIFF
--- a/datadog/util/config.py
+++ b/datadog/util/config.py
@@ -78,7 +78,7 @@ def _unix_config_path():
 
 
 def _mac_config_path():
-    path = os.path.join('~/.datadog-agent/agent', DATADOG_CONF)
+    path = os.path.join('~/.datadog-agent', DATADOG_CONF)
     path = os.path.expanduser(path)
     if os.path.exists(path):
         return path


### PR DESCRIPTION
Addresses #218. 
https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv5. 