### PR TITLE
Handle EAGAIN socket error when dropping packets

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -399,15 +399,15 @@ class DogStatsd(object):
         except socket.timeout:
             # dogstatsd is overflowing, drop the packets (mimicks the UDP behaviour)
             pass
+        except (socket.herror, socket.gaierror) as se:
+            log.warning("Error submitting packet: {}, dropping the packet and closing the socket".format(se))
+            self.close_socket()
         except socket.error as se:
             if se.errno == errno.EAGAIN:
                 log.warning("Socket send would block: {}, dropping the packet".format(se))
             else:
                 log.warning("Error submitting packet: {}, dropping the packet and closing the socket".format(se))
                 self.close_socket()
-        except (socket.herror, socket.gaierror) as se:
-            log.warning("Error submitting packet: {}, dropping the packet and closing the socket".format(se))
-            self.close_socket()
         except Exception as e:
             log.error("Unexpected error: %s", str(e))
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -399,8 +399,11 @@ class DogStatsd(object):
             # dogstatsd is overflowing, drop the packets (mimicks the UDP behaviour)
             pass
         except (socket.error, socket.herror, socket.gaierror) as se:
-            log.warning("Error submitting packet: {}, dropping the packet and closing the socket".format(se))
-            self.close_socket()
+            if se.errno == 11:
+                log.warning("Socket send would block: {}, dropping the packet".format(se))
+            else:
+                log.warning("Error submitting packet: {}, dropping the packet and closing the socket".format(se))
+                self.close_socket()
         except Exception as e:
             log.error("Unexpected error: %s", str(e))
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -11,6 +11,7 @@ from random import random
 import logging
 import os
 import socket
+import errno
 from threading import Lock
 
 # datadog
@@ -398,12 +399,15 @@ class DogStatsd(object):
         except socket.timeout:
             # dogstatsd is overflowing, drop the packets (mimicks the UDP behaviour)
             pass
-        except (socket.error, socket.herror, socket.gaierror) as se:
-            if se.errno == 11:
+        except socket.error as se:
+            if se.errno == errno.EAGAIN:
                 log.warning("Socket send would block: {}, dropping the packet".format(se))
             else:
                 log.warning("Error submitting packet: {}, dropping the packet and closing the socket".format(se))
                 self.close_socket()
+        except (socket.herror, socket.gaierror) as se:
+            log.warning("Error submitting packet: {}, dropping the packet and closing the socket".format(se))
+            self.close_socket()
         except Exception as e:
             log.error("Unexpected error: %s", str(e))
 

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -66,6 +66,14 @@ class BrokenSocket(FakeSocket):
         raise socket.error("Socket error")
 
 
+class OverflownSocket(FakeSocket):
+
+    def send(self, payload):
+        error = socker.error("Socker error")
+        error.errno = 11
+        raise error
+
+
 def telemetry_metrics(metrics=1, events=0, service_checks=0, bytes_sent=0, bytes_dropped=0, packets_sent=0, packets_dropped=0, transport="udp", tags="", namespace=""):
     version = get_version()
     if tags:
@@ -336,6 +344,11 @@ class TestDogStatsd(unittest.TestCase):
 
     def test_socket_error(self):
         self.statsd.socket = BrokenSocket()
+        self.statsd.gauge('no error', 1)
+        assert True, 'success'
+
+    def test_socket_overflown(self):
+        self.statsd.socket = OverflownSocket()
         self.statsd.gauge('no error', 1)
         assert True, 'success'
 

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -10,6 +10,7 @@ Tests for dogstatsd.py
 from collections import deque
 import os
 import socket
+import errno
 import time
 import unittest
 
@@ -70,7 +71,7 @@ class OverflownSocket(FakeSocket):
 
     def send(self, payload):
         error = socker.error("Socker error")
-        error.errno = 11
+        error.errno = errno.EAGAIN
         raise error
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes  #514 by catching `socket.error`and checking `errno == 11` (EAGAIN) and logs a warning without closing the socket.

### Description of the Change

As mentioned in the issue, `socket.send` raises a `BlockingIOError (socket.error on py2)` exception when the socket is "full" rather than a `socket.timeout` exception. Hence, we create a new branch in the try-raise where we catch `socket.error`, check the `errno` and log a warning without closing the socket. This works across both python 2 and 3.

I left the `socket.timeout` branch in place because I wasn't sure if there is another way to set up DogStatsd where `socket.timeout` is thrown when the socket is full. This way, the change shouldn't break compatibility for people who rely on that behaviour.

### Alternate Designs

I considered not logging a message when a `socket.error` with `errno == 11` occurs but thought that people might want to be informed about this happening.

### Possible Drawbacks

N/A

### Verification Process

I created a unit test and checked that it passes.

### Additional Notes

N/A

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [x] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

