### PR TITLE
Add statsd_constant_tags kwarg to datadog.initialize()

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -64,6 +64,9 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
 
     :param statsd_socket_path: path to the DogStatsd UNIX socket. Supersedes statsd_host
     and stats_port if provided.
+    
+    :param statsd_constant_tags: A list of tags to be applied to all metrics ("tag", "tag:value")
+    :type statsd_constant_tags: list of strings
 
     :param cacert: Path to local certificate file used to verify SSL \
         certificates. Can also be set to True (default) to use the systems \

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -31,7 +31,7 @@ logging.getLogger('datadog.threadstats').addHandler(NullHandler())
 
 def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
                statsd_host=None, statsd_port=None, statsd_use_default_route=False,
-               statsd_socket_path=None, statsd_namespace=None, statsd_content_tags=None,
+               statsd_socket_path=None, statsd_namespace=None, statsd_constant_tags=None,
                return_raw_response=False, hostname_from_config=True, **kwargs):
     """
     Initialize and configure Datadog.api and Datadog.statsd modules

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -64,9 +64,9 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
 
     :param statsd_socket_path: path to the DogStatsd UNIX socket. Supersedes statsd_host
     and stats_port if provided.
-    
+
     :param statsd_constant_tags: A list of tags to be applied to all metrics ("tag", "tag:value")
-    :type statsd_constant_tags: list of strings
+    :type statsd_constant_tags: list of string
 
     :param cacert: Path to local certificate file used to verify SSL \
         certificates. Can also be set to True (default) to use the systems \

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -31,8 +31,8 @@ logging.getLogger('datadog.threadstats').addHandler(NullHandler())
 
 def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
                statsd_host=None, statsd_port=None, statsd_use_default_route=False,
-               statsd_socket_path=None, statsd_namespace=None, return_raw_response=False,
-               hostname_from_config=True, **kwargs):
+               statsd_socket_path=None, statsd_namespace=None, statsd_content_tags=None,
+               return_raw_response=False, hostname_from_config=True, **kwargs):
     """
     Initialize and configure Datadog.api and Datadog.statsd modules
 
@@ -105,6 +105,8 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
             statsd.port = int(statsd_port)
     if statsd_namespace:
         statsd.namespace = text(statsd_namespace)
+    if statsd_constant_tags:
+        statsd.constant_tags += statsd_constant_tags
 
     api._return_raw_response = return_raw_response
 


### PR DESCRIPTION
Per the documentation here https://docs.datadoghq.com/developers/dogstatsd/?tab=python#client-instantiation-parameters
It seems like you should be able to pass constant tags to the default statsd via the datadog initialize method. This just adds it and merges the list already in the default datadog.dogstatsd.statsd class similar to how the other statsd_* kwargs are handled