### PR TITLE
Remove namespace from the telemetry metrics

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -321,10 +321,10 @@ class DogStatsd(object):
                 log.error("Unexpected error: %s", str(e))
             self.socket = None
 
-    def _serialize_metric(self, metric, metric_type, value, tags, sample_rate=1):
+    def _serialize_metric(self, metric, metric_type, value, tags, sample_rate=1, ignore_namespace=False):
         # Create/format the metric packet
         return "%s%s:%s|%s%s%s" % (
-            (self.namespace + ".") if self.namespace else "",
+            (self.namespace + ".") if not ignore_namespace and self.namespace else "",
             metric,
             value,
             metric_type,
@@ -370,19 +370,19 @@ class DogStatsd(object):
         telemetry_tags = self._add_constant_tags(self._client_tags)
         return "\n%s\n%s\n%s\n%s\n%s\n%s\n%s" % (
                 self._serialize_metric("datadog.dogstatsd.client.metrics",
-                                       "c", self.metrics_count, telemetry_tags),
+                                       "c", self.metrics_count, telemetry_tags, ignore_namespace=True),
                 self._serialize_metric("datadog.dogstatsd.client.events",
-                                       "c", self.events_count, telemetry_tags),
+                                       "c", self.events_count, telemetry_tags, ignore_namespace=True),
                 self._serialize_metric("datadog.dogstatsd.client.service_checks",
-                                       "c", self.service_checks_count, telemetry_tags),
+                                       "c", self.service_checks_count, telemetry_tags, ignore_namespace=True),
                 self._serialize_metric("datadog.dogstatsd.client.bytes_sent",
-                                       "c", self.bytes_sent, telemetry_tags),
+                                       "c", self.bytes_sent, telemetry_tags, ignore_namespace=True),
                 self._serialize_metric("datadog.dogstatsd.client.bytes_dropped",
-                                       "c", self.bytes_dropped, telemetry_tags),
+                                       "c", self.bytes_dropped, telemetry_tags, ignore_namespace=True),
                 self._serialize_metric("datadog.dogstatsd.client.packets_sent",
-                                       "c", self.packets_sent, telemetry_tags),
+                                       "c", self.packets_sent, telemetry_tags, ignore_namespace=True),
                 self._serialize_metric("datadog.dogstatsd.client.packets_dropped",
-                                       "c", self.packets_dropped, telemetry_tags),
+                                       "c", self.packets_dropped, telemetry_tags, ignore_namespace=True),
                 )
 
     def _send_to_server(self, packet):

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -75,18 +75,18 @@ class OverflownSocket(FakeSocket):
         raise error
 
 
-def telemetry_metrics(metrics=1, events=0, service_checks=0, bytes_sent=0, bytes_dropped=0, packets_sent=0, packets_dropped=0, transport="udp", tags="", namespace=""):
+def telemetry_metrics(metrics=1, events=0, service_checks=0, bytes_sent=0, bytes_dropped=0, packets_sent=0, packets_dropped=0, transport="udp", tags=""):
     version = get_version()
     if tags:
         tags = "," + tags
 
-    return "\n{}datadog.dogstatsd.client.metrics:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(namespace, metrics, version, transport, tags) \
-        + "{}datadog.dogstatsd.client.events:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(namespace, events, version, transport, tags) \
-        + "{}datadog.dogstatsd.client.service_checks:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(namespace, service_checks, version, transport, tags) \
-        + "{}datadog.dogstatsd.client.bytes_sent:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(namespace, bytes_sent, version, transport, tags) \
-        + "{}datadog.dogstatsd.client.bytes_dropped:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(namespace, bytes_dropped, version, transport, tags) \
-        + "{}datadog.dogstatsd.client.packets_sent:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(namespace, packets_sent, version, transport, tags) \
-        + "{}datadog.dogstatsd.client.packets_dropped:{}|c|#client:py,client_version:{},client_transport:{}{}".format(namespace, packets_dropped, version, transport, tags)
+    return "\ndatadog.dogstatsd.client.metrics:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(metrics, version, transport, tags) \
+        + "datadog.dogstatsd.client.events:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(events, version, transport, tags) \
+        + "datadog.dogstatsd.client.service_checks:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(service_checks, version, transport, tags) \
+        + "datadog.dogstatsd.client.bytes_sent:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(bytes_sent, version, transport, tags) \
+        + "datadog.dogstatsd.client.bytes_dropped:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(bytes_dropped, version, transport, tags) \
+        + "datadog.dogstatsd.client.packets_sent:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(packets_sent, version, transport, tags) \
+        + "datadog.dogstatsd.client.packets_dropped:{}|c|#client:py,client_version:{},client_transport:{}{}".format(packets_dropped, version, transport, tags)
 
 def assert_equal_telemetry(expected_payload, actual_payload, telemetry=None):
     if telemetry is None:
@@ -313,7 +313,7 @@ class TestDogStatsd(unittest.TestCase):
         """
         self.statsd.namespace = "foo"
         self.statsd.gauge('gauge', 123.4)
-        assert_equal_telemetry('foo.gauge:123.4|g', self.recv(), telemetry=telemetry_metrics(namespace="foo."))
+        assert_equal_telemetry('foo.gauge:123.4|g', self.recv())
 
     # Test Client level contant tags
     def test_gauge_constant_tags(self):


### PR DESCRIPTION
### What does this PR do?

Remove the namespace from the telemetry metrics

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [x] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

