### PR TITLE
Use Python 2 compatible configparser explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_reqs = [
     "decorator>=3.3.2",
     "requests>=2.6.0",
     'typing;python_version<"3.5"',
-    'configparser;python_version<"3.0"',
+    'configparser<5;python_version<"3.0"',
 ]
 
 if sys.version_info < (2, 7):


### PR DESCRIPTION
### What does this PR do?

Fixes install errors on python 2 with pip<9
Fixes #584

### Description of the Change

Specifies the dependency on `configparser` to explicitly be `configparser<5`

### Alternate Designs

Ideally this restriction would only be imposed when necessary (pip<9 is being used), but I don't believe there's a way to dynamically alter package requirements based on the version of pip being used.

### Possible Drawbacks

Missing new features backported through configparser if they ever reintroduce python 2 support in versions >= 5

### Verification Process

Built a new python 2 wheel with `python setup.py sdist bdist_wheel`
Created a virtual envrionment with python 2.7.12 and pip 8.1.1
Installed the newly created wheel file into that virtualenvironment using that older version of pip

### Additional Notes

N/A

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

