### PR TITLE
[dogstatsd] sock.setblocking(0) for UDP socket

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -241,8 +241,8 @@ class DogStatsd(object):
             if not self.socket:
                 if self.socket_path is not None:
                     sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-                    sock.connect(self.socket_path)
                     sock.setblocking(0)
+                    sock.connect(self.socket_path)
                     self.socket = sock
                 else:
                     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -246,6 +246,7 @@ class DogStatsd(object):
                     self.socket = sock
                 else:
                     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    sock.setblocking(0)
                     sock.connect((self.host, self.port))
                     self.socket = sock
 


### PR DESCRIPTION
### What does this PR do?
Add sock.setblocking(0) for UDP socket when connecting to a dogstastd server.
It resolve a blocking situation that was happening with internal test, making half test job stuck and ultimately failing after hitting the 1h timeout.

### Description of the Change
cf. above.

### Alternate Designs
N/A

### Possible Drawbacks
None identified so far.

### Verification Process

Manual tests.
Test pipelines are all green with this change.

### Additional Notes
IPv6 seems unsupported for dogstatsd communication, should be fixed.

### Release Notes
cf. PR title

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.