### PR TITLE
Address possible flaky tests

### DIFF
--- a/datadog/api/roles.py
+++ b/datadog/api/roles.py
@@ -18,7 +18,7 @@ class Roles(ActionAPIResource, CreateableAPIResource, CustomUpdatableAPIResource
         Update a role's attributes
 
         :param id: uuid of the role
-        :param body: dict with type of the input and modified attributes
+        :param body: dict with type of the input, role `id`, and modified attributes
         :returns: Dictionary representing the API's JSON response
         """
         params = {}

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -24,10 +24,19 @@ WAIT_TIME = 10
 
 class TestDatadog:
     host_name = "test.host.integration"
+    cleanup_role_uuids = []
 
     @classmethod
     def setup_class(cls):
         initialize(api_key=API_KEY, app_key=APP_KEY, api_host=API_HOST)
+
+    @classmethod
+    def teardown_class(cls):
+        # Ensure we cleanup any resources we created during tests
+        # These should be removed during tests, but here as well in case of test failures
+        for uuid in cls.cleanup_role_uuids:
+            dog.Roles.delete(uuid)
+
 
     def test_tags(self):
         hostname = "test.tags.host" + str(time.time())
@@ -771,6 +780,7 @@ class TestDatadog:
 
         # test create role
         role = dog.Roles.create(data=data)
+        self.cleanup_role_uuids.append(role["data"]["id"])
         assert "roles" in role["data"]["type"]
         assert role["data"]["id"] is not None
         assert role["data"]["attributes"]["name"] == role_name
@@ -782,7 +792,8 @@ class TestDatadog:
         data = {
                 "type": "roles",
                 "attributes": {
-                    "name": new_role_name
+                    "name": new_role_name,
+                    "id": role_uuid,
                 }
             }
 

--- a/tests/integration/api/test_aws_integration.py
+++ b/tests/integration/api/test_aws_integration.py
@@ -2,16 +2,23 @@ from datadog import api as dog
 from datadog import initialize
 from tests.integration.api.constants import API_KEY, APP_KEY, API_HOST
 
+from itertools import product
+
 TEST_ACCOUNT_ID_1 = "123456789101"
 TEST_ACCOUNT_ID_2 = "123456789102"
 TEST_ACCOUNT_ID_3 = "123456789103"
 TEST_ACCOUNT_ID_4 = "123456789104"
 TEST_ROLE_NAME = "DatadogApiTestRole"
 TEST_ROLE_NAME_2 = "DatadogApiTestRolo"
+
+ROLE_NAMES = [TEST_ROLE_NAME, TEST_ROLE_NAME_2]
+ACCOUNT_IDS = [TEST_ACCOUNT_ID_1, TEST_ACCOUNT_ID_2, TEST_ACCOUNT_ID_3, TEST_ACCOUNT_ID_4]
 AVAILABLE_NAMESPACES = 76
 
 class TestAwsIntegration:
 
+    # List of dictionaries representing the AWS Accounts to cleanup between tests
+    # Ex: [{"account_id": "1234", "role_name": "R1"}, {"account_id": "5678", "role_name": "r2"}]
     accounts_to_cleanup = []
 
     @classmethod
@@ -21,10 +28,12 @@ class TestAwsIntegration:
         """
         initialize(api_key=API_KEY, app_key=APP_KEY, api_host=API_HOST)
 
+        for acc in product(ACCOUNT_IDS, ROLE_NAMES):
+            cls.accounts_to_cleanup.append({'account_id': acc[0], 'role_name': acc[1]})
+
     def teardown_method(self, method):
         for account in self.accounts_to_cleanup:
-            dog.AwsIntegration.delete(account_id=account.get('account_id'), role_name=account.get('role_name'))
-        self.accounts_to_cleanup = []
+            dog.AwsIntegration.delete(account_id=account['account_id'], role_name=account.get('role_name'))
 
     def test_create(self):
         output = dog.AwsIntegration.create(
@@ -34,7 +43,6 @@ class TestAwsIntegration:
             filter_tags=["filter:test"],
             account_specific_namespace_rules={'auto_scaling': False, 'opsworks': False}
         )
-        self.accounts_to_cleanup.append({"account_id": TEST_ACCOUNT_ID_3, "role_name": TEST_ROLE_NAME})
         assert "external_id" in output
 
     def test_list(self):
@@ -46,8 +54,6 @@ class TestAwsIntegration:
             account_id=TEST_ACCOUNT_ID_2,
             role_name=TEST_ROLE_NAME
         )
-        self.accounts_to_cleanup.append({"account_id": TEST_ACCOUNT_ID_1, "role_name": TEST_ROLE_NAME})
-        self.accounts_to_cleanup.append({"account_id": TEST_ACCOUNT_ID_2, "role_name": TEST_ROLE_NAME})
 
         output = dog.AwsIntegration.list()
         assert "accounts" in output
@@ -75,7 +81,6 @@ class TestAwsIntegration:
             account_id=TEST_ACCOUNT_ID_2,
             role_name=TEST_ROLE_NAME
         )
-        self.accounts_to_cleanup.append({"account_id": TEST_ACCOUNT_ID_2, "role_name": TEST_ROLE_NAME})
         output = dog.AwsIntegration.generate_new_external_id(
             account_id=TEST_ACCOUNT_ID_2,
             role_name=TEST_ROLE_NAME
@@ -88,7 +93,6 @@ class TestAwsIntegration:
             account_id=TEST_ACCOUNT_ID_2,
             role_name=TEST_ROLE_NAME
         )
-        self.accounts_to_cleanup.append({"account_id": TEST_ACCOUNT_ID_2, "role_name": TEST_ROLE_NAME})
         output = dog.AwsIntegration.list_namespace_rules(
             account_id=TEST_ACCOUNT_ID_2,
             role_name=TEST_ROLE_NAME
@@ -100,7 +104,6 @@ class TestAwsIntegration:
             account_id=TEST_ACCOUNT_ID_2,
             role_name=TEST_ROLE_NAME
         )
-        self.accounts_to_cleanup.append({"account_id": TEST_ACCOUNT_ID_2, "role_name": TEST_ROLE_NAME})
 
         dog.AwsIntegration.update(
             account_id=TEST_ACCOUNT_ID_2,
@@ -109,7 +112,6 @@ class TestAwsIntegration:
             host_tags=["api:test2"],
             new_role_name=TEST_ROLE_NAME_2
         )
-        self.accounts_to_cleanup.append({"account_id": TEST_ACCOUNT_ID_4, "role_name": TEST_ROLE_NAME_2})
 
         output = dog.AwsIntegration.list()
         tests_pass = False

--- a/tests/integration/api/test_azure_integration.py
+++ b/tests/integration/api/test_azure_integration.py
@@ -16,6 +16,15 @@ class TestAzureIntegration:
     def setup_class(cls):
         initialize(api_key=API_KEY, app_key=APP_KEY, api_host=API_HOST)
 
+    @classmethod
+    def teardown_class(cls):
+        # Should be deleted as part of the test
+        # but cleanup here if test fails
+        dog.AzureIntegration.delete(
+            tenant_name=cls.test_new_tenant_name,
+            client_id=cls.test_new_client_id
+        )
+
     def test_azure_crud(self):
         # Test Create
         create_output = dog.AzureIntegration.create(

--- a/tests/integration/api/test_gcp_integration.py
+++ b/tests/integration/api/test_gcp_integration.py
@@ -12,6 +12,15 @@ class TestGcpIntegration:
     def setup_class(cls):
         initialize(api_key=API_KEY, app_key=APP_KEY, api_host=API_HOST)
 
+    @classmethod
+    def teardown_class(cls):
+        # Should be deleted as part of the test
+        # but cleanup here if test fails
+        dog.GcpIntegration.delete(
+            project_id=cls.test_project_id,
+            client_email=cls.test_client_email
+        )
+
     def test_gcp_crud(self):
         # Test Create
         create_output = dog.GcpIntegration.create(

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -123,8 +123,9 @@ class TestDogshell:
         )
 
         # Give the host some tags
+        # The host tag association can take some time, so bump the retry limit to reduce flakiness
         tags0 = ["t0", "t1"]
-        out, _, _ = self.dogshell_with_retry(["tag", "add", host] + tags0, retry_limit=15)
+        out, _, _ = self.dogshell_with_retry(["tag", "add", host] + tags0, retry_limit=30)
         for t in tags0:
             assert t in out
 

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -124,7 +124,7 @@ class TestDogshell:
 
         # Give the host some tags
         tags0 = ["t0", "t1"]
-        out, _, _ = self.dogshell_with_retry(["tag", "add", host] + tags0)
+        out, _, _ = self.dogshell_with_retry(["tag", "add", host] + tags0, retry_limit=15)
         for t in tags0:
             assert t in out
 


### PR DESCRIPTION
### What this PR does
Adds a teardown logic to some integration tests to more safely cleanup in the event that the test encounters an assertionError. 

Bumps the retry_limit for the host tags integration test

Update the update `roles` test to now also send along the `id` as part of the payload as its required

### Motivation
Help ensure one test failure won't impact the next test run. 
Give the tags test more time to get the expected value back. 