### PR TITLE
Set API Key in URL when submit distribution metrics

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -273,6 +273,7 @@ class APIClient(object):
         constructed_path = construct_path(api_version, path)
 
         set_of_paths = {
+            "v1/distribution_points",
             "v1/series",
             "v1/check_run",
             "v1/events",

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -259,6 +259,25 @@ class TestDatadog:
         assert len(metric_query_tuple["series"][0]["pointlist"]) == 1
         assert metric_query_tuple["series"][0]["pointlist"][0][1] == 1
 
+    def test_distribution_metrics(self):
+        now = datetime.datetime.now()
+        now_ts = int(time.mktime(now.timetuple()))
+        metric_name = "test.distribution_metric." + str(now_ts)
+        host_name = "test.host." + str(now_ts)
+
+        # Submit a distribution metric
+        assert dog.Distribution.send(
+            distributions=[{
+                'metric': metric_name,
+                'points': [(now_ts - 60, [1.0])],
+                'type': 'distribution',
+                'host': host_name,
+            }]
+        )["status"] == "ok"
+
+        # FIXME: Query and verify the test metric result. Currently, it takes
+        # too long for a new distribution metric to become available for query.
+
     def test_graph_snapshot(self):
         metric_query = "system.load.1{*}"
         event_query = "*"


### PR DESCRIPTION
`api.Distribution.send` no longer works after https://github.com/DataDog/datadogpy/pull/446, as endpoint `v1/distribution_points` still expects the api key in the URL parameter than header.

To reproduce:
```python
from datadog import initialize, api
options = {
    'api_key':'<API-KEY>',
    'app_key':'<APP-KEY>'
}
initialize(**options)

# submitting a regular metric point works
api.Metric.send(metric='my.test.metric', points=1)

# submitting a distribution metric point gets error 'No api key specified'
api.Distribution.send(distributions=[{
    'metric': 'my.dist.test',
    'points': [(1573757950, [1.0])],
    'host': None,
}])
```