### PR TITLE
Add environment variable to disable statsd metric collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ tags = ['version:1', 'application:web']
 api.Event.create(title=title, text=text, tags=tags)
 ```
 
-In development, you can disable any `statsd` metric collection using `DD_DOGSTATSD_ENABLE=False`.
+In development, you can disable any `statsd` metric collection using `DD_DOGSTATSD_DISABLE=True` (or any not-empty value).
 
 ## DogStatsD
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ tags = ['version:1', 'application:web']
 api.Event.create(title=title, text=text, tags=tags)
 ```
 
+In development, you can disable any `statsd` metric collection using `DD_DOGSTATSD_ENABLE=False`.
+
 ## DogStatsD
 
 In order to use DogStatsD metrics, the Agent must be [running and available](https://docs.datadoghq.com/developers/dogstatsd/?tab=python).

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -421,7 +421,7 @@ class DogStatsd(object):
         """
         if value is None:
             return
-        
+
         if self._enabled is not True:
             return
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -158,7 +158,7 @@ class DogStatsd(object):
                 %s, using %s as port number", dogstatsd_port, port)
 
         # Check enabled
-        if os.environ.get('DD_DOGSTATSD_ENABLE', 'True') == 'True':
+        if os.environ.get('DD_DOGSTATSD_ENABLE', 'True') in {'True', 'true', 'yes', '1'}:
             self._enabled = True
         else:
             self._enabled = False

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -158,7 +158,7 @@ class DogStatsd(object):
                 %s, using %s as port number", dogstatsd_port, port)
 
         # Check enabled
-        if os.environ.get('DD_DOGSTATSD_ENABLE', 'True') in {'True', 'true', 'yes', '1'}:
+        if os.environ.get('DD_DOGSTATSD_DISABLE') not in {'True', 'true', 'yes', '1'}:
             self._enabled = True
         else:
             self._enabled = False

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -100,6 +100,9 @@ class DogStatsd(object):
         If set, it is appended to the constant (global) tags of the statsd client.
         :type DD_VERSION: string
 
+        :envvar DD_DOGSTATSD_ENABLE: Enable any statsd metric collection (default True)
+        :type DD_DOGSTATSD_ENABLE: boolean
+
         :param host: the host of the DogStatsd server.
         :type host: string
 
@@ -153,6 +156,12 @@ class DogStatsd(object):
             except ValueError:
                 log.warning("Port number provided in DD_DOGSTATSD_PORT env var is not an integer: \
                 %s, using %s as port number", dogstatsd_port, port)
+
+        # Check enabled
+        if os.environ.get('DD_DOGSTATSD_ENABLE', 'True') == 'True':
+            self._enabled = True
+        else:
+            self._enabled = False
 
         # Connection
         self._max_payload_size = max_buffer_len
@@ -411,6 +420,9 @@ class DogStatsd(object):
         More information about the packets' format: http://docs.datadoghq.com/guides/dogstatsd/
         """
         if value is None:
+            return
+        
+        if self._enabled is not True:
             return
 
         if self._telemetry:

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -100,8 +100,8 @@ class DogStatsd(object):
         If set, it is appended to the constant (global) tags of the statsd client.
         :type DD_VERSION: string
 
-        :envvar DD_DOGSTATSD_ENABLE: Enable any statsd metric collection (default True)
-        :type DD_DOGSTATSD_ENABLE: boolean
+        :envvar DD_DOGSTATSD_DISABLE: Disable any statsd metric collection (default False)
+        :type DD_DOGSTATSD_DISABLE: boolean
 
         :param host: the host of the DogStatsd server.
         :type host: string


### PR DESCRIPTION
#### What does this PR do?

Closes #576

Adds an environment variable to disable `statsd` metric collection in certain cases (e.g development).

#### Description of the Change

Added an environment variable called `DD_DOGSTATSD_ENABLE` that is set as `True` by default.

#### Release Notes

Should be backward compatible.