### PR TITLE
[dogstatsd] use monotonic clock source when available for timers

### DIFF
--- a/datadog/dogstatsd/context_async.py
+++ b/datadog/dogstatsd/context_async.py
@@ -20,7 +20,10 @@ import sys
 # https://github.com/python/mypy/issues/6897
 ASYNC_SOURCE = r'''
 from functools import wraps
-from time import time
+try:
+    from time import monotonic
+except ImportError:
+    from time import time as monotonic
 
 
 def _get_wrapped_co(self, func):
@@ -29,7 +32,7 @@ def _get_wrapped_co(self, func):
     """
     @wraps(func)
     async def wrapped_co(*args, **kwargs):
-        start = time()
+        start = monotonic()
         try:
             result = await func(*args, **kwargs)
             return result

--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -14,6 +14,10 @@ import os
 from contextlib import contextmanager
 from functools import wraps
 from time import time
+try:
+    from time import monotonic  # type: ignore[attr-defined]
+except ImportError:
+    from time import time as monotonic
 
 # datadog
 from datadog.api.exceptions import ApiNotInitialized
@@ -272,12 +276,12 @@ class ThreadStats(object):
                 finally:
                     stats.histogram('user.query.time', time.time() - start)
         """
-        start = time()
+        start = monotonic()
         try:
             yield
         finally:
-            end = time()
-            self.timing(metric_name, end - start, end, tags=tags,
+            end = monotonic()
+            self.timing(metric_name, end - start, time(), tags=tags,
                         sample_rate=sample_rate, host=host)
 
     def timed(self, metric_name, sample_rate=1, tags=None, host=None):


### PR DESCRIPTION
This makes sure the computed time is correct by using a monotonic clock source.