### PR TITLE
Add ability to send compressed payloads for metrics and distribution

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import time
+import zlib
 
 # datadog
 from datadog.api import _api_version, _max_timeouts, _backoff_period
@@ -46,7 +47,8 @@ class APIClient(object):
 
     @classmethod
     def submit(cls, method, path, api_version=None, body=None, attach_host_name=False,
-               response_formatter=None, error_formatter=None, suppress_response_errors_on_codes=None, **params):
+               response_formatter=None, error_formatter=None, suppress_response_errors_on_codes=None,
+               compress_payload=False, **params):
         """
         Make an HTTP API request
 
@@ -73,6 +75,9 @@ class APIClient(object):
         :param suppress_response_errors_on_codes: suppress ApiError on `errors` key in the response for the given HTTP
                                                   status codes
         :type suppress_response_errors_on_codes: None|list(int)
+
+        :param compress_payload: compress the payload using zlib
+        :type compress_payload: bool
 
         :param params: dictionary to be sent in the query string of the request
         :type params: dictionary
@@ -131,6 +136,10 @@ class APIClient(object):
             if isinstance(body, dict):
                 body = json.dumps(body)
                 headers['Content-Type'] = 'application/json'
+
+            if compress_payload:
+                body = zlib.compress(body.encode("utf-8"))
+                headers["Content-Encoding"] = "deflate"
 
             # Construct the URL
             url = construct_url(_api_host, api_version, path)

--- a/datadog/api/distributions.py
+++ b/datadog/api/distributions.py
@@ -8,10 +8,13 @@ class Distribution(SendableAPIResource):
     _resource_name = 'distribution_points'
 
     @classmethod
-    def send(cls, distributions=None, attach_host_name=True, **distribution):
+    def send(cls, distributions=None, attach_host_name=True, compress_payload=False, **distribution):
         """
         Submit a distribution metric or a list of distribution metrics to the distribution metric
         API
+
+        :param compress_payload: compress the payload using zlib
+        :type compress_payload: bool
         :param metric: the name of the time series
         :type metric: string
         :param points: a (timestamp, [list of values]) pair or
@@ -33,4 +36,6 @@ class Distribution(SendableAPIResource):
             # One distribution is sent
             distribution['points'] = format_points(distribution['points'])
             series_dict = {"series": [distribution]}
-        return super(Distribution, cls).send(attach_host_name=attach_host_name, **series_dict)
+        return super(Distribution, cls).send(
+            attach_host_name=attach_host_name, compress_payload=compress_payload, **series_dict
+        )

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -47,7 +47,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
             metric['type'] = metric.pop('metric_type')
 
     @classmethod
-    def send(cls, metrics=None, attach_host_name=True, **single_metric):
+    def send(cls, metrics=None, attach_host_name=True, compress_payload=False, **single_metric):
         """
         Submit a metric or a list of metrics to the metric API
         A metric dictionary should consist of 5 keys: metric, points, host, tags, type (some of which optional),
@@ -55,6 +55,9 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
 
         :param metric: the name of the time series
         :type metric: string
+
+        :param compress_payload: compress the payload using zlib
+        :type compress_payload: bool
 
         :param metrics: a list of dictionaries, each item being a metric to send
         :type metrics: list
@@ -99,7 +102,9 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
         except KeyError:
             raise KeyError("'points' parameter is required")
 
-        return super(Metric, cls).send(attach_host_name=attach_host_name, **metrics_dict)
+        return super(Metric, cls).send(
+            attach_host_name=attach_host_name, compress_payload=compress_payload, **metrics_dict
+        )
 
     @classmethod
     def query(cls, **params):

--- a/datadog/api/resources.py
+++ b/datadog/api/resources.py
@@ -1,7 +1,6 @@
 """
 Datadog API resources.
 """
-# datadog
 
 from datadog.api.api_client import APIClient
 
@@ -56,7 +55,7 @@ class SendableAPIResource(object):
     Fork of CreateableAPIResource class with different method names
     """
     @classmethod
-    def send(cls, attach_host_name=False, id=None, **body):
+    def send(cls, attach_host_name=False, id=None, compress_payload=False, **body):
         """
         Create an API resource object
 
@@ -66,6 +65,9 @@ class SendableAPIResource(object):
         :param id: create a new resource object as a child of the given object
         :type id: id
 
+        :param compress_payload: compress the payload using zlib
+        :type compress_payload: bool
+
         :param body: new resource object attributes
         :type body: dictionary
 
@@ -74,14 +76,22 @@ class SendableAPIResource(object):
         api_version = getattr(cls, '_api_version', None)
 
         if id is None:
-            return APIClient.submit('POST', cls._resource_name, api_version, body,
-                                    attach_host_name=attach_host_name)
+            return APIClient.submit(
+                'POST',
+                cls._resource_name,
+                api_version,
+                body,
+                attach_host_name=attach_host_name,
+                compress_payload=compress_payload
+            )
 
         path = '{resource_name}/{resource_id}'.format(
             resource_name=cls._resource_name,
             resource_id=id
         )
-        return APIClient.submit('POST', path, api_version, body, attach_host_name=attach_host_name)
+        return APIClient.submit(
+            'POST', path, api_version, body, attach_host_name=attach_host_name, compress_payload=compress_payload
+        )
 
 
 class UpdatableAPIResource(object):

--- a/datadog/threadstats/reporters.py
+++ b/datadog/threadstats/reporters.py
@@ -14,11 +14,14 @@ class Reporter(object):
 
 class HttpReporter(Reporter):
 
+    def __init__(self, compress_payload=False):
+        self.compress_payload = compress_payload
+
     def flush_distributions(self, distributions):
-        api.Distribution.send(distributions)
+        api.Distribution.send(distributions, compress_payload=self.compress_payload)
 
     def flush_metrics(self, metrics):
-        api.Metric.send(metrics)
+        api.Metric.send(metrics, compress_payload=self.compress_payload)
 
     def flush_events(self, events):
         for event in events:

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -202,12 +202,14 @@ class TestDatadog:
         def retry_condition(r):
             return not r["series"]
 
-        # Send metrics with single and multi points
+        # Send metrics with single and multi points, and with compression
         assert dog.Metric.send(metric=metric_name_single, points=1, host=host_name)["status"] == "ok"
         points = [(now_ts - 60, 1), (now_ts, 2)]
         assert dog.Metric.send(metric=metric_name_list, points=points, host=host_name)["status"] == "ok"
         points = (now_ts - 60, 1)
-        assert dog.Metric.send(metric=metric_name_tuple, points=points, host=host_name)["status"] == "ok"
+        assert dog.Metric.send(
+            metric=metric_name_tuple, points=points, host=host_name, compress_payload=True
+        )["status"] == "ok"
 
         metric_query_single = get_with_retry(
             "Metric",


### PR DESCRIPTION
Our API supports zlib compressed payloads on the `series` endpoint. Leverage this to help with issue https://github.com/DataDog/datadogpy/issues/465