### PR TITLE
Remove deprecation warnings

### DIFF
--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -305,7 +305,7 @@ class TestDogStatsd(unittest.TestCase):
             'my_check.name', self.statsd.WARNING,
             tags=['key1:val1', 'key2:val2'], timestamp=now,
             hostname='i-abcd1234', message=u"♬ †øU \n†øU ¥ºu|m: T0µ ♪")
-        check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\: T0µ ♪")
+        check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")
         assert_equal_telemetry(check, self.recv(2), telemetry=telemetry_metrics(metrics=0, service_checks=1, bytes_sent=len(check)))
 
     def test_service_check_constant_tags(self):
@@ -315,7 +315,7 @@ class TestDogStatsd(unittest.TestCase):
             'my_check.name', self.statsd.WARNING,
             timestamp=now,
             hostname='i-abcd1234', message=u"♬ †øU \n†øU ¥ºu|m: T0µ ♪")
-        check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#bar:baz,foo|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\: T0µ ♪")
+        check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#bar:baz,foo|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")
         assert_equal_telemetry(check, self.recv(2),
             telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo", bytes_sent=len(check)))
 
@@ -325,7 +325,7 @@ class TestDogStatsd(unittest.TestCase):
             'my_check.name', self.statsd.WARNING,
             tags=['key1:val1', 'key2:val2'], timestamp=now,
             hostname='i-abcd1234', message=u"♬ †øU \n†øU ¥ºu|m: T0µ ♪")
-        check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2,bar:baz,foo|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\: T0µ ♪")
+        check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2,bar:baz,foo|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")
         assert_equal_telemetry(check, self.recv(2),
             telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo", bytes_sent=len(check)))
 
@@ -551,8 +551,7 @@ class TestDogStatsd(unittest.TestCase):
         import asyncio
 
         @self.statsd.timed('timed.test')
-        @asyncio.coroutine
-        def print_foo():
+        async def print_foo():
             """docstring"""
             time.sleep(0.5)
             print("foo")

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -550,14 +550,18 @@ class TestDogStatsd(unittest.TestCase):
         """
         import asyncio
 
-        @self.statsd.timed('timed.test')
-        async def print_foo():
-            """docstring"""
-            time.sleep(0.5)
-            print("foo")
+        source= """
+@self.statsd.timed('timed.test')
+async def print_foo():
+    "docstring"
+    import time
+    time.sleep(0.5)
+    print("foo")
+        """
+        exec(source, {}, locals())
 
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(print_foo())
+        loop.run_until_complete(locals()['print_foo']())
         loop.close()
 
         # Assert

--- a/tests/unit/dogwrap/test_dogwrap.py
+++ b/tests/unit/dogwrap/test_dogwrap.py
@@ -141,7 +141,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('subprocess.Popen')
     def test_execute_exit_code(self, mock_popen, mock_poll):
         mock_proc = mock.Mock()
-        mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', '']
+        mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
         mock_popen.return_value = mock_proc
         mock_poll.return_value = 14
@@ -160,7 +160,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('subprocess.Popen')
     def test_execute_cmd_timeout(self, mock_popen, mock_poll):
         mock_proc = mock.Mock()
-        mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', '']
+        mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
         mock_popen.return_value = mock_proc
         mock_poll.side_effect = [Timeout, 1]
@@ -182,7 +182,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('subprocess.Popen')
     def test_execute_sigterm_timeout(self, mock_popen, mock_poll):
         mock_proc = mock.Mock()
-        mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', '']
+        mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
         mock_popen.return_value = mock_proc
         mock_poll.side_effect = [Timeout, Timeout, 2]
@@ -205,7 +205,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('subprocess.Popen')
     def test_execute_sigkill_timeout(self, mock_popen, mock_poll):
         mock_proc = mock.Mock()
-        mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', '']
+        mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
         mock_popen.return_value = mock_proc
         mock_poll.side_effect = [Timeout, Timeout, Timeout]
@@ -228,7 +228,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('subprocess.Popen')
     def test_execute_oserror(self, mock_popen, mock_poll):
         mock_proc = mock.Mock()
-        mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', '']
+        mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
         mock_popen.return_value = mock_proc
         mock_poll.side_effect = [Timeout, Timeout]


### PR DESCRIPTION
This removes a few deprecation warnings from tests, including using str instead
of bytes, coroutine, and invalid regular expressions.

Closes #598