### PR TITLE
Fix keys in headers for some endpoints

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -105,11 +105,14 @@ class APIClient(object):
             if not api_version:
                 api_version = _api_version
 
-            # set api and app keys in params only for some endpoints
+            # set api and app keys in params only for some endpoints and thus remove keys from headers
+            # as they cannot be set in both params and headers
             if cls._set_api_and_app_keys_in_params(api_version, path):
                 params['api_key'] = _api_key
+                del headers['DD-API-KEY']
                 if _application_key:
                     params['application_key'] = _application_key
+                    del headers['DD-APPLICATION-KEY']
 
             # Attach host name to body
             if attach_host_name and body:

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -148,7 +148,8 @@ class TestInitialization(DatadogAPINoInitialization):
         self.assertEqual(options['headers']['Content-Type'], 'application/json')
         self.assertEqual(options['headers']['DD-API-KEY'], API_KEY)
         self.assertEqual(options['headers']['DD-APPLICATION-KEY'], APP_KEY)
-
+        self.assertIsNone(options['params'].get('api_key'))
+        self.assertIsNone(options['params'].get('application_key'))
 
     def test_request_parameters_api_keys_in_params(self):
         """
@@ -172,8 +173,8 @@ class TestInitialization(DatadogAPINoInitialization):
         self.assertEqual(options['headers']['Content-Type'], 'application/json')
         self.assertEqual(options['params']['api_key'], API_KEY)
         self.assertEqual(options['params']['application_key'], APP_KEY)
-
-
+        self.assertIsNone(options['headers'].get('DD-API-KEY'))
+        self.assertIsNone(options['headers'].get('DD-APPLICATION-KEY'))
 
     def test_initialize_options(self):
         """

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -148,8 +148,8 @@ class TestInitialization(DatadogAPINoInitialization):
         self.assertEqual(options['headers']['Content-Type'], 'application/json')
         self.assertEqual(options['headers']['DD-API-KEY'], API_KEY)
         self.assertEqual(options['headers']['DD-APPLICATION-KEY'], APP_KEY)
-        assert "api_key" not in options
-        assert "application_key" not in options
+        assert "api_key" not in options['params']
+        assert "application_key" not in options['params']
 
     def test_request_parameters_api_keys_in_params(self):
         """
@@ -173,8 +173,8 @@ class TestInitialization(DatadogAPINoInitialization):
         self.assertEqual(options['headers']['Content-Type'], 'application/json')
         self.assertEqual(options['params']['api_key'], API_KEY)
         self.assertEqual(options['params']['application_key'], APP_KEY)
-        assert "api_key" not in options
-        assert "application_key" not in options
+        assert "api_key" not in options['headers']
+        assert "application_key" not in options['headers']
 
     def test_initialize_options(self):
         """

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -173,8 +173,8 @@ class TestInitialization(DatadogAPINoInitialization):
         self.assertEqual(options['headers']['Content-Type'], 'application/json')
         self.assertEqual(options['params']['api_key'], API_KEY)
         self.assertEqual(options['params']['application_key'], APP_KEY)
-        assert "api_key" not in options['headers']
-        assert "application_key" not in options['headers']
+        assert "DD-API-KEY" not in options['headers']
+        assert "DD-APPLICATION-KEY" not in options['headers']
 
     def test_initialize_options(self):
         """

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -148,8 +148,8 @@ class TestInitialization(DatadogAPINoInitialization):
         self.assertEqual(options['headers']['Content-Type'], 'application/json')
         self.assertEqual(options['headers']['DD-API-KEY'], API_KEY)
         self.assertEqual(options['headers']['DD-APPLICATION-KEY'], APP_KEY)
-        self.assertIsNone(options['params'].get('api_key'))
-        self.assertIsNone(options['params'].get('application_key'))
+        assert "api_key" not in options
+        assert "application_key" not in options
 
     def test_request_parameters_api_keys_in_params(self):
         """
@@ -173,8 +173,8 @@ class TestInitialization(DatadogAPINoInitialization):
         self.assertEqual(options['headers']['Content-Type'], 'application/json')
         self.assertEqual(options['params']['api_key'], API_KEY)
         self.assertEqual(options['params']['application_key'], APP_KEY)
-        self.assertIsNone(options['headers'].get('DD-API-KEY'))
-        self.assertIsNone(options['headers'].get('DD-APPLICATION-KEY'))
+        assert "api_key" not in options
+        assert "application_key" not in options
 
     def test_initialize_options(self):
         """


### PR DESCRIPTION
Attempts to fix integration test failures. Follow up from #446.
Also assess that keys aren't in both params and headers.