### PR TITLE
Add enum for monitor types

### DIFF
--- a/datadog/api/constants.py
+++ b/datadog/api/constants.py
@@ -9,3 +9,15 @@ class CheckStatus(object):
     CRITICAL = 2
     UNKNOWN = 3
     ALL = (OK, WARNING, CRITICAL, UNKNOWN)
+
+
+class MonitorType(object):
+    # From https://docs.datadoghq.com/api/?lang=bash#create-a-monitor
+    QUERY_ALERT = "query alert"
+    COMPOSITE = "composite"
+    SERVICE_CHECK = "service check"
+    PROCESS_ALERT = "process alert"
+    LOG_ALERT = "log alert"
+    METRIC_ALERT = "metric alert"
+    RUM_ALERT = "rum alert"
+    EVENT_ALERT = "event alert"

--- a/datadog/api/constants.py
+++ b/datadog/api/constants.py
@@ -21,3 +21,5 @@ class MonitorType(object):
     METRIC_ALERT = "metric alert"
     RUM_ALERT = "rum alert"
     EVENT_ALERT = "event alert"
+    SYNTHETICS_ALERT = "synthetics alert"
+    TRACE_ANALYTICS = "trace-analytics alert"


### PR DESCRIPTION
### What does this PR do?

Closes #99 by adding a class `MonitorType` with constants for the allowed values


### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

