### PR TITLE
[dogshell] Enforce the default 'normal' event priority client side

### DIFF
--- a/datadog/dogshell/event.py
+++ b/datadog/dogshell/event.py
@@ -76,7 +76,8 @@ class EventClient(object):
                                  " when the event occurred. if unset defaults to the current time.")
         post_parser.add_argument('--handle', help="user to post as. if unset, submits "
                                  "as the generic API user.")
-        post_parser.add_argument('--priority', help='"normal" or "low". defaults to "normal"')
+        post_parser.add_argument('--priority', help='"normal" or "low". defaults to "normal"',
+                                 default='normal')
         post_parser.add_argument('--related_event_id', help="event to post as a child of."
                                  " if unset, posts a top-level event")
         post_parser.add_argument('--tags', help="comma separated list of tags")


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Enforce the default event priority value to `normal` when submitting an event via the API. 

### Description of the Change
The CLI help output stats that the default `priority` value used when
posting an event with `dog event post` is `normal`. That value isn't
enforced on the client side, and it seems leaving it to `None` has an
unexpected side effect: the API returns an HTTP 200 response along with
an link to the indexed event, which always returns an HTTP 404.

Example:

```console

$ dog --raw event post --alert_type 'info' --no_host 'test by balthazar' 'checking for any pebcak' | jq .
{
  "status": "ok",
  "event": {
    "id": XXXX,
    "title": "test by balthazar",
    "text": "checking for any pebcak",
    "date_happened": 1578645516,
    "handle": null,
    "priority": null,
    "related_event_id": null,
    "tags": [],
    "url": "https://app.datadoghq.com/event/event?id=1234"
  }
}
```

That event url always returns an HTTP 404 when opened. We can see
`"priority": null` in the response payload.

If we however explicitly set the `--priority` flag to `normal` in the
command-line, we can see `"priority": "normal"` in the JSON output:

```console
$ dog --raw event post --priority normal --alert_type 'info' --no_host 'test by balthazar' 'checking for any pebcak' | jq .
{
  "status": "ok",
  "event": {
    "id": YYYYY,
    "title": "test by balthazar",
    "text": "checking for any pebcak",
    "date_happened": 1578645659,
    "handle": null,
    "priority": "normal",
    "related_event_id": null,
    "tags": [],
    "url": "https://app.datadoghq.com/event/event?id=ABCD"
  }
}
```

Visiting the event URL now returns an HTTP 200, and I can find the event
by searching in the event stream.

Additional API validation will of course have to be added server-side
but this is at least a start.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

