### PR TITLE
[telemetry] optionally decouple telemetry destination from other metrics

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -574,7 +574,7 @@ class DogStatsd(object):
         self._xmit_packet(packet, self._telemetry, False)
         if self._is_telemetry_flush_time():
             telemetry = self._flush_telemetry()
-            if self._xmit_packet(telemetry, False):
+            if self._xmit_packet(telemetry, False, True):
                 self._reset_telemetry()
                 self.packets_sent += 1
                 self.bytes_sent += len(telemetry)
@@ -587,12 +587,12 @@ class DogStatsd(object):
     def _xmit_packet(self, packet, account, is_telemetry):
         try:
             if is_telemetry and self._dedicated_telemetry_destination():
-                socket = (self.telemetry_socket or self.get_socket(telemetry=True))
+                mysocket = (self.telemetry_socket or self.get_socket(telemetry=True))
             else:
                 # If set, use socket directly
-                socket = (self.socket or self.get_socket())
+                mysocket = (self.socket or self.get_socket())
 
-            socket.send(packet.encode(self.encoding))
+            mysocket.send(packet.encode(self.encoding))
 
             if account:
                 self.packets_sent += 1

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -110,6 +110,14 @@ class DogStatsd(object):
         :envvar DD_DOGSTATSD_DISABLE: Disable any statsd metric collection (default False)
         :type DD_DOGSTATSD_DISABLE: boolean
 
+        :envvar DD_TELEMETRY_HOST: the host for the dogstatsd server we wish to submit
+        telemetry stats to. If set, it overrides default value.
+        :type DD_TELEMETRY_HOST: string
+
+        :envvar DD_TELEMETRY_PORT: the port for the dogstatsd server we wish to submit
+        telemetry stats to. If set, it overrides default value.
+        :type DD_TELEMETRY_HOST: string
+
         :param host: the host of the DogStatsd server.
         :type host: string
 
@@ -143,6 +151,26 @@ class DogStatsd(object):
         if sending metrics in batch. If not specified it will be adjusted to a optimal value
         depending on the connection type.
         :type max_buffer_len: integer
+
+        :param disable_telemetry: Should client telemetry be disabled
+        :type disable_telemetry: boolean
+
+        :param telemetry_min_flush_interval: Minimum flush interval for telemtry in seconds
+        :type telemetry_min_flush_interval: integer
+
+        :param telemetry_host: the host for the dogstatsd server we wish to submit
+        telemetry stats to. Optional. If telemetry is enabled and this is not specified
+        the default host will be used.
+        :type host: string
+
+        :param telemetry_port: the port for the dogstatsd server we wish to submit
+        telemetry stats to. Optional. If telemetry is enabled and this is not specified
+        the default host will be used.
+        :type port: integer
+
+        :param telemetry_socket_path: Submit client telemetry to dogstatsd through a UNIX
+        socket instead of UDP. If set, disables UDP transmission (Linux only)
+        :type telemetry_socket_path: string
         """
 
         self.lock = Lock()

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -116,7 +116,7 @@ class DogStatsd(object):
 
         :envvar DD_TELEMETRY_PORT: the port for the dogstatsd server we wish to submit
         telemetry stats to. If set, it overrides default value.
-        :type DD_TELEMETRY_HOST: string
+        :type DD_TELEMETRY_PORT: integer
 
         :param host: the host of the DogStatsd server.
         :type host: string

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -571,7 +571,7 @@ class DogStatsd(object):
         return self._telemetry and self._last_flush_time + self._telemetry_flush_interval < time.time()
 
     def _send_to_server(self, packet):
-        self._xmit_packet(packet, self._telemetry)
+        self._xmit_packet(packet, self._telemetry, False)
         if self._is_telemetry_flush_time():
             telemetry = self._flush_telemetry()
             if self._xmit_packet(telemetry, False):
@@ -586,7 +586,7 @@ class DogStatsd(object):
 
     def _xmit_packet(self, packet, account, is_telemetry):
         try:
-            if is_telemetry and self.telemetry_destination:
+            if is_telemetry and self._dedicated_telemetry_destination():
                 socket = (self.telemetry_socket or self.get_socket(telemetry=True))
             else:
                 # If set, use socket directly

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -155,7 +155,7 @@ class DogStatsd(object):
         :param disable_telemetry: Should client telemetry be disabled
         :type disable_telemetry: boolean
 
-        :param telemetry_min_flush_interval: Minimum flush interval for telemtry in seconds
+        :param telemetry_min_flush_interval: Minimum flush interval for telemetry in seconds
         :type telemetry_min_flush_interval: integer
 
         :param telemetry_host: the host for the dogstatsd server we wish to submit

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -24,7 +24,7 @@ from datadog.dogstatsd.route import get_default_route
 from datadog.util.compat import text
 from datadog.util.format import normalize_tags
 from datadog.version import __version__
-from typing import Optional, List, Text
+from typing import Optional, List, Text, Union
 
 # Logging
 log = logging.getLogger('datadog.dogstatsd')
@@ -72,7 +72,7 @@ class DogStatsd(object):
         ),                              # type: int
 
         telemetry_host=None,            # type: Text
-        telemetry_port=None,            # type: int
+        telemetry_port=None,            # type: Union[str, int]
         telemetry_socket_path=None,     # type: Text
         max_buffer_len=0                # type: int
     ):  # type: (...) -> None

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -735,7 +735,7 @@ class TestDogStatsd(unittest.TestCase):
 
         assert statsd.telemetry_host != None
         assert statsd.telemetry_port != None
-        assert statsd.telemetry_destination
+        assert statsd._dedicated_telemetry_destination()
 
         # set the last flush time in the future to be sure we won't flush
         statsd._last_flush_time = time.time() + statsd._telemetry_flush_interval


### PR DESCRIPTION
### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

In some esoteric setups or testing it might be useful to submit telemetry statistics to a different dogstatsd server. 

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR allows to set a different destination for telemetry metrics flushed. 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

No alternate designs were considered.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Added complexity to Dogstatsd constructor, could be confusing if not well documented.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

Unit tests updated. Feature is being used for dogstatsd performance/feature testing currently.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

None.

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

