### PR TITLE
Add test to check CfgNotFound exception

### DIFF
--- a/datadog/util/hostname.py
+++ b/datadog/util/hostname.py
@@ -50,9 +50,9 @@ def get_hostname(hostname_from_config):
     hostname = None
     config = None
 
-    # first, try the config
-    try:
-        if hostname_from_config:
+    # first, try the config if hostname_from_config is set to True
+    if hostname_from_config:
+        try:
             config = get_config()
             config_hostname = config.get('hostname')
             if config_hostname and is_valid_hostname(config_hostname):
@@ -60,8 +60,8 @@ def get_hostname(hostname_from_config):
                             "in an upcoming version of datadogpy. Set hostname_from_config to False "
                             "to get rid of this warning")
                 return config_hostname
-    except CfgNotFound:
-        log.warning("No agent or invalid configuration file found")
+        except CfgNotFound:
+            log.warning("No agent or invalid configuration file found")
 
     # Try to get GCE instance name
     if hostname is None:

--- a/datadog/util/hostname.py
+++ b/datadog/util/hostname.py
@@ -51,8 +51,8 @@ def get_hostname(hostname_from_config):
     config = None
 
     # first, try the config if hostname_from_config is set to True
-    if hostname_from_config:
-        try:
+    try:
+        if hostname_from_config:
             config = get_config()
             config_hostname = config.get('hostname')
             if config_hostname and is_valid_hostname(config_hostname):
@@ -60,8 +60,8 @@ def get_hostname(hostname_from_config):
                             "in an upcoming version of datadogpy. Set hostname_from_config to False "
                             "to get rid of this warning")
                 return config_hostname
-        except CfgNotFound:
-            log.warning("No agent or invalid configuration file found")
+    except CfgNotFound:
+        log.warning("No agent or invalid configuration file found")
 
     # Try to get GCE instance name
     if hostname is None:

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -39,6 +39,8 @@ from tests.unit.api.helper import (
     HOST_NAME,
     FAKE_PROXY
 )
+from datadog.util.hostname import CfgNotFound, get_hostname
+
 from tests.util.contextmanagers import EnvVars
 
 
@@ -116,9 +118,15 @@ class TestInitialization(DatadogAPINoInitialization):
         initialize()
         self.assertEqual(api._host_name, HOST_NAME, api._host_name)
 
+    def test_hostname_warning_not_present(self):
+        try:
+            get_hostname(hostname_from_config=False)
+        except CfgNotFound:
+            pytest.fail("Unexpected CfgNotFound Exception")
+
     def test_errors_suppressed(self):
         """
-        API `errors` field ApiError supppressed when specified
+        API `errors` field ApiError suppressed when specified
         """
         # Test API, application keys, API host, and some HTTP client options
         initialize(api_key=API_KEY, app_key=APP_KEY, api_host=API_HOST)


### PR DESCRIPTION
Adds test to ensure the `CfgNotFound` is not raised when `hostname_from_config` is set to true (and thus the second warning message is not emitted either).