### PR TITLE
Update histogram in-line description

### DIFF
--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -203,7 +203,7 @@ class ThreadStats(object):
         """
         Sample a histogram value. Histograms will produce metrics that
         describe the distribution of the recorded values, namely the maximum,
-        median, average, count and the 95th percentile. Optionally, specify
+        average, count and the 95th percentile. Optionally, specify
         a list of ``tags`` to associate with the metric.
 
         >>> stats.histogram('uploaded_file.size', uploaded_file.size())

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -202,8 +202,8 @@ class ThreadStats(object):
     def histogram(self, metric_name, value, timestamp=None, tags=None, sample_rate=1, host=None):
         """
         Sample a histogram value. Histograms will produce metrics that
-        describe the distribution of the recorded values, namely the maximum,
-        average, count and the 95th percentile. Optionally, specify
+        describe the distribution of the recorded values, namely the maximum, mininum,
+        average, count and the 75/85/95/99 percentiles. Optionally, specify
         a list of ``tags`` to associate with the metric.
 
         >>> stats.histogram('uploaded_file.size', uploaded_file.size())


### PR DESCRIPTION
Histogram metrics currently do not send the median aggregate: https://github.com/DataDog/datadogpy/blob/48a5a677c58bc7282a25061d811f445329ad1f17/datadog/threadstats/metrics.py#L86-L138

This PR corrects the in-line description of the Histogram function.