### PR TITLE
Add tests for options on delete

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -114,6 +114,7 @@ To setup integration tests you will need to export the following environment var
 ```
 # !!!WARNING!!! The integration tests will use these keys to do destructive changes.
 # Never use keys for an organization that contains anything important.
+# The client test data isn't sent to staging by default, use a different environment apart from staging
 export DD_TEST_CLIENT_API_KEY=<api_key_for_a_testing_org>
 export DD_TEST_CLIENT_APP_KEY=<app_key_for_a_testing_org>
 export DD_TEST_CLIENT_USER=<user_handle_for_testing_comments_api>

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -114,7 +114,6 @@ To setup integration tests you will need to export the following environment var
 ```
 # !!!WARNING!!! The integration tests will use these keys to do destructive changes.
 # Never use keys for an organization that contains anything important.
-# The client test data isn't sent to staging by default, use a different environment apart from staging
 export DD_TEST_CLIENT_API_KEY=<api_key_for_a_testing_org>
 export DD_TEST_CLIENT_APP_KEY=<app_key_for_a_testing_org>
 export DD_TEST_CLIENT_USER=<user_handle_for_testing_comments_api>

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -528,16 +528,11 @@ class TestDatadog:
 
         # Check if you can delete the monitor.
         monitor_ids = [monitor["id"]]
-        assert dog.Monitor.can_delete(monitor_ids=monitor_ids) == {
-            "data": {"ok": []},
-            "errors": {
-                str(monitor["id"]): [
-                    MONITOR_REFERENCED_IN_SLO_MESSAGE.format(
-                        monitor["id"], slo["id"]
-                    )
-                ]
-            },
-        }
+        resp = dog.Monitor.can_delete(monitor_ids=monitor_ids)
+        assert "errors" in resp
+        assert str(monitor["id"]) in resp["errors"]
+        assert len(resp["errors"][str(monitor["id"])])
+        assert "is referenced in slos" in resp["errors"][str(monitor["id"])][0]
 
         # Delete the SLO.
         dog.ServiceLevelObjective.delete(slo["id"])

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -555,6 +555,25 @@ class TestDatadog:
             "deleted_monitor_id": monitor["id"]
         }
 
+    def test_monitor_can_delete(self):
+        # Create a monitor-based SLO.
+        name = "test SLO {}".format(time.time())
+        thresholds = [{"timeframe": "7d", "target": 90}]
+        slo = dog.ServiceLevelObjective.create(
+            type="monitor",
+            monitor_ids=monitor_ids,
+            thresholds=thresholds,
+            name=name,
+        )["data"][0]
+
+        # Check if you can delete the monitor.
+        options = {"force": True}
+        monitor_ids = [monitor["id"]]
+        assert dog.Monitor.can_delete(monitor_ids=monitor_ids, options=options) == {
+            "data": {"ok": monitor_ids},
+            "errors": None,
+        }
+
     def test_service_level_objective_crud(self):
         numerator = "sum:my.custom.metric{type:good}.as_count()"
         denominator = "sum:my.custom.metric{*}.as_count()"

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -40,7 +40,6 @@ class TestDatadog:
         for uuid in cls.cleanup_role_uuids:
             dog.Roles.delete(uuid)
 
-
     def test_tags(self):
         hostname = "test.tags.host" + str(time.time())
         # post a metric to make sure the test host context exists
@@ -576,8 +575,7 @@ class TestDatadog:
         )["data"][0]
 
         # Check if you can delete the monitor with force option
-        options = {"force": True}
-        assert dog.Monitor.delete(monitor["id"], options=options) == {
+        assert dog.Monitor.delete(monitor["id"], force=True) == {
             "deleted_monitor_id": monitor["id"]
         }
 

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -555,7 +555,16 @@ class TestDatadog:
             "deleted_monitor_id": monitor["id"]
         }
 
-    def test_monitor_can_delete(self):
+    def test_monitor_can_delete_with_force(self):
+        # Create a monitor.
+        query = "avg(last_1h):sum:system.net.bytes_rcvd{host:host0} > 100"
+        options = {
+            "silenced": {"*": int(time.time()) + 60 * 60},
+            "notify_no_data": False,
+        }
+        monitor = dog.Monitor.create(type="metric alert", query=query, options=options)
+        monitor_ids = [monitor["id"]]
+
         # Create a monitor-based SLO.
         name = "test SLO {}".format(time.time())
         thresholds = [{"timeframe": "7d", "target": 90}]
@@ -568,10 +577,8 @@ class TestDatadog:
 
         # Check if you can delete the monitor.
         options = {"force": True}
-        monitor_ids = [monitor["id"]]
-        assert dog.Monitor.can_delete(monitor_ids=monitor_ids, options=options) == {
-            "data": {"ok": monitor_ids},
-            "errors": None,
+        assert dog.Monitor.delete([monitor["id"]], options=options) == {
+            "deleted_monitor_id": monitor["id"]
         }
 
     def test_service_level_objective_crud(self):

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -575,9 +575,9 @@ class TestDatadog:
             name=name,
         )["data"][0]
 
-        # Check if you can delete the monitor.
+        # Check if you can delete the monitor with force option
         options = {"force": True}
-        assert dog.Monitor.delete([monitor["id"]], options=options) == {
+        assert dog.Monitor.delete(monitor["id"], options=options) == {
             "deleted_monitor_id": monitor["id"]
         }
 


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/MA-791

### What does this PR do?

Add tests to confirm correct behavior of using options with the delete method in the client.

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

