### PR TITLE
Delay creation of lambda ThreadStats

### DIFF
--- a/datadog/threadstats/aws_lambda.py
+++ b/datadog/threadstats/aws_lambda.py
@@ -44,6 +44,9 @@ class _LambdaDecorator(object):
                 # This avoids adding execution time at the end of the lambda run
                 t = Thread(target=_init_api_client)
                 t.start()
+
+                # Make sure the global ThreadStats has been created
+                _get_lambda_stats()
             cls._counter = cls._counter + 1
 
     @classmethod
@@ -63,7 +66,7 @@ class _LambdaDecorator(object):
                     if cls._counter > 0:
                         should_flush = False
                 if should_flush:
-                    _lambda_stats.flush(float("inf"))
+                    _get_lambda_stats().flush(float("inf"))
 
     def __call__(self, *args, **kw):
         warnings.warn("datadog_lambda_wrapper() is relocated to https://git.io/fjy8o", DeprecationWarning)
@@ -74,14 +77,22 @@ class _LambdaDecorator(object):
             _LambdaDecorator._close()
 
 
-_lambda_stats = ThreadStats()
-_lambda_stats.start(flush_in_greenlet=False, flush_in_thread=False)
+_lambda_stats = None
 datadog_lambda_wrapper = _LambdaDecorator
+
+
+def _get_lambda_stats():
+    global _lambda_stats
+    # This is not thread-safe, it should be called first by _LambdaDecorator
+    if _lambda_stats is None:
+        _lambda_stats = ThreadStats()
+        _lambda_stats.start(flush_in_greenlet=False, flush_in_thread=False)
+    return _lambda_stats
 
 
 def lambda_metric(*args, **kw):
     """ Alias to expose only distributions for lambda functions"""
-    _lambda_stats.distribution(*args, **kw)
+    _get_lambda_stats().distribution(*args, **kw)
 
 
 def _init_api_client():

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -17,7 +17,7 @@ from mock import patch
 
 # datadog
 from datadog import ThreadStats, lambda_metric, datadog_lambda_wrapper
-from datadog.threadstats.aws_lambda import _lambda_stats
+from datadog.threadstats.aws_lambda import _get_lambda_stats
 from tests.util.contextmanagers import preserve_environment_variable
 
 # Silence the logger.
@@ -808,11 +808,11 @@ class TestUnitThreadStats(unittest.TestCase):
         def basic_wrapped_function():
             lambda_metric("lambda.somemetric", 100)
 
-        _lambda_stats.reporter = self.reporter
+        _get_lambda_stats().reporter = self.reporter
         basic_wrapped_function()
 
-        assert _lambda_stats.reporter.dist_flush_counter == 1
-        dists = self.sort_metrics(_lambda_stats.reporter.distributions)
+        assert _get_lambda_stats().reporter.dist_flush_counter == 1
+        dists = self.sort_metrics(_get_lambda_stats().reporter.distributions)
         assert len(dists) == 1
 
     def test_embedded_lambda_decorator(self):
@@ -829,9 +829,9 @@ class TestUnitThreadStats(unittest.TestCase):
             wrapped_function_1()
             lambda_metric("lambda.dist.2", 30)
 
-        _lambda_stats.reporter = self.reporter
+        _get_lambda_stats().reporter = self.reporter
         wrapped_function_2()
-        assert _lambda_stats.reporter.dist_flush_counter == 1
+        assert _get_lambda_stats().reporter.dist_flush_counter == 1
 
-        dists = self.sort_metrics(_lambda_stats.reporter.distributions)
+        dists = self.sort_metrics(_get_lambda_stats().reporter.distributions)
         assert len(dists) == 2


### PR DESCRIPTION
### Description of the Change

This pushes creation of the ThreadStats used by the lambda code to its first use, instead of doing it at import time.

Closes #608

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.