### PR TITLE
Support DD_API_KEY environment variable in dogwrap

### DIFF
--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -22,6 +22,8 @@ dogwrap -n test-job -k $API_KEY --timeout=1 "sleep 3"
 '''
 # stdlib
 from __future__ import print_function
+
+import os
 from copy import copy
 import optparse
 import subprocess
@@ -260,7 +262,7 @@ the order they were sent.", version="%prog {0}".format(get_version()), option_cl
     parser.add_option('-n', '--name', action='store', type='string', help="the name of the event \
 as it should appear on your Datadog stream")
     parser.add_option('-k', '--api_key', action='store', type='string',
-                      help="your DataDog API Key")
+                      help="your DataDog API Key", default=os.environ.get("DD_API_KEY"))
     parser.add_option('-s', '--site', action='store', type='choice', default='datadoghq.com', choices=['datadoghq.com', 'us', 'datadoghq.eu', 'eu'], help="The site \
 to send data, US (datadoghq.com) or EU (datadoghq.eu), default: US")
     parser.add_option('-m', '--submit_mode', action='store', type='choice',

--- a/tests/unit/dogwrap/test_dogwrap.py
+++ b/tests/unit/dogwrap/test_dogwrap.py
@@ -94,6 +94,10 @@ class TestDogwrap(unittest.TestCase):
         with self.assertRaises(SystemExit):
             parse_options(['--proc_poll_interval', 'invalid'])
 
+        with mock.patch.dict(os.environ, values={"DD_API_KEY": "the_key"}, clear=True):
+            options, _ = parse_options([])
+            self.assertEqual(options.api_key, "the_key")
+
     def test_poll_proc(self):
         mock_proc = mock.Mock()
         mock_proc.poll.side_effect = [None, 0]


### PR DESCRIPTION


### What does this PR do?

Allow setting the API key for dog wrap via the `DD_API_KEY` environment variable like for other Datadog products.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

