### PR TITLE
dogshell: remove Exception wrapping

### DIFF
--- a/datadog/dogshell/dashboard.py
+++ b/datadog/dogshell/dashboard.py
@@ -79,10 +79,7 @@ class DashboardClient(object):
         widgets = args.widgets
         if args.widgets is None:
             widgets = sys.stdin.read()
-        try:
-            widgets = json.loads(widgets)
-        except Exception:
-            raise Exception('bad json parameter')
+        widgets = json.loads(widgets)
 
         # Required arguments
         payload = {
@@ -115,10 +112,7 @@ class DashboardClient(object):
         widgets = args.widgets
         if args.widgets is None:
             widgets = sys.stdin.read()
-        try:
-            widgets = json.loads(widgets)
-        except Exception:
-            raise Exception('bad json parameter')
+        widgets = json.loads(widgets)
 
         # Required arguments
         payload = {

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -124,10 +124,7 @@ class MonitorClient(object):
         format = args.format
         options = None
         if args.options is not None:
-            try:
-                options = json.loads(args.options)
-            except Exception:
-                raise Exception('bad json parameter')
+            options = json.loads(args.options)
 
         if args.tags:
             tags = sorted(set([t.strip() for t in args.tags.split(',') if t.strip()]))
@@ -190,10 +187,7 @@ class MonitorClient(object):
             to_update['query'] = args.query_opt
 
         if args.options is not None:
-            try:
-                to_update['options'] = json.loads(args.options)
-            except Exception:
-                raise Exception('bad json parameter')
+            to_update['options'] = json.loads(args.options)
 
         res = api.Monitor.update(args.monitor_id, **to_update)
 

--- a/datadog/dogshell/screenboard.py
+++ b/datadog/dogshell/screenboard.py
@@ -107,10 +107,7 @@ class ScreenboardClient(object):
     def _push(cls, args):
         api._timeout = args.timeout
         for f in args.file:
-            try:
-                screen_obj = json.load(f)
-            except Exception as err:
-                raise Exception("Could not parse {0}: {1}".format(f.name, err))
+            screen_obj = json.load(f)
 
             if args.append_auto_text:
                 datetime_str = datetime.now().strftime('%x %X')
@@ -172,10 +169,7 @@ class ScreenboardClient(object):
         graphs = args.graphs
         if args.graphs is None:
             graphs = sys.stdin.read()
-        try:
-            graphs = json.loads(graphs)
-        except Exception:
-            raise Exception('bad json parameter')
+        graphs = json.loads(graphs)
         res = api.Screenboard.create(
             title=args.title, description=args.description, graphs=[graphs],
             template_variables=args.template_variables, width=args.width, height=args.height)
@@ -193,10 +187,7 @@ class ScreenboardClient(object):
         graphs = args.graphs
         if args.graphs is None:
             graphs = sys.stdin.read()
-        try:
-            graphs = json.loads(graphs)
-        except Exception:
-            raise Exception('bad json parameter')
+        graphs = json.loads(graphs)
 
         res = api.Screenboard.update(
             args.screenboard_id, board_title=args.title, description=args.description,
@@ -269,10 +260,7 @@ class ScreenboardClient(object):
         graphs = args.graphs
         if args.graphs is None:
             graphs = sys.stdin.read()
-        try:
-            graphs = json.loads(graphs)
-        except Exception:
-            raise Exception('bad json parameter')
+        graphs = json.loads(graphs)
         res = api.Screenboard.create(board_title=args.filename,
                                      description="Description for {0}".format(args.filename),
                                      widgets=[graphs])

--- a/datadog/dogshell/timeboard.py
+++ b/datadog/dogshell/timeboard.py
@@ -139,10 +139,7 @@ class TimeboardClient(object):
         graphs = args.graphs
         if args.graphs is None:
             graphs = sys.stdin.read()
-        try:
-            graphs = json.loads(graphs)
-        except Exception:
-            raise Exception('bad json parameter')
+        graphs = json.loads(graphs)
         res = api.Timeboard.create(
             title=args.filename,
             description="Description for {0}".format(args.filename),
@@ -234,10 +231,7 @@ class TimeboardClient(object):
         graphs = args.graphs
         if args.graphs is None:
             graphs = sys.stdin.read()
-        try:
-            graphs = json.loads(graphs)
-        except Exception:
-            raise Exception('bad json parameter')
+        graphs = json.loads(graphs)
         res = api.Timeboard.create(title=args.title, description=args.description, graphs=[graphs],
                                    template_variables=args.template_variables)
         report_warnings(res)
@@ -254,10 +248,7 @@ class TimeboardClient(object):
         graphs = args.graphs
         if args.graphs is None:
             graphs = sys.stdin.read()
-        try:
-            graphs = json.loads(graphs)
-        except Exception:
-            raise Exception('bad json parameter')
+        graphs = json.loads(graphs)
 
         res = api.Timeboard.update(args.timeboard_id, title=args.title,
                                    description=args.description, graphs=graphs,


### PR DESCRIPTION
Hiding the real JSON exception to hide behind a generic Exception is not a good
practice and does not add any value.