### PR TITLE
use start and stop instead of __enter__ and __exit__

### DIFF
--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -119,7 +119,7 @@ class TestDogStatsd(unittest.TestCase):
         # Mock the proc filesystem
         route_data = load_fixtures('route')
         self._procfs_mock = patch('datadog.util.compat.builtins.open', mock_open())
-        self._procfs_mock.__enter__().return_value.readlines.return_value = route_data.split("\n")
+        self._procfs_mock.start().return_value.readlines.return_value = route_data.split("\n")
 
     #def setup_method(self, method):
     #    self.statsd._reset_telemetry()
@@ -128,7 +128,7 @@ class TestDogStatsd(unittest.TestCase):
         """
         Unmock the proc filesystem.
         """
-        self._procfs_mock.__exit__()
+        self._procfs_mock.stop()
 
     def recv(self, n=1):
         packets = []


### PR DESCRIPTION
Fix usage of mocks: solves 
```
self = <tests.unit.dogstatsd.test_statsd.TestDogStatsd testMethod=test_default_sample_rate>

    def tearDown(self):
        """
        Unmock the proc filesystem.
        """
>       self._procfs_mock.__exit__()

tests/unit/dogstatsd/test_statsd.py:131:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.tox/py38/lib/python3.8/site-packages/mock/mock.py:1545: in __exit__
    return exit_stack.__exit__(*exc_info)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <contextlib.ExitStack object at 0x7fed341ca580>, exc_details = ()

    def __exit__(self, *exc_details):
>       received_exc = exc_details[0] is not None
E       IndexError: tuple index out of range

/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/contextlib.py:483: IndexError
```