### PR TITLE
Fix Synthetics delete_test parameter name

### DIFF
--- a/datadog/api/synthetics.py
+++ b/datadog/api/synthetics.py
@@ -209,14 +209,14 @@ class Synthetics(
         """
         Delete a test
 
-        :param ids: list of public IDs to delete corresponding tests
-        :type ids: list of strings
+        :param public_ids: list of public IDs to delete corresponding tests
+        :type public_ids: list of strings
 
         :return: Dictionary representing the API's JSON response
         """
 
         if not isinstance(body["public_ids"], list):
-            raise ApiError("Parameter 'ids' must be a list")
+            raise ApiError("Parameter 'public_ids' must be a list")
 
         # API path = "synthetics/tests/delete
 


### PR DESCRIPTION
Change doc string and error message to use the correct name for the `public_ids` parameter of `delete_test`.

### What does this PR do?
Correct an error message to use the proper name of a parameter.

### Description of the Change
Change doc string and error message to use the correct name for the `public_ids` parameter of `delete_test`.

### Alternate Designs
N/A

### Possible Drawbacks
N/A

### Verification Process
Run code using incorrect type for parameter to ensure error message displays correctly.

### Additional Notes
Also updated documentation here: https://github.com/DataDog/documentation/pull/8640

### Release Notes
Fix `Synthetics` `delete_test` parameter name in docstring and `ApiError` text.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

