### PR TITLE
Remove Python3.4 from the test matrix, and add Python3.8

### DIFF
--- a/.azure-pipelines/unit_tests.yml
+++ b/.azure-pipelines/unit_tests.yml
@@ -18,9 +18,6 @@ jobs:
       Py27:
         PYTHON_VERSION: "2.7"
         TOXENV: "py27"
-      Py34:
-        PYTHON_VERSION: "3.4"
-        TOXENV: "py34"
       Py35:
         PYTHON_VERSION: "3.5"
         TOXENV: "py35"
@@ -30,6 +27,9 @@ jobs:
       Py37:
         PYTHON_VERSION: "3.7"
         TOXENV: "py37"
+      Py38:
+        PYTHON_VERSION: "3.8"
+        TOXENV: "py38"
       Pypy2:
         PYTHON_VERSION: "pypy2"
         TOXENV: "pypy2"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.7.0
 skip_missing_interpreters = true
 envlist =
-    py{27,34,35,36,37,py2,py3}
+    py{27,35,36,37,38,py2,py3}
     flake8
     integration
 


### PR DESCRIPTION
Python3.4 is EOL and is not supported anymore by azure-pipelines
Python3.8 is out :)