### PR TITLE
Add warning option for dogwrap based on exit codes

### DIFF
--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -19,7 +19,8 @@ dogwrap -n test-job -k $API_KEY --timeout=1 "sleep 3"
 '''
 # stdlib
 from __future__ import print_function
-import optparse
+import argparse
+import os
 import subprocess
 import sys
 import threading
@@ -33,6 +34,7 @@ from datadog.util.compat import is_p3k
 
 SUCCESS = 'success'
 ERROR = 'error'
+WARNING = 'warning'
 
 MAX_EVENT_BODY_LENGTH = 3000
 
@@ -223,95 +225,112 @@ def parse_options(raw_args=None):
     '''
     Parse the raw command line options into an options object and the remaining command string
     '''
-    parser = optparse.OptionParser(usage="%prog -n [event_name] -k [api_key] --submit_mode \
+    parser = argparse.ArgumentParser(usage="prog -n [event_name] -k [api_key] --submit_mode \
 [ all | errors ] [options] \"command\". \n\nNote that you need to enclose your command in \
 quotes to prevent python executing as soon as there is a space in your command. \n \nNOTICE: In \
 normal mode, the whole stderr is printed before stdout, in flush_live mode they will be mixed but \
 there is not guarantee that messages sent by the command on both stderr and stdout are printed in \
-the order they were sent.", version="%prog {0}".format(get_version()))
+the order they were sent.", epilog="%prog {0}".format(get_version()))
 
-    parser.add_option('-n', '--name', action='store', type='string', help="the name of the event \
+    parser.add_argument('-n', '--name', action='store', help="the name of the event \
 as it should appear on your Datadog stream")
-    parser.add_option('-k', '--api_key', action='store', type='string',
+    parser.add_argument('--config', help="location of your dogrc file (default ~/.dogrc)",
+                        default=os.path.expanduser('~/.dogrc'))
+    parser.add_argument('-k', '--api_key', action='store',
                       help="your DataDog API Key")
-    parser.add_option('-m', '--submit_mode', action='store', type='choice',
+    parser.add_argument('-m', '--submit_mode', action='store',
                       default='errors', choices=['errors', 'all'], help="[ all | errors ] if set \
 to error, an event will be sent only of the command exits with a non zero exit status or if it \
 times out.")
-    parser.add_option('-p', '--priority', action='store', type='choice', choices=['normal', 'low'],
+    parser.add_argument('-w', '--warning', nargs='+', action='store', type=int, \
+                        help="a whitespace separated list of exit codes, treated as warnings", default=None)
+    parser.add_argument('-p', '--priority', action='store', choices=['normal', 'low'],
                       help="the priority of the event (default: 'normal')")
-    parser.add_option('-t', '--timeout', action='store', type='int', default=60 * 60 * 24,
+    parser.add_argument('-t', '--timeout', action='store', type=int, default=60 * 60 * 24,
                       help="(in seconds)  a timeout after which your command must be aborted. An \
 event will be sent to your DataDog stream (default: 24hours)")
-    parser.add_option('--sigterm_timeout', action='store', type='int', default=60 * 2,
+    parser.add_argument('--sigterm_timeout', action='store', type=int, default=60 * 2,
                       help="(in seconds)  When your command times out, the \
 process it triggers is sent a SIGTERM. If this sigterm_timeout is reached, it will be sent a \
 SIGKILL signal. (default: 2m)")
-    parser.add_option('--sigkill_timeout', action='store', type='int', default=60,
+    parser.add_argument('--sigkill_timeout', action='store', type=int, default=60,
                       help="(in seconds) how long to wait at most after SIGKILL \
                               has been sent (default: 60s)")
-    parser.add_option('--proc_poll_interval', action='store', type='float', default=0.5,
+    parser.add_argument('--proc_poll_interval', action='store', type=float, default=0.5,
                       help="(in seconds). interval at which your command will be polled \
 (default: 500ms)")
-    parser.add_option('--notify_success', action='store', type='string', default='',
+    parser.add_argument('--notify_success', action='store', default='',
                       help="a message string and @people directives to send notifications in \
 case of success.")
-    parser.add_option('--notify_error', action='store', type='string', default='',
+    parser.add_argument('--notify_error', action='store', default='',
                       help="a message string and @people directives to send notifications in \
 case of error.")
-    parser.add_option('-b', '--buffer_outs', action='store_true', dest='buffer_outs', default=False,
+    parser.add_argument('--notify_warning', action='store', default='',
+                        help="a message string and @people directives to send notifications in \
+    case of warning.")
+    parser.add_argument('-b', '--buffer_outs', action='store_true', dest='buffer_outs', default=False,
                       help="displays the stderr and stdout of the command only once it has \
 returned (the command outputs remains buffered in dogwrap meanwhile)")
-    parser.add_option('--tags', action='store', type='string', dest='tags', default='',
+    parser.add_argument('--tags', action='store', dest='tags', default='',
                       help="comma separated list of tags")
 
-    options, args = parser.parse_args(args=raw_args)
+    args = parser.parse_args(args=raw_args)
 
     if is_p3k():
         cmd = ' '.join(args)
     else:
         cmd = b' '.join(args).decode('utf-8')
 
-    return options, cmd
+    return args, cmd
 
 
 def main():
-    options, cmd = parse_options()
+    args, cmd = parse_options()
 
     # If silent is checked we force the outputs to be buffered (and therefore
     # not forwarded to the Terminal streams) and we just avoid printing the
     # buffers at the end
     returncode, stdout, stderr, duration = execute(
-        cmd, options.timeout,
-        options.sigterm_timeout, options.sigkill_timeout,
-        options.proc_poll_interval, options.buffer_outs)
+        cmd, args.timeout,
+        args.sigterm_timeout, args.sigkill_timeout,
+        args.proc_poll_interval, args.buffer_outs)
 
-    initialize(api_key=options.api_key)
+    initialize(api_key=args.api_key)
     host = api._host_name
 
     if returncode == 0:
         alert_type = SUCCESS
         event_priority = 'low'
-        event_title = u'[%s] %s succeeded in %.2fs' % (host, options.name,
+        event_title = u'[%s] %s succeeded in %.2fs' % (host, args.name,
                                                        duration)
+    elif returncode in args.warning:
+        alert_type = WARNING
+        event_priority = 'normal'
+        if returncode is Timeout:
+            event_title = u'[%s] %s timed out after %.2fs' % (host, args.name, duration)
+            returncode = -1
+        else:
+            event_title = u'[%s] %s failed in %.2fs' % (host, args.name, duration)
     else:
         alert_type = ERROR
         event_priority = 'normal'
 
         if returncode is Timeout:
-            event_title = u'[%s] %s timed out after %.2fs' % (host, options.name, duration)
+            event_title = u'[%s] %s timed out after %.2fs' % (host, args.name, duration)
             returncode = -1
         else:
-            event_title = u'[%s] %s failed in %.2fs' % (host, options.name, duration)
+            event_title = u'[%s] %s failed in %.2fs' % (host, args.name, duration)
 
     notifications = ""
-    if alert_type == SUCCESS and options.notify_success:
-        notifications = options.notify_success
-    elif alert_type == ERROR and options.notify_error:
-        notifications = options.notify_error
+    if alert_type == SUCCESS and args.notify_success:
+        notifications = args.notify_success
+    elif alert_type == ERROR and args.notify_error:
+        notifications = args.notify_error
+    elif alert_type == WARNING and args.notify_warning:
+        notifications = args.notify_warning
 
-    if options.tags:
-        tags = [t.strip() for t in options.tags.split(',')]
+    if args.tags:
+        tags = [t.strip() for t in args.tags.split(',')]
     else:
         tags = None
 
@@ -319,13 +338,13 @@ def main():
 
     event = {
         'alert_type': alert_type,
-        'aggregation_key': options.name,
+        'aggregation_key': args.name,
         'host': host,
-        'priority': options.priority or event_priority,
+        'priority': args.priority or event_priority,
         'tags': tags
     }
 
-    if options.buffer_outs:
+    if args.buffer_outs:
         if is_p3k():
             stderr = stderr.decode('utf-8')
             stdout = stdout.decode('utf-8')
@@ -333,7 +352,7 @@ def main():
         print(stderr.strip(), file=sys.stderr)
         print(stdout.strip(), file=sys.stdout)
 
-    if options.submit_mode == 'all' or returncode != 0:
+    if args.submit_mode == 'all' or returncode != 0:
         api.Event.create(title=event_title, text=event_body, **event)
 
     sys.exit(returncode)

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -223,14 +223,16 @@ def build_event_body(cmd, returncode, stdout, stderr, notifications):
 
 def generate_warning_codes(option, opt, options_warning):
     try:
-        # options_warning should be a comma separated string
-        warning_codes = [options_warning.split(",")]
+        # options_warning is a string e.g.: --warning_codes 123,456,789
+        # we need to create a list from it
+        warning_codes = options_warning.split(",")
         return warning_codes
     except ValueError:
         raise optparse.OptionValueError("option %s: invalid warning codes value(s): %r" % (opt, options_warning))
 
 
 class WarningOption(optparse.Option):
+    # https://docs.python.org/3.7/library/optparse.html#adding-new-types
     TYPES = optparse.Option.TYPES + ("warning_codes",)
     TYPE_CHECKER = copy(optparse.Option.TYPE_CHECKER)
     TYPE_CHECKER["warning_codes"] = generate_warning_codes
@@ -312,8 +314,7 @@ def main():
     host = api._host_name
 
     if options.warning_codes:
-        warning_codes = generate_warning_codes(WarningOption, "--warning_codes", options.warning_codes)
-        # warning_codes = [int(w.strip()) for w in options.warning_codes.split(',')]
+        warning_codes = options.warning_codes
 
     if returncode == 0:
         alert_type = SUCCESS

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -231,7 +231,7 @@ def generate_warning_codes(option, opt, options_warning):
         raise optparse.OptionValueError("option %s: invalid warning codes value(s): %r" % (opt, options_warning))
 
 
-class WarningOption(optparse.Option):
+class DogwrapOption(optparse.Option):
     # https://docs.python.org/3.7/library/optparse.html#adding-new-types
     TYPES = optparse.Option.TYPES + ("warning_codes",)
     TYPE_CHECKER = copy(optparse.Option.TYPE_CHECKER)
@@ -247,7 +247,7 @@ def parse_options(raw_args=None):
 quotes to prevent python executing as soon as there is a space in your command. \n \nNOTICE: In \
 normal mode, the whole stderr is printed before stdout, in flush_live mode they will be mixed but \
 there is not guarantee that messages sent by the command on both stderr and stdout are printed in \
-the order they were sent.", version="%prog {0}".format(get_version()), option_class=WarningOption)
+the order they were sent.", version="%prog {0}".format(get_version()), option_class=DogwrapOption)
 
     parser.add_option('-n', '--name', action='store', type='string', help="the name of the event \
 as it should appear on your Datadog stream")

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -306,6 +306,14 @@ def main():
     elif returncode in warning_codes and options.submit_mode == 'warnings':
         alert_type = WARNING
         event_priority = 'normal'
+    elif options.submit_mode == 'warnings' and not warning_codes:
+        # Exit - warning codes need to be provided
+        print("A comma separated list of exit codes need to be provided")
+        sys.exit()
+    elif warning_codes and not options.submit_mode == 'warnings':
+        # Exit - submit mode: warning needs to be set
+        print("Submit mode --warning needs to be set")
+        sys.exit()
     else:
         alert_type = ERROR
         event_priority = 'normal'

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -124,7 +124,8 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout,
         # code when it finishes
         returncode = poll_proc(proc, proc_poll_interval, cmd_timeout)
 
-        # Let's harvest the outputs collected by our background threads after making sure they're done reading it.
+        # Let's harvest the outputs collected by our background threads
+        # after making sure they're done reading it.
         out_reader.join()
         err_reader.join()
         stdout = out_reader.content
@@ -330,7 +331,7 @@ def main():
             alert_type = WARNING
             event_priority = 'normal'
             event_title = u'[%s] %s failed in %.2fs' % (host, options.name,
-                                                           duration)
+                                                        duration)
         else:
             print("Command exited with a different exit code that the one(s) provided")
             sys.exit()

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -124,8 +124,7 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout,
         # code when it finishes
         returncode = poll_proc(proc, proc_poll_interval, cmd_timeout)
 
-        # Let's harvest the outputs collected by our background threads after
-        # making sure they're done reading it.
+        # Let's harvest the outputs collected by our background threads after making sure they're done reading it.
         out_reader.join()
         err_reader.join()
         stdout = out_reader.content
@@ -316,7 +315,7 @@ def main():
     if options.warning_codes:
         # Convert warning codes from string to int since return codes will evaluate the latter
         warning_codes = list(map(int, options.warning_codes))
-        
+
     if returncode == 0:
         alert_type = SUCCESS
         event_priority = 'low'

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -257,8 +257,8 @@ as it should appear on your Datadog stream")
                       default='errors', choices=['errors', 'warnings', 'all'], help="[ all | errors | warnings ] if set \
 to error, an event will be sent only of the command exits with a non zero exit status or if it \
 times out. If set to warning, a list of exit codes need to be provided")
-    parser.add_option('--warning_codes', action='store', type='warning_codes', dest='warning_codes', default='',
-                      help="comma separated list of warning codes")
+    parser.add_option('--warning_codes', action='store', type='warning_codes', dest='warning_codes',
+                      help="comma separated list of warning codes, e.g: 127,255")
     parser.add_option('-p', '--priority', action='store', type='choice', choices=['normal', 'low'],
                       help="the priority of the event (default: 'normal')")
     parser.add_option('-t', '--timeout', action='store', type='int', default=60 * 60 * 24,
@@ -313,6 +313,8 @@ def main():
     initialize(api_key=options.api_key)
     host = api._host_name
 
+    warning_codes = None
+
     if options.warning_codes:
         # Convert warning codes from string to int since return codes will evaluate the latter
         warning_codes = list(map(int, options.warning_codes))
@@ -323,7 +325,7 @@ def main():
         event_title = u'[%s] %s succeeded in %.2fs' % (host, options.name,
                                                        duration)
     elif returncode != 0 and options.submit_mode == 'warnings':
-        if warning_codes == ['']:
+        if not warning_codes:
             # the list of warning codes is empty - the option was not specified
             print("A comma separated list of exit codes need to be provided")
             sys.exit()

--- a/tests/unit/dogwrap/test_dogwrap.py
+++ b/tests/unit/dogwrap/test_dogwrap.py
@@ -28,13 +28,13 @@ class TestDogwrap(unittest.TestCase):
 
     def test_build_event_body(self):
         # Only cmd is already unicode, the rest is decoded in the function
-        cmd = u"yö dudes"
+        cmd = u"yö friends"
         returncode = 0
         stdout = b"s\xc3\xb9p\xaa"
         stderr = b"d\xc3\xa0wg\xaa"
         notifications = b"@m\xc3\xa9\xaa"
         expected_body = u"%%%\n" \
-            u"**>>>> CMD <<<<**\n```\nyö dudes \n```\n" \
+            u"**>>>> CMD <<<<**\n```\nyö friends \n```\n" \
             u"**>>>> EXIT CODE <<<<**\n\n 0\n\n\n" \
             u"**>>>> STDOUT <<<<**\n```\nsùp\ufffd \n```\n" \
             u"**>>>> STDERR <<<<**\n```\ndàwg\ufffd \n```\n" \
@@ -45,7 +45,7 @@ class TestDogwrap(unittest.TestCase):
         self.assertEqual(expected_body, event_body)
 
     def test_parse_options(self):
-        options, cmd = parse_options([])
+        args, cmd = parse_options()
         self.assertEqual(cmd, '')
 
         # The output of parse_args is already unicode in python 3, so don't encode the input
@@ -54,24 +54,26 @@ class TestDogwrap(unittest.TestCase):
         else:
             arg = u'helløøééé'.encode('utf-8')
 
-        options, cmd = parse_options(['-n', 'name', '-k', 'key', '-m', 'all', '-p', 'low', '-t', '123',
+        args, cmd = parse_options(['-n', 'name', '-k', 'key', '-m', 'all', '-p', 'low', '-t', '123',
                                       '--sigterm_timeout', '456', '--sigkill_timeout', '789',
                                       '--proc_poll_interval', '1.5', '--notify_success', 'success',
-                                      '--notify_error', 'error', '-b', '--tags', 'k1:v1,k2:v2',
+                                      '--notify_error', 'error', '--notify_warning', 'warning', '-b',
+                                      '--tags', 'k1:v1,k2:v2',
                                       'echo', arg])
         self.assertEqual(cmd, u'echo helløøééé')
-        self.assertEqual(options.name, 'name')
-        self.assertEqual(options.api_key, 'key')
-        self.assertEqual(options.submit_mode, 'all')
-        self.assertEqual(options.priority, 'low')
-        self.assertEqual(options.timeout, 123)
-        self.assertEqual(options.sigterm_timeout, 456)
-        self.assertEqual(options.sigkill_timeout, 789)
-        self.assertEqual(options.proc_poll_interval, 1.5)
-        self.assertEqual(options.notify_success, 'success')
-        self.assertEqual(options.notify_error, 'error')
-        self.assertTrue(options.buffer_outs)
-        self.assertEqual(options.tags, 'k1:v1,k2:v2')
+        self.assertEqual(args.name, 'name')
+        self.assertEqual(args.api_key, 'key')
+        self.assertEqual(args.submit_mode, 'all')
+        self.assertEqual(args.priority, 'low')
+        self.assertEqual(args.timeout, 123)
+        self.assertEqual(args.sigterm_timeout, 456)
+        self.assertEqual(args.sigkill_timeout, 789)
+        self.assertEqual(args.proc_poll_interval, 1.5)
+        self.assertEqual(args.notify_success, 'success')
+        self.assertEqual(args.notify_error, 'error')
+        self.assertEqual(args.notify_warning, 'warning')
+        self.assertTrue(args.buffer_outs)
+        self.assertEqual(args.tags, 'k1:v1,k2:v2')
 
         with self.assertRaises(SystemExit):
             parse_options(['-m', 'invalid'])

--- a/tests/unit/dogwrap/test_dogwrap.py
+++ b/tests/unit/dogwrap/test_dogwrap.py
@@ -28,13 +28,13 @@ class TestDogwrap(unittest.TestCase):
 
     def test_build_event_body(self):
         # Only cmd is already unicode, the rest is decoded in the function
-        cmd = u"yö friends"
+        cmd = u"yö dudes"
         returncode = 0
         stdout = b"s\xc3\xb9p\xaa"
         stderr = b"d\xc3\xa0wg\xaa"
         notifications = b"@m\xc3\xa9\xaa"
         expected_body = u"%%%\n" \
-            u"**>>>> CMD <<<<**\n```\nyö friends \n```\n" \
+            u"**>>>> CMD <<<<**\n```\nyö dudes \n```\n" \
             u"**>>>> EXIT CODE <<<<**\n\n 0\n\n\n" \
             u"**>>>> STDOUT <<<<**\n```\nsùp\ufffd \n```\n" \
             u"**>>>> STDERR <<<<**\n```\ndàwg\ufffd \n```\n" \
@@ -45,7 +45,7 @@ class TestDogwrap(unittest.TestCase):
         self.assertEqual(expected_body, event_body)
 
     def test_parse_options(self):
-        args, cmd = parse_options()
+        options, cmd = parse_options([])
         self.assertEqual(cmd, '')
 
         # The output of parse_args is already unicode in python 3, so don't encode the input
@@ -54,26 +54,24 @@ class TestDogwrap(unittest.TestCase):
         else:
             arg = u'helløøééé'.encode('utf-8')
 
-        args, cmd = parse_options(['-n', 'name', '-k', 'key', '-m', 'all', '-p', 'low', '-t', '123',
+        options, cmd = parse_options(['-n', 'name', '-k', 'key', '-m', 'all', '-p', 'low', '-t', '123',
                                       '--sigterm_timeout', '456', '--sigkill_timeout', '789',
                                       '--proc_poll_interval', '1.5', '--notify_success', 'success',
-                                      '--notify_error', 'error', '--notify_warning', 'warning', '-b',
-                                      '--tags', 'k1:v1,k2:v2',
+                                      '--notify_error', 'error', '-b', '--tags', 'k1:v1,k2:v2',
                                       'echo', arg])
         self.assertEqual(cmd, u'echo helløøééé')
-        self.assertEqual(args.name, 'name')
-        self.assertEqual(args.api_key, 'key')
-        self.assertEqual(args.submit_mode, 'all')
-        self.assertEqual(args.priority, 'low')
-        self.assertEqual(args.timeout, 123)
-        self.assertEqual(args.sigterm_timeout, 456)
-        self.assertEqual(args.sigkill_timeout, 789)
-        self.assertEqual(args.proc_poll_interval, 1.5)
-        self.assertEqual(args.notify_success, 'success')
-        self.assertEqual(args.notify_error, 'error')
-        self.assertEqual(args.notify_warning, 'warning')
-        self.assertTrue(args.buffer_outs)
-        self.assertEqual(args.tags, 'k1:v1,k2:v2')
+        self.assertEqual(options.name, 'name')
+        self.assertEqual(options.api_key, 'key')
+        self.assertEqual(options.submit_mode, 'all')
+        self.assertEqual(options.priority, 'low')
+        self.assertEqual(options.timeout, 123)
+        self.assertEqual(options.sigterm_timeout, 456)
+        self.assertEqual(options.sigkill_timeout, 789)
+        self.assertEqual(options.proc_poll_interval, 1.5)
+        self.assertEqual(options.notify_success, 'success')
+        self.assertEqual(options.notify_error, 'error')
+        self.assertTrue(options.buffer_outs)
+        self.assertEqual(options.tags, 'k1:v1,k2:v2')
 
         with self.assertRaises(SystemExit):
             parse_options(['-m', 'invalid'])


### PR DESCRIPTION
Add a warning option based on exit codes provided by the user.
Warning exit codes should be a comma separated list such as `--warning_codes 123,345,678`.