### PR TITLE
Fix syntax error in dogwrap timeout handler and always collect output (#537)

### DIFF
--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -117,45 +117,49 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout,
     try:
         # Let's that the threads collecting the output from the command in the
         # background
-        stdout = sys.stdout.buffer if is_p3k() else sys.stdout
-        stderr = sys.stderr.buffer if is_p3k() else sys.stderr
-        out_reader = OutputReader(proc.stdout, stdout if not buffer_outs else None)
-        err_reader = OutputReader(proc.stderr, stderr if not buffer_outs else None)
+        stdout_buffer = sys.stdout.buffer if is_p3k() else sys.stdout
+        stderr_buffer = sys.stderr.buffer if is_p3k() else sys.stderr
+        out_reader = OutputReader(proc.stdout, stdout_buffer if not buffer_outs else None)
+        err_reader = OutputReader(proc.stderr, stderr_buffer if not buffer_outs else None)
         out_reader.start()
         err_reader.start()
 
-        # Let's quietly wait from the program's completion here et get the exit
+        # Let's quietly wait from the program's completion here to get the exit
         # code when it finishes
         returncode = poll_proc(proc, proc_poll_interval, cmd_timeout)
-
-        # Let's harvest the outputs collected by our background threads
-        # after making sure they're done reading it.
-        out_reader.join()
-        err_reader.join()
-        stdout = out_reader.content
-        stderr = err_reader.content
-
-        duration = time.time() - start_time
     except Timeout:
-        duration = time.time() - start_time
+        returncode = Timeout
+        sigterm_start = time.time()
+        print("Command timed out after %.2fs, killing with SIGTERM" % (time.time() - start_time),
+              file=sys.stderr)
         try:
             proc.terminate()
-            sigterm_start = time.time()
             try:
-                print("Command timed out after %.2fs, killing with SIGTERM", file=sys.stderr) \
-                    % (time.time() - start_time)
                 poll_proc(proc, proc_poll_interval, sigterm_timeout)
-                returncode = Timeout
             except Timeout:
-                print("SIGTERM timeout failed after %.2fs, killing with SIGKILL", file=sys.stderr) \
-                    % (time.time() - sigterm_start)
+                print("SIGTERM timeout failed after %.2fs, killing with SIGKILL" % (time.time() - sigterm_start),
+                      file=sys.stderr)
+                sigkill_start = time.time()
                 proc.kill()
-                poll_proc(proc, proc_poll_interval, sigkill_timeout)
-                returncode = Timeout
+                try:
+                    poll_proc(proc, proc_poll_interval, sigkill_timeout)
+                except Timeout:
+                    print("SIGKILL timeout failed after %.2fs, exiting" % (time.time() - sigkill_start),
+                          file=sys.stderr)
         except OSError as e:
             # Ignore OSError 3: no process found.
             if e.errno != 3:
                 raise
+
+    # Let's harvest the outputs collected by our background threads
+    # after making sure they're done reading it.
+    out_reader.join()
+    err_reader.join()
+    stdout = out_reader.content
+    stderr = err_reader.content
+
+    duration = time.time() - start_time
+
     return returncode, stdout, stderr, duration
 
 


### PR DESCRIPTION
### What does this PR do?

This PR addresses a bug in the timeout handling code in the dogwrap script (#537). If the `--timeout` argument is used and the child process does not exit before the timeout expires, a syntax error was thrown and no event was sent to the Datadog API.

### Description of the Change

I fixed the `print` syntax within the timeout handling, and also ensured that the `stdout` and `stderr` of the child process are still collected if the process times out (this was skipped previously).

### Alternate Designs


### Possible Drawbacks

### Verification Process

I added tests for this behavior, using mocks to simulate different subprocess behavior. (I originally tried to actually run a child process in the tests, but the behavior for signal handling in Azure devops seemed different from local. Someone with more experience in this CI environment could probably add more comprehensive testing 😄)

I also ran the dogwrap script from the command line, with various timeout behaviors, to demonstrate that the error was resolved and the event contained the output from the child process.

### Additional Notes

### Release Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

