### PR TITLE
[dogstatsd] Fix race condition in _flush_buffer

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -552,7 +552,7 @@ class DogStatsd(object):
         return False
 
     def _flush_buffer(self):
-        with Lock():
+        with self.lock:
             to_send, self.buffer = self.buffer, []
             self._current_buffer_total_size = 0
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -552,8 +552,10 @@ class DogStatsd(object):
         return False
 
     def _flush_buffer(self):
-        to_send, self.buffer = self.buffer, []
-        self._current_buffer_total_size = 0
+        with Lock():
+            to_send, self.buffer = self.buffer, []
+            self._current_buffer_total_size = 0
+
         self._send_to_server("\n".join(to_send))
 
     def _escape_event_content(self, string):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -552,9 +552,9 @@ class DogStatsd(object):
         return False
 
     def _flush_buffer(self):
-        self._send_to_server("\n".join(self.buffer))
+        to_send, self.buffer = self.buffer, []
         self._current_buffer_total_size = 0
-        self.buffer = []
+        self._send_to_server("\n".join(to_send))
 
     def _escape_event_content(self, string):
         return string.replace('\n', '\\n')


### PR DESCRIPTION
### What does this PR do?

fixes bug #439

### Description of the Change

copy the global buffer to a local buffer so we can't accidentally flush it twice.

### Alternate Designs

`self.buffer` could be a queue, but that has other issues, this approach should be good enough without the complexity

### Verification Process

existing tests should cover this

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

