### PR TITLE
Initial support for Python type hints and Mypy type checking

### DIFF
--- a/.azure-pipelines/unit_tests.yml
+++ b/.azure-pipelines/unit_tests.yml
@@ -39,6 +39,9 @@ jobs:
       Lint:
         PYTHON_VERSION: "3.5"
         TOXENV: "flake8"
+      Mypy:
+        PYTHON_VERSION: "3.5"
+        TOXENV: "mypy"
   steps:
   - task: UsePythonVersion@0
     displayName: Use python $(PYTHON_VERSION)

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.mypy_cache
 
 #Doc
 ###doc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
+include datadog/py.typed
 graft tests

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -60,6 +60,10 @@ def initialize(api_key=None,                    # type: Optional[str]
     :param host_name: Set a specific hostname
     :type host_name: string
 
+    :param proxies: Proxy to use to connect to Datadog API;
+                    for example, 'proxies': {'http': "http:<user>:<pass>@<ip>:<port>/"}
+    :type proxies: dictionary mapping protocol to the URL of the proxy.
+
     :param api_host: Datadog API endpoint
     :type api_host: url
 

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -14,6 +14,7 @@ without hindering performance.
 import logging
 import os
 import os.path
+from typing import Any, List, Optional
 
 # datadog
 from datadog import api
@@ -32,10 +33,21 @@ logging.getLogger('datadog.dogstatsd').addHandler(NullHandler())
 logging.getLogger('datadog.threadstats').addHandler(NullHandler())
 
 
-def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
-               statsd_host=None, statsd_port=None, statsd_use_default_route=False,
-               statsd_socket_path=None, statsd_namespace=None, statsd_constant_tags=None,
-               return_raw_response=False, hostname_from_config=True, **kwargs):
+def initialize(api_key=None,                    # type: Optional[str]
+               app_key=None,                    # type: Optional[str]
+               host_name=None,                  # type: Optional[str]
+               api_host=None,                   # type: Optional[str]
+               statsd_host=None,                # type: Optional[str]
+               statsd_port=None,                # type: Optional[int]
+               statsd_use_default_route=False,  # type: bool
+               statsd_socket_path=None,         # type: Optional[str]
+               statsd_namespace=None,           # type: Optional[str]
+               statsd_constant_tags=None,       # type: Optional[List[str]]
+               return_raw_response=False,       # type: bool
+               hostname_from_config=True,       # type: bool
+               **kwargs                         # type: Any
+               ):
+    # type: (...) -> None
     """
     Initialize and configure Datadog.api and Datadog.statsd modules
 
@@ -47,10 +59,6 @@ def initialize(api_key=None, app_key=None, host_name=None, api_host=None,
 
     :param host_name: Set a specific hostname
     :type host_name: string
-
-    :param proxies: Proxy to use to connect to Datadog API;
-                    for example, 'proxies': {'http': "http:<user>:<pass>@<ip>:<port>/"}
-    :type proxies: dictionary mapping protocol to the URL of the proxy.
 
     :param api_host: Datadog API endpoint
     :type api_host: url

--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -3,12 +3,14 @@
 # Copyright 2015-Present Datadog, Inc
 # flake8: noqa
 
+from typing import Optional
+
 # API settings
-_api_key = None
-_application_key = None
+_api_key = None          # type: Optional[str]
+_application_key = None  # type: Optional[str]
 _api_version = 'v1'
-_api_host = None
-_host_name = None
+_api_host = None         # type: Optional[str]
+_host_name = None        # type: Optional[str]
 _hostname_from_config = True
 _cacert = True
 

--- a/datadog/api/format.py
+++ b/datadog/api/format.py
@@ -1,12 +1,14 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
 from numbers import Number
+import sys
 import time
+
+if sys.version_info[0] >= 3:
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 
 def format_points(points):

--- a/datadog/api/http_client.py
+++ b/datadog/api/http_client.py
@@ -18,7 +18,7 @@ try:
     import requests
     import requests.adapters
 except ImportError:
-    requests = None
+    requests = None  # type: ignore
 
 try:
     from google.appengine.api import urlfetch, urlfetch_errors

--- a/datadog/dogstatsd/context.py
+++ b/datadog/dogstatsd/context.py
@@ -6,20 +6,8 @@ from functools import wraps
 from time import time
 
 # datadog
-from datadog.util.compat import (
-    is_higher_py35,
-    iscoroutinefunction,
-)
-
-
-if is_higher_py35():
-    from datadog.dogstatsd.context_async import _get_wrapped_co
-else:
-    def _get_wrapped_co(self, func):
-        raise NotImplementedError(
-            u"Decorator `timed` compatibility with coroutine functions"
-            u" requires Python 3.5 or higher."
-        )
+from datadog.dogstatsd.context_async import _get_wrapped_co
+from datadog.util.compat import iscoroutinefunction
 
 
 class TimedContextManagerDecorator(object):

--- a/datadog/dogstatsd/context_async.py
+++ b/datadog/dogstatsd/context_async.py
@@ -7,9 +7,20 @@ Decorator `timed` for coroutine methods.
 Warning: requires Python 3.5 or higher.
 """
 # stdlib
+import sys
+
+
+# Wrap the Python 3.5+ function in a docstring to avoid syntax errors when
+# running mypy in --py2 mode. Currently there is no way to have mypy skip an
+# entire file if it has syntax errors. This solution is very hacky; another
+# option is to specify the source files to process in mypy.ini (using glob
+# inclusion patterns), and omit this file from the list.
+#
+# https://stackoverflow.com/a/57023749/3776794
+# https://github.com/python/mypy/issues/6897
+ASYNC_SOURCE = r'''
 from functools import wraps
 from time import time
-
 
 def _get_wrapped_co(self, func):
     """
@@ -24,3 +35,15 @@ def _get_wrapped_co(self, func):
         finally:
             self._send(start)
     return wrapped_co
+'''
+
+
+def _get_wrapped_co(self, func):
+    raise NotImplementedError(
+        u"Decorator `timed` compatibility with coroutine functions"
+        u" requires Python 3.5 or higher."
+    )
+
+
+if sys.version_info >= (3, 5):
+    exec(compile(ASYNC_SOURCE, __file__, "exec"))

--- a/datadog/dogstatsd/context_async.py
+++ b/datadog/dogstatsd/context_async.py
@@ -22,6 +22,7 @@ ASYNC_SOURCE = r'''
 from functools import wraps
 from time import time
 
+
 def _get_wrapped_co(self, func):
     """
     `timed` wrapper for coroutine methods.

--- a/datadog/util/compat.py
+++ b/datadog/util/compat.py
@@ -23,7 +23,6 @@ if sys.version_info[0] >= 3:
     import configparser
     from configparser import ConfigParser
     from io import StringIO
-    import pkg_resources as pkg
     from urllib.parse import urljoin, urlparse
     import urllib.request as url_lib, urllib.error, urllib.parse
 
@@ -40,14 +39,13 @@ if sys.version_info[0] >= 3:
 else:
     import __builtin__ as builtins
     import ConfigParser as configparser
-    from ConfigParser import ConfigParser
+    from configparser import ConfigParser
     from cStringIO import StringIO
     from itertools import imap
     import urllib2 as url_lib
     from urlparse import urljoin, urlparse
     from UserDict import IterableUserDict
 
-    pkg = None
     get_input = raw_input
     text = unicode
 
@@ -75,6 +73,11 @@ else:
     class NullHandler(Handler):
         def emit(self, record):
             pass
+
+try:
+    import pkg_resources as pkg
+except ImportError:
+    pkg = None  # type: ignore
 
 
 def _is_py_version_higher_than(major, minor=0):

--- a/datadog/util/hostname.py
+++ b/datadog/util/hostname.py
@@ -8,6 +8,7 @@ import re
 import socket
 import subprocess
 import types
+from typing import Dict, Optional
 
 # datadog
 from datadog.util.compat import url_lib, is_p3k, iteritems
@@ -39,6 +40,7 @@ def is_valid_hostname(hostname):
 
 
 def get_hostname(hostname_from_config):
+    # type: (bool) -> Optional[str]
     """
     Get the canonical host name this agent should identify as. This is
     the authoritative source of the host name for the agent.
@@ -102,7 +104,7 @@ def get_hostname(hostname_from_config):
     # fall back on socket.gethostname(), socket.getfqdn() is too unreliable
     if hostname is None:
         try:
-            socket_hostname = socket.gethostname()
+            socket_hostname = socket.gethostname()  # type: Optional[str]
         except socket.error:
             socket_hostname = None
         if socket_hostname and is_valid_hostname(socket_hostname):
@@ -188,7 +190,7 @@ class EC2(object):
     """
     URL = "http://169.254.169.254/latest/meta-data"
     TIMEOUT = 0.1  # second
-    metadata = {}
+    metadata = {}  # type: Dict[str, str]
 
     @staticmethod
     def get_tags(agentConfig):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,22 @@
 [mypy]
 
+# Ignore Mypy errors about packages with missing type hints.
+#
+# Note: If Python 2 support is dropped in the future, `pkg_resources` and
+# `configparser` will no longer need to be ignored because the Python 3
+# versions have type hints.
+
 [mypy-boto.*]
+ignore_missing_imports = True
+
+[mypy-configparser.*]
 ignore_missing_imports = True
 
 [mypy-gevent.*]
 ignore_missing_imports = True
 
 [mypy-google.*]
+ignore_missing_imports = True
+
+[mypy-pkg_resources.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+
+[mypy-boto.*]
+ignore_missing_imports = True
+
+[mypy-gevent.*]
+ignore_missing_imports = True
+
+[mypy-google.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,11 @@ def get_readme_md_contents():
 
 install_reqs = ["decorator>=3.3.2", "requests>=2.6.0"]
 
-if [sys.version_info[0], sys.version_info[1]] < [2, 7]:
+if sys.version_info < (2, 7):
     install_reqs.append("argparse>=1.2")
+
+if sys.version_info < (3, 5):
+    install_reqs.append("typing")
 
 setup(
     name="datadog",

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=install_reqs,
     tests_require=["pytest", "mock", "freezegun"],
     packages=["datadog", "datadog.api", "datadog.dogstatsd", "datadog.threadstats", "datadog.util", "datadog.dogshell"],
+    package_data={"datadog": ["py.typed"]},
     author="Datadog, Inc.",
     long_description=get_readme_md_contents(),
     long_description_content_type="text/markdown",
@@ -61,4 +62,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
+    # Required by Mypy when declaring PEP 561 compatibility with `py.typed`
+    # file.
+    zip_safe=False
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{27,35,36,37,38,py2,py3}
     flake8
     integration
+    mypy
 
 [testenv]
 passenv = DD_TEST_CLIENT*
@@ -39,6 +40,15 @@ skip_install = true
 deps =
     flake8==3.7.9
 commands = flake8 datadog
+
+[testenv:mypy]
+basepython = python3
+skip_install = true
+deps =
+    mypy==0.770
+commands =
+    mypy --config-file mypy.ini datadog
+    mypy --config-file mypy.ini --py2 datadog
 
 [flake8]
 max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,8 @@ deps =
 commands = flake8 datadog
 
 [testenv:mypy]
+# Mypy requires Python 3.5 or higher (but it can still type-check Python 2
+# code).
 basepython = python3
 skip_install = true
 deps =


### PR DESCRIPTION
### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

This PR begins to address #311 by adding initial support for Python type hints and type checking via Mypy.

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR updates the codebase to support Mypy type checking and includes type hints for a couple of functions. Before adding type hints to the entire codebase, I wanted to share these initial changes and see if this is a direction that maintainers want to move in. This PR can be merged on its own (with follow-up PRs to add additional type hints), or I'm also happy to continue adding type hints here before merge.

Type hints use the comment-based syntax described in [PEP 484](https://www.python.org/dev/peps/pep-0484/) to be compatible with both Python 2 and 3. Other changes to the codebase were necessary in order to fix a few Mypy errors (commented in the code and noted below).

The following changes were made:

- The functions `datadog.initialize` and `datadog.util.hostname.get_hostname` have been updated with type hints. These functions serve as examples of multi-line and single-line annotations, respectively.
- The package declares [PEP 561](https://www.python.org/dev/peps/pep-0561/) type hint compatibility via a `py.typed` marker file.
- There is a new tox `mypy` environment for running the Mypy type checker in Python 2 and Python 3 modes (`tox -e mypy`). This is hooked up to the CI job matrix.
- A few updates were necessary to fix Mypy errors related to version-specific code paths (most of the changes happened in `datadog.util.compat`). Mypy requires using `sys.version_info` directly instead of helper functions or variables to detect version-specific code paths. Also, mypy doesn't support try/except imports for version-specific code paths (more details [here](https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks)).
- I added a hack to `datadog.dogstatsd.context_async` to avoid Mypy syntax errors (see code comment for details and an alternative solution).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Comment-based annotations are used over function annotations because the codebase must be Python 2/3 compatible. If support for Python 2 is dropped in the future, it may be desirable to use Python 3 function annotations instead. Also, the `sys.version_info` checks could be removed, and the hack in `datadog.dogstatsd.context_async` could be reverted.

If the hack in `datadog.dogstatsd.context_async` is undesirable, another option is to specify the source files to process in `mypy.ini` (using `glob` inclusion patterns), and omit `datadog.dogstatsd.context_async` from the list. I chose the current hack because manually listing the source files to include (even with recursive `glob`) could be error-prone (e.g. if a new module or subpackage is added, the developer would have to remember to update `mypy.ini` to include the file or folder).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

The changes introduce some complexity in a couple of places (mainly the hack in `datadog.dogstatsd.context_async` and requiring the direct usage of `sys.version_info` for version-specific code). Also, the type hints may be redundant in cases where a function's docstring already describes parameter types. Mypy may complain about invalid assignment statements in type-hinted functions, and typing annotations may need to be applied to fix these errors.

There shouldn't be noticeable performance issues to users.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

I tested the changes locally with tox and added a new `mypy` environment to ensure future changes are tested automatically in CI/CD. I used the new `mypy` environment to find and fix all errors, and verified that new Mypy errors are reported as tox failures.

To run the new `mypy` environment: `tox -e mypy`

### Additional Notes

<!-- Anything else we should know when reviewing? -->

N/A

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

N/A

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [x] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

