### PR TITLE
Lazy log formatting

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -257,7 +257,10 @@ class APIClient(object):
         # number of timeouts, then enter the backoff state, recording the time
         # we started backing off
         if not cls._backoff_timestamp and cls._timeout_counter >= cls._max_timeouts:
-            log.info("Max number of datadog timeouts exceeded, backing off for {0} seconds".format(cls._backoff_period))
+            log.info(
+                "Max number of datadog timeouts exceeded, backing off for %s seconds",
+                cls._backoff_period,
+            )
             cls._backoff_timestamp = now
             should_submit = False
 
@@ -268,13 +271,17 @@ class APIClient(object):
             backed_off_time, backoff_time_left = cls._backoff_status()
             if backoff_time_left < 0:
                 log.info(
-                    "Exiting backoff state after {0} seconds, will try to submit metrics again".format(backed_off_time)
+                    "Exiting backoff state after %s seconds, will try to submit metrics again",
+                    backed_off_time,
                 )
                 cls._backoff_timestamp = None
                 cls._timeout_counter = 0
                 should_submit = True
             else:
-                log.info("In backoff state, won't submit metrics for another {0} seconds".format(backoff_time_left))
+                log.info(
+                    "In backoff state, won't submit metrics for another %s seconds",
+                    backoff_time_left,
+                )
                 should_submit = False
         else:
             should_submit = True

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -605,13 +605,19 @@ class DogStatsd(object):
             # dogstatsd is overflowing, drop the packets (mimicks the UDP behaviour)
             pass
         except (socket.herror, socket.gaierror) as se:
-            log.warning("Error submitting packet: {}, dropping the packet and closing the socket".format(se))
+            log.warning(
+                "Error submitting packet: %s, dropping the packet and closing the socket",
+                se,
+            )
             self.close_socket()
         except socket.error as se:
             if se.errno == errno.EAGAIN:
                 log.debug("Socket send would block: %s, dropping the packet", se)
             else:
-                log.warning("Error submitting packet: {}, dropping the packet and closing the socket".format(se))
+                log.warning(
+                    "Error submitting packet: %s, dropping the packet and closing the socket",
+                    se,
+                )
                 self.close_socket()
         except Exception as e:
             log.error("Unexpected error: %s", str(e))

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -375,7 +375,8 @@ class TestDogStatsd(unittest.TestCase):
             self.statsd.gauge('no error', 1)
             mock_log.error.assert_not_called()
             mock_log.warning.assert_called_once_with(
-                "Error submitting packet: Socket error, dropping the packet and closing the socket"
+                "Error submitting packet: %s, dropping the packet and closing the socket",
+                mock.ANY,
             )
 
     def test_socket_overflown(self):


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

Use the formatting provided by the logger instance to lazily format log messages. `log.info("test message: %s", "hello")` will only be formatted to `"test message: hello"` if the logger is configured to log `INFO` messages. If not, the formatting will be skipped. This is preferable to `log.info("test message: {}".format("hello"))` because this formatting will always run even if the log message is eventually thrown away.

Most of the calls to `log.(debug|info|warning|error|exception)` already do this correctly; I'm just fixing the instance of `.format` that I found.

### Description of the Change

Using the lazy formatting is most useful when the log volume is very high. In the case of the `log.warning` calls in dogstatsd, we suspect that if/when the datadog agent becomes unavailable and `socket.send` calls start to fail, the log volume jumps dramatically. We can filter out `WARNING` level messages but we also want to prevent the formatting from happening.

### Alternate Designs

None

### Possible Drawbacks

None

### Verification Process

Testing internally to determine if this reduces load when the agent becomes unavailable. Will update.

### Additional Notes

None

### Release Notes

TBD

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

