### PR TITLE
Size-based packetization for dogstatsd batched metrics 

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -427,10 +427,7 @@ class DogStatsd(object):
         ))
 
     def _is_telemetry_flush_time(self):
-        if self._telemetry \
-           and self._last_flush_time + self._telemetry_flush_interval < time.time():
-            return True
-        return False
+        return self._last_flush_time + self._telemetry_flush_interval < time.time()
 
     def _send_to_server(self, packet):
         self._xmit_packet(packet, self._telemetry)

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -32,6 +32,10 @@ DEFAULT_PORT = 8125
 # Tag name of entity_id
 ENTITY_ID_TAG_NAME = "dd.internal.entity_id"
 
+# Default buffer settings
+UDP_OPTIMAL_PAYLOAD_LENGTH = 1432
+UDS_OPTIMAL_PAYLOAD_LENGTH = 8192
+
 # Mapping of each "DD_" prefixed environment variable to a specific tag name
 DD_ENV_TAGS_MAPPING = {
     'DD_ENTITY_ID': ENTITY_ID_TAG_NAME,
@@ -47,10 +51,11 @@ DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL = 10
 class DogStatsd(object):
     OK, WARNING, CRITICAL, UNKNOWN = (0, 1, 2, 3)
 
-    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT, max_buffer_size=50, namespace=None,
+    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT, max_buffer_size=None, namespace=None,
                  constant_tags=None, use_ms=False, use_default_route=False,
                  socket_path=None, default_sample_rate=1, disable_telemetry=False,
-                 telemetry_min_flush_interval=DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL):
+                 telemetry_min_flush_interval=DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL,
+                 max_buffer_len=0):
         """
         Initialize a DogStatsd object.
 
@@ -88,9 +93,8 @@ class DogStatsd(object):
         :param port: the port of the DogStatsd server.
         :type port: integer
 
-        :param max_buffer_size: Maximum number of metrics to buffer before sending to the server
-        if sending metrics in batch
-        :type max_buffer_size: integer
+        :max_buffer_size: Deprecated option, do not use it anymore.
+        :type max_buffer_type: None
 
         :param namespace: Namespace to prefix all metric names
         :type namespace: string
@@ -111,9 +115,18 @@ class DogStatsd(object):
 
         :param default_sample_rate: Sample rate to use by default for all metrics
         :type default_sample_rate: float
+
+        :param max_buffer_len: Maximum number of bytes to buffer before sending to the server
+        if sending metrics in batch. If not specified it will be adjusted to a optimal value
+        depending on the connection type.
+        :type max_buffer_len: integer
         """
 
         self.lock = Lock()
+
+        # Check for deprecated option
+        if max_buffer_size is not None:
+            log.warning("The parameter max_buffer_size is now deprecated and is not used anymore")
 
         # Check host and port env vars
         agent_host = os.environ.get('DD_AGENT_HOST')
@@ -129,20 +142,24 @@ class DogStatsd(object):
                 %s, using %s as port number", dogstatsd_port, port)
 
         # Connection
+        self._max_payload_size = max_buffer_len
         if socket_path is not None:
             self.socket_path = socket_path
             self.host = None
             self.port = None
             transport = "uds"
+            if not self._max_payload_size:
+                self._max_payload_size = UDP_OPTIMAL_PAYLOAD_LENGTH
         else:
             self.socket_path = None
             self.host = self.resolve_host(host, use_default_route)
             self.port = int(port)
             transport = "udp"
+            if not self._max_payload_size:
+                self._max_payload_size = UDS_OPTIMAL_PAYLOAD_LENGTH
 
         # Socket
         self.socket = None
-        self.max_buffer_size = max_buffer_size
         self._send = self._send_to_server
         self.encoding = 'utf-8'
 
@@ -168,7 +185,7 @@ class DogStatsd(object):
                 "client_version:{}".format(__version__),
                 "client_transport:{}".format(transport),
                 ]
-        self._reset_telementry()
+        self._reset_telemetry()
         self._telemetry_flush_interval = telemetry_min_flush_interval
         self._telemetry = not disable_telemetry
 
@@ -179,7 +196,7 @@ class DogStatsd(object):
         self._telemetry = True
 
     def __enter__(self):
-        self.open_buffer(self.max_buffer_size)
+        self.open_buffer()
         return self
 
     def __exit__(self, type, value, traceback):
@@ -221,9 +238,9 @@ class DogStatsd(object):
 
         return self.socket
 
-    def open_buffer(self, max_buffer_size=50):
+    def open_buffer(self, max_buffer_size=None):
         """
-        Open a buffer to send a batch of metrics in one packet.
+        Open a buffer to send a batch of metrics.
 
         You can also use this as a context manager.
 
@@ -231,7 +248,9 @@ class DogStatsd(object):
         >>>     batch.gauge('users.online', 123)
         >>>     batch.gauge('active.connections', 1001)
         """
-        self.max_buffer_size = max_buffer_size
+        if max_buffer_size is not None:
+            log.warning("The parameter max_buffer_size is now deprecated and is not used anymore")
+        self._current_buffer_total_size = 0
         self.buffer = []
         self._send = self._send_to_buffer
 
@@ -385,7 +404,7 @@ class DogStatsd(object):
         # Send it
         self._send(payload)
 
-    def _reset_telementry(self):
+    def _reset_telemetry(self):
         self.metrics_count = 0
         self.events_count = 0
         self.service_checks_count = 0
@@ -414,19 +433,27 @@ class DogStatsd(object):
         return False
 
     def _send_to_server(self, packet):
-        flush_telemetry = self._is_telemetry_flush_time()
-        if flush_telemetry:
-            packet += "\n"+self._flush_telemetry()
+        self._xmit_packet(packet, self._telemetry)
+        if self._is_telemetry_flush_time():
+            telemetry = self._flush_telemetry()
+            if self._xmit_packet(telemetry, False):
+                self._reset_telemetry()
+                self.packets_sent += 1
+                self.bytes_sent += len(telemetry)
+            else:
+                # Telemetry packet has been dropped, keep telemetry data for the next flush
+                self._last_flush_time = time.time()
+                self.bytes_dropped += len(telemetry)
+                self.packets_dropped += 1
 
+    def _xmit_packet(self, packet, telemetry):
         try:
             # If set, use socket directly
             (self.socket or self.get_socket()).send(packet.encode(self.encoding))
-            if self._telemetry:
-                if flush_telemetry:
-                    self._reset_telementry()
+            if telemetry:
                 self.packets_sent += 1
                 self.bytes_sent += len(packet)
-            return
+            return True
         except socket.timeout:
             # dogstatsd is overflowing, drop the packets (mimicks the UDP behaviour)
             pass
@@ -441,18 +468,26 @@ class DogStatsd(object):
                 self.close_socket()
         except Exception as e:
             log.error("Unexpected error: %s", str(e))
-
-        if self._telemetry:
+        if telemetry:
             self.bytes_dropped += len(packet)
             self.packets_dropped += 1
+        return False
 
     def _send_to_buffer(self, packet):
-        self.buffer.append(packet)
-        if len(self.buffer) >= self.max_buffer_size:
+        if self._should_flush(len(packet)):
             self._flush_buffer()
+        self.buffer.append(packet)
+        # Update the current buffer length, including line break to anticipate the final packet size
+        self._current_buffer_total_size += (len(packet) + 1)
+
+    def _should_flush(self, length_to_be_added):
+        if self._current_buffer_total_size + length_to_be_added > self._max_payload_size:
+            return True
+        return False
 
     def _flush_buffer(self):
         self._send_to_server("\n".join(self.buffer))
+        self._current_buffer_total_size = 0
         self.buffer = []
 
     def _escape_event_content(self, string):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -427,7 +427,7 @@ class DogStatsd(object):
         ))
 
     def _is_telemetry_flush_time(self):
-        return self._last_flush_time + self._telemetry_flush_interval < time.time()
+        return self._telemetry and self._last_flush_time + self._telemetry_flush_interval < time.time()
 
     def _send_to_server(self, packet):
         self._xmit_packet(packet, self._telemetry)

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -18,6 +18,7 @@ import unittest
 
 # 3p
 from mock import (
+    call,
     mock_open,
     patch,
 )
@@ -50,9 +51,12 @@ class FakeSocket(object):
             assert type(payload) == str
         self.payloads.append(payload)
 
-    def recv(self):
+    def recv(self, n = 1):
         try:
-            return self.payloads.popleft().decode('utf-8')
+            out = []
+            for i in range(n):
+                out.append(self.payloads.popleft().decode('utf-8'))
+            return '\n'.join(out)
         except IndexError:
             return None
 
@@ -77,10 +81,10 @@ class OverflownSocket(FakeSocket):
         raise error
 
 
-def telemetry_metrics(metrics=1, events=0, service_checks=0, bytes_sent=0, bytes_dropped=0, packets_sent=0, packets_dropped=0, transport="udp", tags=""):
+def telemetry_metrics(metrics=1, events=0, service_checks=0, bytes_sent=0, bytes_dropped=0, packets_sent=1, packets_dropped=0, transport="udp", tags=""):
     tags = "," + tags if tags else ""
 
-    return "\ndatadog.dogstatsd.client.metrics:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(metrics, version, transport, tags) \
+    return "datadog.dogstatsd.client.metrics:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(metrics, version, transport, tags) \
         + "datadog.dogstatsd.client.events:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(events, version, transport, tags) \
         + "datadog.dogstatsd.client.service_checks:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(service_checks, version, transport, tags) \
         + "datadog.dogstatsd.client.bytes_sent:{}|c|#client:py,client_version:{},client_transport:{}{}\n".format(bytes_sent, version, transport, tags) \
@@ -90,7 +94,8 @@ def telemetry_metrics(metrics=1, events=0, service_checks=0, bytes_sent=0, bytes
 
 def assert_equal_telemetry(expected_payload, actual_payload, telemetry=None):
     if telemetry is None:
-        telemetry = telemetry_metrics()
+        telemetry = telemetry_metrics(bytes_sent=len(expected_payload))
+    expected_payload += "\n"
     expected_payload += telemetry
     return assert_equal(expected_payload, actual_payload)
 
@@ -110,7 +115,7 @@ class TestDogStatsd(unittest.TestCase):
         self._procfs_mock.__enter__().return_value.readlines.return_value = route_data.split("\n")
 
     #def setup_method(self, method):
-    #    self.statsd._reset_telementry()
+    #    self.statsd._reset_telemetry()
 
     def tearDown(self):
         """
@@ -118,8 +123,11 @@ class TestDogStatsd(unittest.TestCase):
         """
         self._procfs_mock.__exit__()
 
-    def recv(self):
-        return self.statsd.socket.recv()
+    def recv(self, n=1):
+        packets = []
+        for _ in range(n):
+            packets.append(self.statsd.socket.recv())
+        return "\n".join(packets)
 
     def test_initialization(self):
         """
@@ -186,52 +194,52 @@ class TestDogStatsd(unittest.TestCase):
 
     def test_set(self):
         self.statsd.set('set', 123)
-        assert_equal_telemetry('set:123|s', self.recv())
+        assert_equal_telemetry('set:123|s', self.recv(2))
 
     def test_gauge(self):
         self.statsd.gauge('gauge', 123.4)
-        assert_equal_telemetry('gauge:123.4|g', self.recv())
+        assert_equal_telemetry('gauge:123.4|g', self.recv(2))
 
     def test_counter(self):
         self.statsd.increment('page.views')
-        assert_equal_telemetry('page.views:1|c', self.recv())
+        assert_equal_telemetry('page.views:1|c', self.recv(2))
 
-        self.statsd._reset_telementry()
+        self.statsd._reset_telemetry()
         self.statsd.increment('page.views', 11)
-        assert_equal_telemetry('page.views:11|c', self.recv())
+        assert_equal_telemetry('page.views:11|c', self.recv(2))
 
-        self.statsd._reset_telementry()
+        self.statsd._reset_telemetry()
         self.statsd.decrement('page.views')
-        assert_equal_telemetry('page.views:-1|c', self.recv())
+        assert_equal_telemetry('page.views:-1|c', self.recv(2))
 
-        self.statsd._reset_telementry()
+        self.statsd._reset_telemetry()
         self.statsd.decrement('page.views', 12)
-        assert_equal_telemetry('page.views:-12|c', self.recv())
+        assert_equal_telemetry('page.views:-12|c', self.recv(2))
 
     def test_histogram(self):
         self.statsd.histogram('histo', 123.4)
-        assert_equal_telemetry('histo:123.4|h', self.recv())
+        assert_equal_telemetry('histo:123.4|h', self.recv(2))
 
     def test_pipe_in_tags(self):
         self.statsd.gauge('gt', 123.4, tags=['pipe|in:tag', 'red'])
-        assert_equal_telemetry('gt:123.4|g|#pipe_in:tag,red', self.recv())
+        assert_equal_telemetry('gt:123.4|g|#pipe_in:tag,red', self.recv(2))
 
     def test_tagged_gauge(self):
         self.statsd.gauge('gt', 123.4, tags=['country:china', 'age:45', 'blue'])
-        assert_equal_telemetry('gt:123.4|g|#country:china,age:45,blue', self.recv())
+        assert_equal_telemetry('gt:123.4|g|#country:china,age:45,blue', self.recv(2))
 
     def test_tagged_counter(self):
         self.statsd.increment('ct', tags=[u'country:españa', 'red'])
-        assert_equal_telemetry(u'ct:1|c|#country:españa,red', self.recv())
+        assert_equal_telemetry(u'ct:1|c|#country:españa,red', self.recv(2))
 
     def test_tagged_histogram(self):
         self.statsd.histogram('h', 1, tags=['red'])
-        assert_equal_telemetry('h:1|h|#red', self.recv())
+        assert_equal_telemetry('h:1|h|#red', self.recv(2))
 
     def test_sample_rate(self):
         self.statsd._telemetry = False # disabling telemetry since sample_rate imply randomness
         self.statsd.increment('c', sample_rate=0)
-        assert not self.recv()
+        assert not self.statsd.socket.recv()
         for i in range(10000):
             self.statsd.increment('sampled_counter', sample_rate=0.3)
         self.assert_almost_equal(3000, len(self.statsd.socket.payloads), 150)
@@ -257,28 +265,32 @@ class TestDogStatsd(unittest.TestCase):
 
     def test_timing(self):
         self.statsd.timing('t', 123)
-        assert_equal_telemetry('t:123|ms', self.recv())
+        assert_equal_telemetry('t:123|ms', self.recv(2))
 
     def test_event(self):
         self.statsd.event('Title', u'L1\nL2', priority='low', date_happened=1375296969)
-        assert_equal_telemetry(u'_e{5,6}:Title|L1\\nL2|d:1375296969|p:low', self.recv(), telemetry=telemetry_metrics(metrics=0, events=1))
+        event = u'_e{5,6}:Title|L1\\nL2|d:1375296969|p:low'
+        assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
 
-        self.statsd._reset_telementry()
+        self.statsd._reset_telemetry()
 
         self.statsd.event('Title', u'♬ †øU †øU ¥ºu T0µ ♪',
                           aggregation_key='key', tags=['t1', 't2:v2'])
-        assert_equal_telemetry(u'_e{5,19}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2', self.recv(), telemetry=telemetry_metrics(metrics=0, events=1))
+        event = u'_e{5,19}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2'
+        assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
 
     def test_event_constant_tags(self):
         self.statsd.constant_tags = ['bar:baz', 'foo']
         self.statsd.event('Title', u'L1\nL2', priority='low', date_happened=1375296969)
-        assert_equal_telemetry(u'_e{5,6}:Title|L1\\nL2|d:1375296969|p:low|#bar:baz,foo', self.recv(), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo"))
+        event = u'_e{5,6}:Title|L1\\nL2|d:1375296969|p:low|#bar:baz,foo'
+        assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo", bytes_sent=len(event)))
 
-        self.statsd._reset_telementry()
+        self.statsd._reset_telemetry()
 
         self.statsd.event('Title', u'♬ †øU †øU ¥ºu T0µ ♪',
                           aggregation_key='key', tags=['t1', 't2:v2'])
-        assert_equal_telemetry(u'_e{5,19}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2,bar:baz,foo', self.recv(), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo"))
+        event = u'_e{5,19}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2,bar:baz,foo'
+        assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo", bytes_sent=len(event)))
 
     def test_service_check(self):
         now = int(time.time())
@@ -286,9 +298,8 @@ class TestDogStatsd(unittest.TestCase):
             'my_check.name', self.statsd.WARNING,
             tags=['key1:val1', 'key2:val2'], timestamp=now,
             hostname='i-abcd1234', message=u"♬ †øU \n†øU ¥ºu|m: T0µ ♪")
-        assert_equal_telemetry(
-            u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2|m:{2}'
-            .format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\: T0µ ♪"), self.recv(), telemetry=telemetry_metrics(metrics=0, service_checks=1))
+        check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\: T0µ ♪")
+        assert_equal_telemetry(check, self.recv(2), telemetry=telemetry_metrics(metrics=0, service_checks=1, bytes_sent=len(check)))
 
     def test_service_check_constant_tags(self):
         self.statsd.constant_tags = ['bar:baz', 'foo']
@@ -297,19 +308,19 @@ class TestDogStatsd(unittest.TestCase):
             'my_check.name', self.statsd.WARNING,
             timestamp=now,
             hostname='i-abcd1234', message=u"♬ †øU \n†øU ¥ºu|m: T0µ ♪")
-        assert_equal_telemetry(
-            u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#bar:baz,foo|m:{2}'
-            .format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\: T0µ ♪"), self.recv(), telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo"))
+        check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#bar:baz,foo|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\: T0µ ♪")
+        assert_equal_telemetry(check, self.recv(2),
+            telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo", bytes_sent=len(check)))
 
-        self.statsd._reset_telementry()
+        self.statsd._reset_telemetry()
 
         self.statsd.service_check(
             'my_check.name', self.statsd.WARNING,
             tags=['key1:val1', 'key2:val2'], timestamp=now,
             hostname='i-abcd1234', message=u"♬ †øU \n†øU ¥ºu|m: T0µ ♪")
-        assert_equal_telemetry(
-            u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2,bar:baz,foo|m:{2}'
-            .format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\: T0µ ♪"), self.recv(), telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo"))
+        check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2,bar:baz,foo|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\: T0µ ♪")
+        assert_equal_telemetry(check, self.recv(2),
+            telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo", bytes_sent=len(check)))
 
     def test_metric_namespace(self):
         """
@@ -317,31 +328,35 @@ class TestDogStatsd(unittest.TestCase):
         """
         self.statsd.namespace = "foo"
         self.statsd.gauge('gauge', 123.4)
-        assert_equal_telemetry('foo.gauge:123.4|g', self.recv())
+        assert_equal_telemetry('foo.gauge:123.4|g', self.recv(2))
 
     # Test Client level contant tags
     def test_gauge_constant_tags(self):
         self.statsd.constant_tags=['bar:baz', 'foo']
         self.statsd.gauge('gauge', 123.4)
-        assert_equal_telemetry('gauge:123.4|g|#bar:baz,foo', self.recv(), telemetry=telemetry_metrics(tags="bar:baz,foo"))
+        metric = 'gauge:123.4|g|#bar:baz,foo'
+        assert_equal_telemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz,foo", bytes_sent=len(metric)))
 
     def test_counter_constant_tag_with_metric_level_tags(self):
         self.statsd.constant_tags=['bar:baz', 'foo']
         self.statsd.increment('page.views', tags=['extra'])
-        assert_equal_telemetry('page.views:1|c|#extra,bar:baz,foo', self.recv(), telemetry=telemetry_metrics(tags="bar:baz,foo"))
+        metric = 'page.views:1|c|#extra,bar:baz,foo'
+        assert_equal_telemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz,foo", bytes_sent=len(metric)))
 
     def test_gauge_constant_tags_with_metric_level_tags_twice(self):
         metric_level_tag = ['foo:bar']
         self.statsd.constant_tags=['bar:baz']
         self.statsd.gauge('gauge', 123.4, tags=metric_level_tag)
-        assert_equal_telemetry('gauge:123.4|g|#foo:bar,bar:baz', self.recv(), telemetry=telemetry_metrics(tags="bar:baz"))
+        metric = 'gauge:123.4|g|#foo:bar,bar:baz'
+        assert_equal_telemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz", bytes_sent=len(metric)))
 
-        self.statsd._reset_telementry()
+        self.statsd._reset_telemetry()
 
         # sending metrics multiple times with same metric-level tags
         # should not duplicate the tags being sent
         self.statsd.gauge('gauge', 123.4, tags=metric_level_tag)
-        assert_equal_telemetry('gauge:123.4|g|#foo:bar,bar:baz', self.recv(), telemetry=telemetry_metrics(tags="bar:baz"))
+        metric = "gauge:123.4|g|#foo:bar,bar:baz"
+        assert_equal_telemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz", bytes_sent=len(metric)))
 
     @staticmethod
     def assert_almost_equal(a, b, delta):
@@ -361,7 +376,8 @@ class TestDogStatsd(unittest.TestCase):
         with mock.patch("datadog.dogstatsd.base.log") as mock_log:
             self.statsd.gauge('no error', 1)
             mock_log.error.assert_not_called()
-            mock_log.warning.assert_called_once_with("Socket send would block: Socket error, dropping the packet")
+            c = [call("Socket send would block: Socket error, dropping the packet")]
+            mock_log.warning.assert_has_calls(c * 2)
 
     def test_timed(self):
         """
@@ -381,7 +397,7 @@ class TestDogStatsd(unittest.TestCase):
         # Assert it handles args and kwargs correctly.
         assert_equal(result, (1, 2, 1, 3))
 
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -398,7 +414,7 @@ class TestDogStatsd(unittest.TestCase):
 
         func(1, 2, d=3)
 
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -423,7 +439,7 @@ class TestDogStatsd(unittest.TestCase):
         func(1, 2, d=3)
 
         # Assess the packet
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -440,7 +456,7 @@ class TestDogStatsd(unittest.TestCase):
 
         func(1, 2, d=3)
 
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv()
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -466,7 +482,7 @@ class TestDogStatsd(unittest.TestCase):
         # Assert it handles args and kwargs correctly.
         assert_equal(result, (1, 2, 1, 3))
 
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -495,7 +511,7 @@ class TestDogStatsd(unittest.TestCase):
         loop.close()
 
         # Assert
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -512,7 +528,7 @@ class TestDogStatsd(unittest.TestCase):
             assert isinstance(timer, TimedContextManagerDecorator)
             time.sleep(0.5)
 
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -525,7 +541,7 @@ class TestDogStatsd(unittest.TestCase):
         with self.statsd.timed('timed_context.test', use_ms=True) as timer:
             time.sleep(0.5)
 
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -551,7 +567,7 @@ class TestDogStatsd(unittest.TestCase):
             func(self)
 
         # Ensure the timing was recorded.
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -571,7 +587,7 @@ class TestDogStatsd(unittest.TestCase):
             func(self)
 
         # Ensure the timing was recorded.
-        packet = self.recv()
+        packet = self.statsd.socket.recv()
         assert_equal(packet, None)
 
     def test_timed_start_stop_calls(self):
@@ -581,7 +597,7 @@ class TestDogStatsd(unittest.TestCase):
         time.sleep(0.5)
         timer.stop()
 
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -595,7 +611,7 @@ class TestDogStatsd(unittest.TestCase):
         time.sleep(0.5)
         timer.stop()
 
-        packet = self.recv().split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -608,8 +624,8 @@ class TestDogStatsd(unittest.TestCase):
         self.statsd.gauge('page.views', 123)
         self.statsd.timing('timer', 123)
         self.statsd.close_buffer()
-
-        assert_equal_telemetry("page.views:123|g\ntimer:123|ms", self.recv(), telemetry=telemetry_metrics(metrics=2))
+        expected = "page.views:123|g\ntimer:123|ms"
+        assert_equal_telemetry(expected, self.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=len(expected)))
 
     def test_telemetry(self):
         self.statsd.metrics_count = 1
@@ -624,16 +640,16 @@ class TestDogStatsd(unittest.TestCase):
         self.statsd.gauge('page.views', 123)
         self.statsd.close_buffer()
 
-        telemetry = telemetry_metrics(metrics=2, events=2, service_checks=3, bytes_sent=4,
-                                          bytes_dropped=5,  packets_sent=6, packets_dropped=7)
-
         payload = "page.views:123|g"
-        assert_equal_telemetry(payload, self.recv(), telemetry=telemetry)
+        telemetry = telemetry_metrics(metrics=2, events=2, service_checks=3, bytes_sent=4 + len(payload),
+                                          bytes_dropped=5,  packets_sent=7, packets_dropped=7)
+
+        assert_equal_telemetry(payload, self.recv(2), telemetry=telemetry)
 
         assert_equal(0, self.statsd.metrics_count)
         assert_equal(0, self.statsd.events_count)
         assert_equal(0, self.statsd.service_checks_count)
-        assert_equal(len(payload) + len(telemetry), self.statsd.bytes_sent)
+        assert_equal(len(telemetry), self.statsd.bytes_sent)
         assert_equal(0, self.statsd.bytes_dropped)
         assert_equal(1, self.statsd.packets_sent)
         assert_equal(0, self.statsd.packets_dropped)
@@ -647,14 +663,15 @@ class TestDogStatsd(unittest.TestCase):
         statsd._last_flush_time = time.time() + statsd._telemetry_flush_interval
         statsd.gauge('gauge', 123.4)
 
-        assert_equal('gauge:123.4|g', fake_socket.recv())
+        metric = 'gauge:123.4|g'
+        assert_equal(metric, fake_socket.recv())
 
         t1 = time.time()
         # setting the last flush time in the past to trigger a telemetry flush
         statsd._last_flush_time = t1 - statsd._telemetry_flush_interval -1
         statsd.gauge('gauge', 123.4)
+        assert_equal_telemetry(metric, fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=2*len(metric), packets_sent=2))
 
-        assert_equal_telemetry('gauge:123.4|g', fake_socket.recv(), telemetry=telemetry_metrics(metrics=2, bytes_sent=13, packets_sent=1))
         # assert that _last_flush_time has been updated
         assert t1 < statsd._last_flush_time
 
@@ -674,7 +691,8 @@ class TestDogStatsd(unittest.TestCase):
 
         statsd.close_buffer()
 
-        assert_equal_telemetry('gauge1:1|g\ngauge2:2|g', fake_socket.recv(), telemetry=telemetry_metrics(metrics=2))
+        metric = 'gauge1:1|g\ngauge2:2|g'
+        assert_equal_telemetry(metric, fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=len(metric)))
         # assert that _last_flush_time has been updated
         assert t1 < statsd._last_flush_time
 
@@ -684,24 +702,29 @@ class TestDogStatsd(unittest.TestCase):
             statsd.socket = fake_socket
             statsd.gauge('page.views', 123)
             statsd.timing('timer', 123)
-
-        assert_equal_telemetry("page.views:123|g\ntimer:123|ms", fake_socket.recv(), telemetry=telemetry_metrics(metrics=2))
-
+        metric = "page.views:123|g\ntimer:123|ms"
+        assert_equal(metric, fake_socket.recv())
+        assert_equal(telemetry_metrics(metrics=2, bytes_sent=len(metric)), fake_socket.recv())
+        # assert_equal_telemetry("page.views:123|g\ntimer:123|ms", fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2))
     def test_batched_buffer_autoflush(self):
         fake_socket = FakeSocket()
         bytes_sent = 0
         with DogStatsd(telemetry_min_flush_interval=0) as statsd:
+            single_metric = 'mycounter:1|c'
+            statsd._max_payload_size = 2048
+            metrics_per_packet = statsd._max_payload_size // (len(single_metric) + 1)
             statsd.socket = fake_socket
-            for i in range(51):
+            for i in range(metrics_per_packet + 1):
                 statsd.increment('mycounter')
-            payload = '\n'.join(['mycounter:1|c' for i in range(50)])
+            payload = '\n'.join([single_metric for i in range(metrics_per_packet)])
 
-            telemetry = telemetry_metrics(metrics=50)
-            bytes_sent += len(payload)+len(telemetry)
-
-            assert_equal_telemetry(payload, fake_socket.recv(), telemetry=telemetry)
-
-        assert_equal_telemetry('mycounter:1|c', fake_socket.recv(), telemetry=telemetry_metrics(packets_sent=1, bytes_sent=bytes_sent))
+            telemetry = telemetry_metrics(metrics=metrics_per_packet+1, bytes_sent=len(payload))
+            bytes_sent += len(payload) + len(telemetry)
+            assert_equal(payload, fake_socket.recv())
+            assert_equal(telemetry, fake_socket.recv())
+        assert_equal(single_metric, fake_socket.recv())
+        telemetry = telemetry_metrics(metrics=0, packets_sent=2, bytes_sent=len(single_metric) + len(telemetry))
+        assert_equal(telemetry, fake_socket.recv())
 
     def test_module_level_instance(self):
         assert isinstance(statsd, DogStatsd)
@@ -730,18 +753,20 @@ class TestDogStatsd(unittest.TestCase):
             statsd = DogStatsd(telemetry_min_flush_interval=0)
         statsd.socket = FakeSocket()
         statsd.gauge('gt', 123.4)
-        assert_equal_telemetry('gt:123.4|g|#country:china,age:45,blue',
-                statsd.socket.recv(),
-                telemetry=telemetry_metrics(tags="country:china,age:45,blue"))
+        metric = 'gt:123.4|g|#country:china,age:45,blue'
+        assert_equal(metric, statsd.socket.recv())
+        assert_equal(telemetry_metrics(tags="country:china,age:45,blue", bytes_sent=len(metric)), statsd.socket.recv())
 
     def test_tags_from_environment_and_constant(self):
         with preserve_environment_variable('DATADOG_TAGS'):
-           os.environ['DATADOG_TAGS'] = 'country:china,age:45,blue'
-           statsd = DogStatsd(constant_tags=['country:canada', 'red'], telemetry_min_flush_interval=0)
+            os.environ['DATADOG_TAGS'] = 'country:china,age:45,blue'
+            statsd = DogStatsd(constant_tags=['country:canada', 'red'], telemetry_min_flush_interval=0)
         statsd.socket = FakeSocket()
         statsd.gauge('gt', 123.4)
         tags="country:canada,red,country:china,age:45,blue"
-        assert_equal_telemetry('gt:123.4|g|#'+tags, statsd.socket.recv(), telemetry=telemetry_metrics(tags=tags))
+        metric = 'gt:123.4|g|#'+tags
+        assert_equal(metric, statsd.socket.recv())
+        assert_equal(telemetry_metrics(tags=tags, bytes_sent=len(metric)), statsd.socket.recv())
 
     def test_entity_tag_from_environment(self):
         with preserve_environment_variable('DD_ENTITY_ID'):
@@ -749,9 +774,11 @@ class TestDogStatsd(unittest.TestCase):
             statsd = DogStatsd(telemetry_min_flush_interval=0)
         statsd.socket = FakeSocket()
         statsd.gauge('gt', 123.4)
-        assert_equal_telemetry('gt:123.4|g|#dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d',
-                statsd.socket.recv(),
-                telemetry=telemetry_metrics(tags="dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d"))
+        metric = 'gt:123.4|g|#dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d'
+        assert_equal(metric, statsd.socket.recv())
+        assert_equal(
+            telemetry_metrics(tags="dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d", bytes_sent=len(metric)),
+            statsd.socket.recv())
 
     def test_entity_tag_from_environment_and_constant(self):
         with preserve_environment_variable('DD_ENTITY_ID'):
@@ -759,9 +786,11 @@ class TestDogStatsd(unittest.TestCase):
             statsd = DogStatsd(constant_tags=['country:canada', 'red'], telemetry_min_flush_interval=0)
         statsd.socket = FakeSocket()
         statsd.gauge('gt', 123.4)
-        assert_equal_telemetry('gt:123.4|g|#country:canada,red,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d',
-                statsd.socket.recv(),
-                telemetry=telemetry_metrics(tags="country:canada,red,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d"))
+        metric = 'gt:123.4|g|#country:canada,red,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d'
+        assert_equal(metric, statsd.socket.recv())
+        assert_equal(
+            telemetry_metrics(tags="country:canada,red,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d",
+            bytes_sent=len(metric)), statsd.socket.recv())
 
     def test_entity_tag_and_tags_from_environment_and_constant(self):
         with preserve_environment_variable('DATADOG_TAGS'):
@@ -772,7 +801,9 @@ class TestDogStatsd(unittest.TestCase):
         statsd.socket = FakeSocket()
         statsd.gauge('gt', 123.4)
         tags = "country:canada,red,country:china,age:45,blue,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d"
-        assert_equal_telemetry('gt:123.4|g|#'+tags, statsd.socket.recv(), telemetry=telemetry_metrics(tags=tags))
+        metric = 'gt:123.4|g|#'+tags
+        assert_equal(metric, statsd.socket.recv())
+        assert_equal(telemetry_metrics(tags=tags, bytes_sent=len(metric)), statsd.socket.recv())
 
     def test_dogstatsd_initialization_with_dd_env_service_version(self):
         """
@@ -812,40 +843,37 @@ class TestDogStatsd(unittest.TestCase):
             # Make call with no tags passed; only the globally configured tags will be used.
             global_tags_str = ','.join([t for t in global_tags])
             statsd.gauge('gt', 123.4)
-            assert_equal_telemetry(
-                # Protect against the no tags case.
-                'gt:123.4|g|#{}'.format(global_tags_str) if global_tags_str else 'gt:123.4|g',
-                statsd.socket.recv(),
-                telemetry=telemetry_metrics(tags=global_tags_str)
-            )
-            statsd._reset_telementry()
+            # Protect against the no tags case.
+            metric = 'gt:123.4|g|#{}'.format(global_tags_str) if global_tags_str else 'gt:123.4|g'
+            assert_equal(metric, statsd.socket.recv())
+            assert_equal(telemetry_metrics(tags=global_tags_str, bytes_sent=len(metric)), statsd.socket.recv())
+            statsd._reset_telemetry()
 
             # Make another call with local tags passed.
             passed_tags = ['env:prod', 'version:def456', 'custom_tag:toad']
             all_tags_str = ','.join([t for t in passed_tags + global_tags])
             statsd.gauge('gt', 123.4, tags=passed_tags)
-            assert_equal_telemetry(
-                'gt:123.4|g|#{}'.format(all_tags_str),
-                statsd.socket.recv(),
-                telemetry=telemetry_metrics(tags=global_tags_str)
-            )
+
+            metric = 'gt:123.4|g|#{}'.format(all_tags_str)
+            assert_equal(metric, statsd.socket.recv())
+            assert_equal(telemetry_metrics(tags=global_tags_str, bytes_sent=len(metric)), statsd.socket.recv())
 
     def test_gauge_doesnt_send_None(self):
         self.statsd.gauge('metric', None)
-        assert self.recv() is None
+        assert self.statsd.socket.recv() is None
 
     def test_increment_doesnt_send_None(self):
         self.statsd.increment('metric', None)
-        assert self.recv() is None
+        assert self.statsd.socket.recv() is None
 
     def test_decrement_doesnt_send_None(self):
         self.statsd.decrement('metric', None)
-        assert self.recv() is None
+        assert self.statsd.socket.recv() is None
 
     def test_timing_doesnt_send_None(self):
         self.statsd.timing('metric', None)
-        assert self.recv() is None
+        assert self.statsd.socket.recv() is None
 
     def test_histogram_doesnt_send_None(self):
         self.statsd.histogram('metric', None)
-        assert self.recv() is None
+        assert self.statsd.socket.recv() is None


### PR DESCRIPTION
### What does this PR do?
It improves the packetization while sending batched metrics with packet size adjusted to prevent fragmentation while maximizing payload usage. Telemetry is sent in separate packets, once every 10 seconds won't impact overall performance. API is backward compatible, `max_buffer_size` has been deprecated but not removed, warning are logged if the parameter is used when building `Dogstatsd` objects.
<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change
It adds sending heuristic based on current buffer length. Some approximation regarding the actual bytes sent on wire include unicode character encoding (note that the telemetry is not accounting for that either).
<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
Better optimal packet size detection could have been considered but it seems overkill, moreover the settings can be overridden.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Unit tests, integration tests, manual tests, packet capture.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes
Future rework of the client is planned and will include better multithreading awareness and optimal packet size management without the need to use batched metrics pattern.
<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

