### PR TITLE
Handle OSError on socket.close on Python 3.6+

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -314,7 +314,10 @@ class DogStatsd(object):
         Closes connected socket if connected.
         """
         if self.socket:
-            self.socket.close()
+            try:
+                self.socket.close()
+            except Exception as e:
+                log.error("Unexpected error: %s", str(e))
             self.socket = None
 
     def _serialize_metric(self, metric, metric_type, value, tags, sample_rate=1):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -316,7 +316,7 @@ class DogStatsd(object):
         if self.socket:
             try:
                 self.socket.close()
-            except Exception as e:
+            except OSError as e:
                 log.error("Unexpected error: %s", str(e))
             self.socket = None
 


### PR DESCRIPTION
### What does this PR do?

This PR handles unexpected exceptions in `DogStatsd.close_socket()`.

Under certain obscure circumstances we get a crash on Python 3.6+ if the file descriptor vanishes before close is called.

See https://bugs.python.org/issue29343
