### PR TITLE
[MA-669] Add support for `/v1/downtime/cancel/by_scope`.

### DIFF
--- a/datadog/api/downtimes.py
+++ b/datadog/api/downtimes.py
@@ -1,10 +1,23 @@
 from datadog.api.resources import GetableAPIResource, CreateableAPIResource,\
-    UpdatableAPIResource, ListableAPIResource, DeletableAPIResource
+    UpdatableAPIResource, ListableAPIResource, DeletableAPIResource, \
+    ActionAPIResource
 
 
 class Downtime(GetableAPIResource, CreateableAPIResource, UpdatableAPIResource,
-               ListableAPIResource, DeletableAPIResource):
+               ListableAPIResource, DeletableAPIResource, ActionAPIResource):
     """
     A wrapper around Monitor Downtiming HTTP API.
     """
     _resource_name = 'downtime'
+
+    @classmethod
+    def cancel_downtime_by_scope(cls, **body):
+        """
+        Cancels all downtimes matching the scope.
+
+        :param scope: scope to cancel downtimes by
+        :type scope: string
+
+        :returns: Dictionary representing the API's JSON response
+        """
+        return super(Downtime, cls)._trigger_class_action('POST', 'cancel/by_scope', **body)

--- a/datadog/dogshell/downtime.py
+++ b/datadog/dogshell/downtime.py
@@ -44,14 +44,13 @@ class DowntimeClient(object):
         show_parser.add_argument('downtime_id', help="downtime to show")
         show_parser.set_defaults(func=cls._show_downtime)
 
-        show_all_parser = verb_parsers.add_parser('show_all', help="Show a list of all downtimes")
-        show_all_parser.add_argument('--current_only', help="only return downtimes that"
-                                     " are active when the request is made", default=None)
-        show_all_parser.set_defaults(func=cls._show_all_downtime)
-
         delete_parser = verb_parsers.add_parser('delete', help="Delete a downtime")
         delete_parser.add_argument('downtime_id', help="downtime to delete")
         delete_parser.set_defaults(func=cls._cancel_downtime)
+
+        cancel_parser = verb_parsers.add_parser('cancel_by_scope', help="Cancel all downtimes with a given scope")
+        cancel_parser.add_argument('scope', help="The scope of the downtimes to cancel")
+        cancel_parser.set_defaults(func=cls._cancel_downtime_by_scope)
 
     @classmethod
     def _schedule_downtime(cls, args):
@@ -100,12 +99,10 @@ class DowntimeClient(object):
             print(json.dumps(res))
 
     @classmethod
-    def _show_all_downtime(cls, args):
+    def _cancel_downtime_by_scope(cls, args):
         api._timeout = args.timeout
         format = args.format
-        res = api.Downtime.get_all(current_only=args.current_only)
-        report_warnings(res)
-        report_errors(res)
+        res = api.Downtime.cancel_downtime_by_scope(scope=args.scope)
         if format == 'pretty':
             print(pretty_json(res))
         else:

--- a/datadog/dogshell/downtime.py
+++ b/datadog/dogshell/downtime.py
@@ -44,6 +44,11 @@ class DowntimeClient(object):
         show_parser.add_argument('downtime_id', help="downtime to show")
         show_parser.set_defaults(func=cls._show_downtime)
 
+        show_all_parser = verb_parsers.add_parser('show_all', help="Show a list of all downtimes")
+        show_all_parser.add_argument('--current_only', help="only return downtimes that"
+                                     " are active when the request is made", default=None)
+        show_all_parser.set_defaults(func=cls._show_all_downtime)
+
         delete_parser = verb_parsers.add_parser('delete', help="Delete a downtime")
         delete_parser.add_argument('downtime_id', help="downtime to delete")
         delete_parser.set_defaults(func=cls._cancel_downtime)
@@ -91,6 +96,18 @@ class DowntimeClient(object):
         api._timeout = args.timeout
         format = args.format
         res = api.Downtime.get(args.downtime_id)
+        report_warnings(res)
+        report_errors(res)
+        if format == 'pretty':
+            print(pretty_json(res))
+        else:
+            print(json.dumps(res))
+
+    @classmethod
+    def _show_all_downtime(cls, args):
+        api._timeout = args.timeout
+        format = args.format
+        res = api.Downtime.get_all(current_only=args.current_only)
         report_warnings(res)
         report_errors(res)
         if format == 'pretty':

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -683,7 +683,8 @@ class TestDatadog:
                 "Downtime", downtime["id"], retry_condition=lambda r: r["disabled"] is False
             )
         for downtime in downtimes_with_scope_two:
-            get_with_retry("Downtime", downtime["id"])
+            d = get_with_retry("Downtime", downtime["id"])
+            assert d["disabled"] is False
 
         # Cancel downtimes with scope `scope_two`
         dog.Downtime.cancel_downtime_by_scope(scope=scope_two)

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -535,6 +535,24 @@ class TestDogshell:
         assert out["scope"][0] == scope
         assert out["disabled"] is True
 
+    def test_downtime_cancel_by_scope(self):
+        # Schedule a downtime
+        scope = "env:staging"
+        out, _, _ = self.dogshell(["downtime", "post", scope, str(int(time.time()))])
+        out = json.loads(out)
+        assert out["scope"][0] == scope
+        assert out["disabled"] is False
+        downtime_id = str(out["id"])
+
+        # Cancel the downtime by scope
+        self.dogshell(["downtime", "cancel_by_scope", scope])
+
+        # Get downtime and check if it is cancelled
+        out, _, _ = self.dogshell(["downtime", "show", downtime_id])
+        out = json.loads(out)
+        assert out["scope"][0] == scope
+        assert out["disabled"] is True
+
     def test_service_check(self):
         out, _, _ = self.dogshell(["service_check", "check", "check_pg", "host0", "1"])
         out = json.loads(out)


### PR DESCRIPTION
@DataDog/monitor-app 

___

https://docs.datadoghq.com/api/?lang=python#cancel-monitor-downtimes-by-scope