### PR TITLE
Roles and Permissions APIs

### DIFF
--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -36,5 +36,7 @@ from datadog.api.hosts import Host, Hosts
 from datadog.api.service_checks import ServiceCheck
 from datadog.api.tags import Tag
 from datadog.api.users import User
+from datadog.api.roles import Roles
+from datadog.api.permissions import Permissions
 from datadog.api.service_level_objectives import ServiceLevelObjective
 from datadog.api.synthetics import Synthetics

--- a/datadog/api/permissions.py
+++ b/datadog/api/permissions.py
@@ -3,7 +3,7 @@ from datadog.api.resources import ActionAPIResource, CreateableAPIResource, Cust
 
 
 class Permissions(ActionAPIResource, CreateableAPIResource, CustomUpdatableAPIResource, GetableAPIResource,
-            ListableAPIResource, DeletableAPIResource):
+                ListableAPIResource, DeletableAPIResource):
     """
     A wrapper around Tag HTTP API.
     """

--- a/datadog/api/permissions.py
+++ b/datadog/api/permissions.py
@@ -1,0 +1,11 @@
+from datadog.api.resources import ActionAPIResource, CreateableAPIResource, CustomUpdatableAPIResource, \
+    DeletableAPIResource, GetableAPIResource, ListableAPIResource
+
+
+class Permissions(ActionAPIResource, CreateableAPIResource, CustomUpdatableAPIResource, GetableAPIResource,
+            ListableAPIResource, DeletableAPIResource):
+    """
+    A wrapper around Tag HTTP API.
+    """
+    _resource_name = 'permissions'
+    _api_version = 'v2'

--- a/datadog/api/permissions.py
+++ b/datadog/api/permissions.py
@@ -3,7 +3,7 @@ from datadog.api.resources import ActionAPIResource, CreateableAPIResource, Cust
 
 
 class Permissions(ActionAPIResource, CreateableAPIResource, CustomUpdatableAPIResource, GetableAPIResource,
-                ListableAPIResource, DeletableAPIResource):
+                  ListableAPIResource, DeletableAPIResource):
     """
     A wrapper around Tag HTTP API.
     """

--- a/datadog/api/resources.py
+++ b/datadog/api/resources.py
@@ -132,6 +132,12 @@ class CustomUpdatableAPIResource(object):
         """
         Update an API resource object
 
+        :param method: HTTP method, defaults to PUT
+        :type params: string
+
+        :param params: updatable resource id
+        :type params: string
+
         :param params: updated resource object source
         :type params: dictionary
 

--- a/datadog/api/resources.py
+++ b/datadog/api/resources.py
@@ -123,6 +123,38 @@ class UpdatableAPIResource(object):
         return APIClient.submit('PUT', path, api_version, body, **params)
 
 
+class CustomUpdatableAPIResource(object):
+    """
+    Updatable API Resource with custom HTTP Verb
+    """
+    @classmethod
+    def update(cls, method=None, id=None, params=None, **body):
+        """
+        Update an API resource object
+
+        :param params: updated resource object source
+        :type params: dictionary
+
+        :param body: updated resource object attributes
+        :type body: dictionary
+
+        :returns: Dictionary representing the API's JSON response
+        """
+
+        if method is None:
+            method = 'PUT'
+        if params is None:
+            params = {}
+
+        path = '{resource_name}/{resource_id}'.format(
+            resource_name=cls._resource_name,
+            resource_id=id
+        )
+        api_version = getattr(cls, '_api_version', None)
+
+        return APIClient.submit(method, path, api_version, body, **params)
+
+
 class DeletableAPIResource(object):
     """
     Deletable API Resource

--- a/datadog/api/roles.py
+++ b/datadog/api/roles.py
@@ -1,0 +1,60 @@
+from datadog.api.resources import ActionAPIResource, CreateableAPIResource, CustomUpdatableAPIResource,\
+    DeletableAPIResource, GetableAPIResource, ListableAPIResource
+
+from datadog.api.api_client import APIClient
+
+class Roles(ActionAPIResource, CreateableAPIResource, CustomUpdatableAPIResource, GetableAPIResource,
+          ListableAPIResource, DeletableAPIResource):
+    """
+    A wrapper around Tag HTTP API.
+    """
+    _resource_name = 'roles'
+    _api_version = 'v2'
+
+    @classmethod
+    def update(cls, id, **body):
+        """
+        Update a role's attributes
+
+        :param id: uuid of the role
+        :param body: dict with type of the input and modified attributes
+        :returns: Dictionary representing the API's JSON response
+        """
+        params = {}
+        return super(Roles, cls).update("PATCH", id, params=params, **body)
+
+    @classmethod
+    def assign_permission(cls, id, **body):
+        """
+        Assign permission to a role
+
+        :param id: uuid of the role to assign permission to
+        :param body: dict with "type": "permissions" and uuid of permission to assign
+        :returns: Dictionary representing the API's JSON response
+        """
+        params = {}
+        path = '{resource_name}/{resource_id}/permissions'.format(
+            resource_name=cls._resource_name,
+            resource_id=id
+        )
+        api_version = getattr(cls, '_api_version', None)
+
+        return APIClient.submit("POST", path, api_version, body, **params)
+
+    @classmethod
+    def unassign_permission(cls, id, **body):
+        """
+        Unassign permission from a role
+
+        :param id: uuid of the role to unassign permission from
+        :param body: dict with "type": "permissions" and uuid of permission to unassign
+        :returns: Dictionary representing the API's JSON response
+        """
+        params = {}
+        path = '{resource_name}/{resource_id}/permissions'.format(
+            resource_name=cls._resource_name,
+            resource_id=id
+        )
+        api_version = getattr(cls, '_api_version', None)
+
+        return APIClient.submit("DELETE", path, api_version, body, **params)

--- a/datadog/api/roles.py
+++ b/datadog/api/roles.py
@@ -3,8 +3,9 @@ from datadog.api.resources import ActionAPIResource, CreateableAPIResource, Cust
 
 from datadog.api.api_client import APIClient
 
+
 class Roles(ActionAPIResource, CreateableAPIResource, CustomUpdatableAPIResource, GetableAPIResource,
-          ListableAPIResource, DeletableAPIResource):
+            ListableAPIResource, DeletableAPIResource):
     """
     A wrapper around Tag HTTP API.
     """


### PR DESCRIPTION
This PR implements datadog's roles and permissions apis. This implements `v2` format of Datadog's apis. Tests are also included.