### PR TITLE
Turn EAGAIN warning into debug

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -609,7 +609,7 @@ class DogStatsd(object):
             self.close_socket()
         except socket.error as se:
             if se.errno == errno.EAGAIN:
-                log.warning("Socket send would block: {}, dropping the packet".format(se))
+                log.debug("Socket send would block: %s, dropping the packet", se)
             else:
                 log.warning("Error submitting packet: {}, dropping the packet and closing the socket".format(se))
                 self.close_socket()

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -383,8 +383,8 @@ class TestDogStatsd(unittest.TestCase):
         with mock.patch("datadog.dogstatsd.base.log") as mock_log:
             self.statsd.gauge('no error', 1)
             mock_log.error.assert_not_called()
-            c = [call("Socket send would block: Socket error, dropping the packet")]
-            mock_log.warning.assert_has_calls(c * 2)
+            c = [call("Socket send would block: %s, dropping the packet", mock.ANY)]
+            mock_log.debug.assert_has_calls(c * 2)
 
     def test_distributed(self):
         """


### PR DESCRIPTION
It can be super verbose, let's keep it but reduce from warning.