### PR TITLE
[MA-665]  Add support for the `Monitor.validate` endpoint.

### DIFF
--- a/datadog/api/graphs.py
+++ b/datadog/api/graphs.py
@@ -69,7 +69,7 @@ class Embed(ListableAPIResource, GetableAPIResource, ActionAPIResource, Createab
 
         :returns: Dictionary representing the API's JSON response
         """
-        return super(Embed, cls)._trigger_class_action('GET', id=embed_id, name='enable')
+        return super(Embed, cls)._trigger_class_action('GET', id=embed_id, action_name='enable')
 
     @classmethod
     def revoke(cls, embed_id):
@@ -81,4 +81,4 @@ class Embed(ListableAPIResource, GetableAPIResource, ActionAPIResource, Createab
 
         :returns: Dictionary representing the API's JSON response
         """
-        return super(Embed, cls)._trigger_class_action('GET', id=embed_id,  name='revoke')
+        return super(Embed, cls)._trigger_class_action('GET', id=embed_id,  action_name='revoke')

--- a/datadog/api/monitors.py
+++ b/datadog/api/monitors.py
@@ -131,3 +131,12 @@ class Monitor(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
         :returns: Dictionary representing the API's JSON response
         """
         return super(Monitor, cls)._trigger_class_action('GET', 'can_delete', params=params)
+
+    @classmethod
+    def validate(cls, **body):
+        """
+        Checks if the monitors definition is valid.
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        return super(Monitor, cls)._trigger_class_action('POST', 'validate', **body)

--- a/datadog/api/resources.py
+++ b/datadog/api/resources.py
@@ -384,15 +384,15 @@ class ActionAPIResource(object):
     Actionable API Resource
     """
     @classmethod
-    def _trigger_class_action(cls, method, name, id=None, params=None, **body):
+    def _trigger_class_action(cls, method, action_name, id=None, params=None, **body):
         """
         Trigger an action
 
         :param method: HTTP method to use to contact API endpoint
         :type method: HTTP method string
 
-        :param name: action name
-        :type name: string
+        :param action_name: action name
+        :type action_name: string
 
         :param id: trigger the action for the specified resource object
         :type id: id
@@ -413,13 +413,13 @@ class ActionAPIResource(object):
         if id is None:
             path = '{resource_name}/{action_name}'.format(
                 resource_name=cls._resource_name,
-                action_name=name
+                action_name=action_name
             )
         else:
             path = '{resource_name}/{resource_id}/{action_name}'.format(
                 resource_name=cls._resource_name,
                 resource_id=id,
-                action_name=name
+                action_name=action_name
             )
         if method == "GET":
             # Do not add body to GET requests, it causes 400 Bad request responses on EU site

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -129,10 +129,10 @@ class MonitorClient(object):
         validate_parser.add_argument('type', help="type of the monitor, e.g."
                                      "'metric alert' 'service check'")
         validate_parser.add_argument('query', help="query to notify on with syntax varying "
-                                    "depending on what type of monitor you are creating")
+                                     "depending on what type of monitor you are creating")
         validate_parser.add_argument('--name', help="name of the alert", default=None)
         validate_parser.add_argument('--message', help="message to include with notifications"
-                                    " for this monitor", default=None)
+                                     " for this monitor", default=None)
         validate_parser.add_argument('--tags', help="comma-separated list of tags", default=None)
         validate_parser.add_argument('--options', help="json options for the monitor", default=None)
         validate_parser.set_defaults(func=cls._validate)

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -128,7 +128,7 @@ class MonitorClient(object):
                                                   help="Validates if a monitor definition is correct")
         validate_parser.add_argument('type', help="type of the monitor, e.g."
                                      "'metric alert' 'service check'")
-        validate_parser.add_argument('query', help="query to notify on with syntax varying "
+        validate_parser.add_argument('query', help="the monitor query"
                                      "depending on what type of monitor you are creating")
         validate_parser.add_argument('--name', help="name of the alert", default=None)
         validate_parser.add_argument('--message', help="message to include with notifications"

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -128,8 +128,7 @@ class MonitorClient(object):
                                                   help="Validates if a monitor definition is correct")
         validate_parser.add_argument('type', help="type of the monitor, e.g."
                                      "'metric alert' 'service check'")
-        validate_parser.add_argument('query', help="the monitor query"
-                                     "depending on what type of monitor you are creating")
+        validate_parser.add_argument('query', help="the monitor query")
         validate_parser.add_argument('--name', help="name of the alert", default=None)
         validate_parser.add_argument('--message', help="message to include with notifications"
                                      " for this monitor", default=None)

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -487,7 +487,7 @@ class TestDatadog:
         # Check with an invalid query.
         invalid_query = "THIS IS A BAD QUERY"
         res = dog.Monitor.validate(type=monitor_type, query=invalid_query, options=valid_options)
-        assert res == {"errors": ["thresholds parameter must be specified in the options"]}
+        assert res == {"errors": ["The value provided for parameter 'query' is invalid"]}
 
         # Check with a valid query, invalid options.
         valid_query = "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 200"

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -479,6 +479,25 @@ class TestDatadog:
             "deleted_monitor_id": monitor["id"]
         }
 
+    def test_monitor_validate(self):
+        monitor_type = "metric alert"
+        valid_options = {"thresholds": {"critical": 200.0}}
+        invalid_options = {"thresholds": {"critical": 90.0}}
+
+        # Check with an invalid query.
+        invalid_query = "THIS IS A BAD QUERY"
+        res = dog.Monitor.validate(type=monitor_type, query=invalid_query, options=valid_options)
+        assert res == {"errors": ["thresholds parameter must be specified in the options"]}
+
+        # Check with a valid query, invalid options.
+        valid_query = "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 200"
+        res = dog.Monitor.validate(type=monitor_type, query=valid_query, options=invalid_options)
+        assert res == {"errors": ["Alert threshold (90.0) does not match that used in the query (200.0)."]}
+
+        # Check with a valid query, valid options.
+        res = dog.Monitor.validate(type=monitor_type, query=valid_query, options=valid_options)
+        assert res == {}
+
     def test_monitor_can_delete(self):
         # Create a monitor.
         query = "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100"

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -438,6 +438,28 @@ class TestDogshell:
         _, _, return_code = self.dogshell(["monitor", "unmute_all"], check_return_code=False)
         assert return_code != 0
 
+        # Test validate monitor
+        monitor_type = "metric alert"
+        valid_options = {"thresholds": {"critical": 200.0}}
+        invalid_options = {"thresholds": {"critical": 90.0}}
+
+        # Check with an invalid query.
+        invalid_query = "THIS IS A BAD QUERY"
+        out, _, _ = self.dogshell(["monitor", "validate", monitor_type, invalid_query, "--options", valid_options])
+        out = json.loads(out)
+        assert out == {"errors": ["thresholds parameter must be specified in the options"]}
+
+        # Check with a valid query, invalid options.
+        valid_query = "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 200"
+        out, _, _ = self.dogshell(["monitor", "validate", monitor_type, valid_query, "--options", invalid_options])
+        out = json.loads(out)
+        assert out == {"errors": ["Alert threshold (90.0) does not match that used in the query (200.0)."]}
+
+        # Check with a valid query, valid options.
+        out, _, _ = self.dogshell(["monitor", "validate", monitor_type, valid_query, "--options", valid_options])
+        out = json.loads(out)
+        assert out == {}
+
     def test_host_muting(self):
         # Submit a metric to create a host
         hostname = "my.test.host{}".format(self.get_unique())

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -440,8 +440,8 @@ class TestDogshell:
 
         # Test validate monitor
         monitor_type = "metric alert"
-        valid_options = {"thresholds": {"critical": 200.0}}
-        invalid_options = {"thresholds": {"critical": 90.0}}
+        valid_options = '{"thresholds": {"critical": 200.0}}'
+        invalid_options = '{"thresholds": {"critical": 90.0}}'
 
         # Check with an invalid query.
         invalid_query = "THIS IS A BAD QUERY"

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -447,7 +447,7 @@ class TestDogshell:
         invalid_query = "THIS IS A BAD QUERY"
         out, _, _ = self.dogshell(["monitor", "validate", monitor_type, invalid_query, "--options", valid_options])
         out = json.loads(out)
-        assert out == {"errors": ["thresholds parameter must be specified in the options"]}
+        assert out == {"errors": ["The value provided for parameter 'query' is invalid"]}
 
         # Check with a valid query, invalid options.
         valid_query = "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 200"


### PR DESCRIPTION
@DataDog/monitor-app 

___

The `validate` endpoint can be used to check if a monitor definition is valid.