### PR TITLE
[statsd] Clean up statsd tests

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -6,7 +6,7 @@
 """
 DogStatsd is a Python client for DogStatsd, a Statsd fork for Datadog.
 """
-# stdlib
+# Standard libraries
 from random import random
 import logging
 import os
@@ -15,7 +15,7 @@ import errno
 import time
 from threading import Lock
 
-# datadog
+# Datadog libraries
 from datadog.dogstatsd.context import (
     TimedContextManagerDecorator,
     DistributedContextManagerDecorator,

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=line-too-long,too-many-public-methods
 
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
@@ -6,7 +7,7 @@
 """
 Tests for dogstatsd.py
 """
-# Standard libs
+# Standard libraries
 from collections import deque
 import os
 import socket
@@ -15,12 +16,12 @@ import errno
 import time
 import unittest
 
-# Third-party libs
+# Third-party libraries
 import mock
 from mock import call, mock_open, patch
 import pytest
 
-# Datadog libs
+# Datadog libraries
 from datadog import initialize, statsd
 from datadog import __version__ as version
 from datadog.dogstatsd.base import DogStatsd, UDP_OPTIMAL_PAYLOAD_LENGTH
@@ -38,15 +39,16 @@ class FakeSocket(object):
 
     def send(self, payload):
         if is_p3k():
-            assert type(payload) == bytes
+            assert isinstance(payload, bytes)
         else:
-            assert type(payload) == str
+            assert isinstance(payload, str)
+
         self.payloads.append(payload)
 
-    def recv(self, n = 1):
+    def recv(self, count=1):
         try:
             out = []
-            for i in range(n):
+            for _ in range(count):
                 out.append(self.payloads.popleft().decode('utf-8'))
             return '\n'.join(out)
         except IndexError:
@@ -95,14 +97,12 @@ class TestDogStatsd(unittest.TestCase):
         #
         self.statsd = DogStatsd(telemetry_min_flush_interval=0)
         self.statsd.socket = FakeSocket()
+        self.statsd._reset_telemetry()
 
         # Mock the proc filesystem
         route_data = load_fixtures('route')
         self._procfs_mock = patch('datadog.util.compat.builtins.open', mock_open())
         self._procfs_mock.start().return_value.readlines.return_value = route_data.split("\n")
-
-    #def setup_method(self, method):
-    #    self.statsd._reset_telemetry()
 
     def tearDown(self):
         """
@@ -110,7 +110,7 @@ class TestDogStatsd(unittest.TestCase):
         """
         self._procfs_mock.stop()
 
-    def assertEqualTelemetry(self, expected_payload, actual_payload, telemetry=None):
+    def assert_equal_telemetry(self, expected_payload, actual_payload, telemetry=None):
         if telemetry is None:
             telemetry = telemetry_metrics(bytes_sent=len(expected_payload))
 
@@ -121,12 +121,12 @@ class TestDogStatsd(unittest.TestCase):
 
         return self.assertEqual(expected_payload, actual_payload)
 
-    def assertAlmostEqual(self, val1, val2, delta):
-        assert 0 <= abs(val1 - val2) <= delta, "%s - %s not within %s" % (val1, val2, delta)
+    def assert_almost_equal(self, val1, val2, delta):
+        return self.assertTrue(0 <= abs(val1 - val2) <= delta, "%s - %s not within %s" % (val1, val2, delta))
 
-    def recv(self, n=1):
+    def recv(self, count=1):
         packets = []
-        for _ in range(n):
+        for _ in range(count):
             packets.append(self.statsd.socket.recv())
         return "\n".join(packets)
 
@@ -177,121 +177,117 @@ class TestDogStatsd(unittest.TestCase):
             os.environ['DD_AGENT_HOST'] = 'myenvvarhost'
             with preserve_environment_variable('DD_DOGSTATSD_PORT'):
                 os.environ['DD_DOGSTATSD_PORT'] = '4321'
-                statsd = DogStatsd()
+                dogstatsd = DogStatsd()
 
         # Assert
-        self.assertEqual(statsd.host, "myenvvarhost")
-        self.assertEqual(statsd.port, 4321)
+        self.assertEqual(dogstatsd.host, "myenvvarhost")
+        self.assertEqual(dogstatsd.port, 4321)
 
     def test_default_route(self):
         """
         Dogstatsd host can be dynamically set to the default route.
         """
-        # Setup
-        statsd = DogStatsd(use_default_route=True)
-
-        # Assert
-        self.assertEqual(statsd.host, "172.17.0.1")
+        self.assertEqual(
+            DogStatsd(use_default_route=True).host,
+            "172.17.0.1"
+        )
 
     def test_set(self):
         self.statsd.set('set', 123)
-        self.assertEqualTelemetry('set:123|s', self.recv(2))
+        self.assert_equal_telemetry('set:123|s', self.recv(2))
 
     def test_gauge(self):
         self.statsd.gauge('gauge', 123.4)
-        self.assertEqualTelemetry('gauge:123.4|g', self.recv(2))
+        self.assert_equal_telemetry('gauge:123.4|g', self.recv(2))
 
     def test_counter(self):
         self.statsd.increment('page.views')
-        self.assertEqualTelemetry('page.views:1|c', self.recv(2))
+        self.assert_equal_telemetry('page.views:1|c', self.recv(2))
 
         self.statsd._reset_telemetry()
         self.statsd.increment('page.views', 11)
-        self.assertEqualTelemetry('page.views:11|c', self.recv(2))
+        self.assert_equal_telemetry('page.views:11|c', self.recv(2))
 
         self.statsd._reset_telemetry()
         self.statsd.decrement('page.views')
-        self.assertEqualTelemetry('page.views:-1|c', self.recv(2))
+        self.assert_equal_telemetry('page.views:-1|c', self.recv(2))
 
         self.statsd._reset_telemetry()
         self.statsd.decrement('page.views', 12)
-        self.assertEqualTelemetry('page.views:-12|c', self.recv(2))
+        self.assert_equal_telemetry('page.views:-12|c', self.recv(2))
 
     def test_histogram(self):
         self.statsd.histogram('histo', 123.4)
-        self.assertEqualTelemetry('histo:123.4|h', self.recv(2))
+        self.assert_equal_telemetry('histo:123.4|h', self.recv(2))
 
     def test_pipe_in_tags(self):
         self.statsd.gauge('gt', 123.4, tags=['pipe|in:tag', 'red'])
-        self.assertEqualTelemetry('gt:123.4|g|#pipe_in:tag,red', self.recv(2))
+        self.assert_equal_telemetry('gt:123.4|g|#pipe_in:tag,red', self.recv(2))
 
     def test_tagged_gauge(self):
         self.statsd.gauge('gt', 123.4, tags=['country:china', 'age:45', 'blue'])
-        self.assertEqualTelemetry('gt:123.4|g|#country:china,age:45,blue', self.recv(2))
+        self.assert_equal_telemetry('gt:123.4|g|#country:china,age:45,blue', self.recv(2))
 
     def test_tagged_counter(self):
         self.statsd.increment('ct', tags=[u'country:españa', 'red'])
-        self.assertEqualTelemetry(u'ct:1|c|#country:españa,red', self.recv(2))
+        self.assert_equal_telemetry(u'ct:1|c|#country:españa,red', self.recv(2))
 
     def test_tagged_histogram(self):
         self.statsd.histogram('h', 1, tags=['red'])
-        self.assertEqualTelemetry('h:1|h|#red', self.recv(2))
+        self.assert_equal_telemetry('h:1|h|#red', self.recv(2))
 
     def test_sample_rate(self):
         self.statsd._telemetry = False # disabling telemetry since sample_rate imply randomness
         self.statsd.increment('c', sample_rate=0)
         self.assertFalse(self.statsd.socket.recv())
-        for i in range(10000):
+        for _ in range(10000):
             self.statsd.increment('sampled_counter', sample_rate=0.3)
-        self.assertAlmostEqual(3000, len(self.statsd.socket.payloads), 150)
+        self.assert_almost_equal(3000, len(self.statsd.socket.payloads), 150)
         self.assertEqual('sampled_counter:1|c|@0.3', self.recv())
 
     def test_default_sample_rate(self):
         self.statsd._telemetry = False # disabling telemetry since sample_rate imply randomness
         self.statsd.default_sample_rate = 0.3
-        for i in range(10000):
+        for _ in range(10000):
             self.statsd.increment('sampled_counter')
-        self.assertAlmostEqual(3000, len(self.statsd.socket.payloads), 150)
+        self.assert_almost_equal(3000, len(self.statsd.socket.payloads), 150)
         self.assertEqual('sampled_counter:1|c|@0.3', self.recv())
 
     def test_tags_and_samples(self):
         self.statsd._telemetry = False # disabling telemetry since sample_rate imply randomness
-        for i in range(100):
+        for _ in range(100):
             self.statsd.gauge('gst', 23, tags=["sampled"], sample_rate=0.9)
 
-        def test_tags_and_samples(self):
-            for i in range(100):
-                self.statsd.gauge('gst', 23, tags=["sampled"], sample_rate=0.9)
-            self.assertEqual('gst:23|g|@0.9|#sampled')
+        self.assertEqual('gst:23|g|@0.9|#sampled', self.recv())
 
     def test_timing(self):
         self.statsd.timing('t', 123)
-        self.assertEqualTelemetry('t:123|ms', self.recv(2))
+        self.assert_equal_telemetry('t:123|ms', self.recv(2))
 
     def test_event(self):
         self.statsd.event('Title', u'L1\nL2', priority='low', date_happened=1375296969)
         event = u'_e{5,6}:Title|L1\\nL2|d:1375296969|p:low'
-        self.assertEqualTelemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
+        self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
 
         self.statsd._reset_telemetry()
 
         self.statsd.event('Title', u'♬ †øU †øU ¥ºu T0µ ♪',
                           aggregation_key='key', tags=['t1', 't2:v2'])
         event = u'_e{5,19}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2'
-        self.assertEqualTelemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
+        self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
 
     def test_event_constant_tags(self):
         self.statsd.constant_tags = ['bar:baz', 'foo']
         self.statsd.event('Title', u'L1\nL2', priority='low', date_happened=1375296969)
         event = u'_e{5,6}:Title|L1\\nL2|d:1375296969|p:low|#bar:baz,foo'
-        self.assertEqualTelemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo", bytes_sent=len(event)))
+        self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo", bytes_sent=len(event)))
 
         self.statsd._reset_telemetry()
 
         self.statsd.event('Title', u'♬ †øU †øU ¥ºu T0µ ♪',
                           aggregation_key='key', tags=['t1', 't2:v2'])
         event = u'_e{5,19}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2,bar:baz,foo'
-        self.assertEqualTelemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo", bytes_sent=len(event)))
+        self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo", bytes_sent=len(event)))
 
     def test_service_check(self):
         now = int(time.time())
@@ -300,7 +296,7 @@ class TestDogStatsd(unittest.TestCase):
             tags=['key1:val1', 'key2:val2'], timestamp=now,
             hostname='i-abcd1234', message=u"♬ †øU \n†øU ¥ºu|m: T0µ ♪")
         check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")
-        self.assertEqualTelemetry(check, self.recv(2), telemetry=telemetry_metrics(metrics=0, service_checks=1, bytes_sent=len(check)))
+        self.assert_equal_telemetry(check, self.recv(2), telemetry=telemetry_metrics(metrics=0, service_checks=1, bytes_sent=len(check)))
 
     def test_service_check_constant_tags(self):
         self.statsd.constant_tags = ['bar:baz', 'foo']
@@ -310,8 +306,11 @@ class TestDogStatsd(unittest.TestCase):
             timestamp=now,
             hostname='i-abcd1234', message=u"♬ †øU \n†øU ¥ºu|m: T0µ ♪")
         check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#bar:baz,foo|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")
-        self.assertEqualTelemetry(check, self.recv(2),
-            telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo", bytes_sent=len(check)))
+        self.assert_equal_telemetry(
+            check,
+            self.recv(2),
+            telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo", bytes_sent=len(check))
+        )
 
         self.statsd._reset_telemetry()
 
@@ -320,8 +319,11 @@ class TestDogStatsd(unittest.TestCase):
             tags=['key1:val1', 'key2:val2'], timestamp=now,
             hostname='i-abcd1234', message=u"♬ †øU \n†øU ¥ºu|m: T0µ ♪")
         check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2,bar:baz,foo|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")
-        self.assertEqualTelemetry(check, self.recv(2),
-            telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo", bytes_sent=len(check)))
+        self.assert_equal_telemetry(
+            check,
+            self.recv(2),
+            telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo", bytes_sent=len(check))
+        )
 
     def test_metric_namespace(self):
         """
@@ -329,27 +331,27 @@ class TestDogStatsd(unittest.TestCase):
         """
         self.statsd.namespace = "foo"
         self.statsd.gauge('gauge', 123.4)
-        self.assertEqualTelemetry('foo.gauge:123.4|g', self.recv(2))
+        self.assert_equal_telemetry('foo.gauge:123.4|g', self.recv(2))
 
     # Test Client level contant tags
     def test_gauge_constant_tags(self):
-        self.statsd.constant_tags=['bar:baz', 'foo']
+        self.statsd.constant_tags = ['bar:baz', 'foo']
         self.statsd.gauge('gauge', 123.4)
         metric = 'gauge:123.4|g|#bar:baz,foo'
-        self.assertEqualTelemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz,foo", bytes_sent=len(metric)))
+        self.assert_equal_telemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz,foo", bytes_sent=len(metric)))
 
     def test_counter_constant_tag_with_metric_level_tags(self):
-        self.statsd.constant_tags=['bar:baz', 'foo']
+        self.statsd.constant_tags = ['bar:baz', 'foo']
         self.statsd.increment('page.views', tags=['extra'])
         metric = 'page.views:1|c|#extra,bar:baz,foo'
-        self.assertEqualTelemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz,foo", bytes_sent=len(metric)))
+        self.assert_equal_telemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz,foo", bytes_sent=len(metric)))
 
     def test_gauge_constant_tags_with_metric_level_tags_twice(self):
         metric_level_tag = ['foo:bar']
-        self.statsd.constant_tags=['bar:baz']
+        self.statsd.constant_tags = ['bar:baz']
         self.statsd.gauge('gauge', 123.4, tags=metric_level_tag)
         metric = 'gauge:123.4|g|#foo:bar,bar:baz'
-        self.assertEqualTelemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz", bytes_sent=len(metric)))
+        self.assert_equal_telemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz", bytes_sent=len(metric)))
 
         self.statsd._reset_telemetry()
 
@@ -357,7 +359,7 @@ class TestDogStatsd(unittest.TestCase):
         # should not duplicate the tags being sent
         self.statsd.gauge('gauge', 123.4, tags=metric_level_tag)
         metric = "gauge:123.4|g|#foo:bar,bar:baz"
-        self.assertEqualTelemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz", bytes_sent=len(metric)))
+        self.assert_equal_telemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz", bytes_sent=len(metric)))
 
     def test_socket_error(self):
         self.statsd.socket = BrokenSocket()
@@ -374,8 +376,8 @@ class TestDogStatsd(unittest.TestCase):
         with mock.patch("datadog.dogstatsd.base.log") as mock_log:
             self.statsd.gauge('no error', 1)
             mock_log.error.assert_not_called()
-            c = [call("Socket send would block: %s, dropping the packet", mock.ANY)]
-            mock_log.debug.assert_has_calls(c * 2)
+            calls = [call("Socket send would block: %s, dropping the packet", mock.ANY)]
+            mock_log.debug.assert_has_calls(calls * 2)
 
     def test_distributed(self):
         """
@@ -383,15 +385,15 @@ class TestDogStatsd(unittest.TestCase):
         """
         # In seconds
         @self.statsd.distributed('distributed.test')
-        def func(a, b, c=1, d=1):
+        def func(arg1, arg2, kwarg1=1, kwarg2=1):
             """docstring"""
             time.sleep(0.5)
-            return (a, b, c, d)
+            return (arg1, arg2, kwarg1, kwarg2)
 
         self.assertEqual('func', func.__name__)
         self.assertEqual('docstring', func.__doc__)
 
-        result = func(1, 2, d=3)
+        result = func(1, 2, kwarg2=3)
         # Assert it handles args and kwargs correctly.
         self.assertEqual(result, (1, 2, 1, 3))
 
@@ -401,16 +403,16 @@ class TestDogStatsd(unittest.TestCase):
 
         self.assertEqual('d', type_)
         self.assertEqual('distributed.test', name)
-        self.assertAlmostEqual(0.5, float(value), 0.1)
+        self.assert_almost_equal(0.5, float(value), 0.1)
 
         # Repeat, force timer value in milliseconds
         @self.statsd.distributed('distributed.test', use_ms=True)
-        def func(a, b, c=1, d=1):
+        def func(arg1, arg2, kwarg1=1, kwarg2=1):
             """docstring"""
             time.sleep(0.5)
-            return (a, b, c, d)
+            return (arg1, arg2, kwarg1, kwarg2)
 
-        func(1, 2, d=3)
+        func(1, 2, kwarg2=3)
 
         packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
@@ -418,7 +420,7 @@ class TestDogStatsd(unittest.TestCase):
 
         self.assertEqual('d', type_)
         self.assertEqual('distributed.test', name)
-        self.assertAlmostEqual(500, float(value), 100)
+        self.assert_almost_equal(500, float(value), 100)
 
 
     def test_timed(self):
@@ -427,15 +429,15 @@ class TestDogStatsd(unittest.TestCase):
         """
         # In seconds
         @self.statsd.timed('timed.test')
-        def func(a, b, c=1, d=1):
+        def func(arg1, arg2, kwarg1=1, kwarg2=1):
             """docstring"""
             time.sleep(0.5)
-            return (a, b, c, d)
+            return (arg1, arg2, kwarg1, kwarg2)
 
         self.assertEqual('func', func.__name__)
         self.assertEqual('docstring', func.__doc__)
 
-        result = func(1, 2, d=3)
+        result = func(1, 2, kwarg2=3)
         # Assert it handles args and kwargs correctly.
         self.assertEqual(result, (1, 2, 1, 3))
 
@@ -445,16 +447,16 @@ class TestDogStatsd(unittest.TestCase):
 
         self.assertEqual('ms', type_)
         self.assertEqual('timed.test', name)
-        self.assertAlmostEqual(0.5, float(value), 0.1)
+        self.assert_almost_equal(0.5, float(value), 0.1)
 
         # Repeat, force timer value in milliseconds
         @self.statsd.timed('timed.test', use_ms=True)
-        def func(a, b, c=1, d=1):
+        def func(arg1, arg2, kwarg1=1, kwarg2=1):
             """docstring"""
             time.sleep(0.5)
-            return (a, b, c, d)
+            return (arg1, arg2, kwarg1, kwarg2)
 
-        func(1, 2, d=3)
+        func(1, 2, kwarg2=3)
 
         packet = self.recv(2).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
@@ -462,7 +464,7 @@ class TestDogStatsd(unittest.TestCase):
 
         self.assertEqual('ms', type_)
         self.assertEqual('timed.test', name)
-        self.assertAlmostEqual(500, float(value), 100)
+        self.assert_almost_equal(500, float(value), 100)
 
     def test_timed_in_ms(self):
         """
@@ -473,12 +475,12 @@ class TestDogStatsd(unittest.TestCase):
 
         # Sample a function run time
         @self.statsd.timed('timed.test')
-        def func(a, b, c=1, d=1):
+        def func(arg1, arg2, kwarg1=1, kwarg2=1):
             """docstring"""
             time.sleep(0.5)
-            return (a, b, c, d)
+            return (arg1, arg2, kwarg1, kwarg2)
 
-        func(1, 2, d=3)
+        func(1, 2, kwarg2=3)
 
         # Assess the packet
         packet = self.recv(2).split("\n")[0] # ignore telemetry packet
@@ -487,16 +489,16 @@ class TestDogStatsd(unittest.TestCase):
 
         self.assertEqual('ms', type_)
         self.assertEqual('timed.test', name)
-        self.assertAlmostEqual(500, float(value), 100)
+        self.assert_almost_equal(500, float(value), 100)
 
         # Repeat, force timer value in seconds
         @self.statsd.timed('timed.test', use_ms=False)
-        def func(a, b, c=1, d=1):
+        def func(arg1, arg2, kwarg1=1, kwarg2=1):
             """docstring"""
             time.sleep(0.5)
-            return (a, b, c, d)
+            return (arg1, arg2, kwarg1, kwarg2)
 
-        func(1, 2, d=3)
+        func(1, 2, kwarg2=3)
 
         packet = self.recv()
         name_value, type_ = packet.split('|')
@@ -504,7 +506,7 @@ class TestDogStatsd(unittest.TestCase):
 
         self.assertEqual('ms', type_)
         self.assertEqual('timed.test', name)
-        self.assertAlmostEqual(0.5, float(value), 0.1)
+        self.assert_almost_equal(0.5, float(value), 0.1)
 
     def test_timed_no_metric(self, ):
         """
@@ -512,15 +514,15 @@ class TestDogStatsd(unittest.TestCase):
         """
 
         @self.statsd.timed()
-        def func(a, b, c=1, d=1):
+        def func(arg1, arg2, kwarg1=1, kwarg2=1):
             """docstring"""
             time.sleep(0.5)
-            return (a, b, c, d)
+            return (arg1, arg2, kwarg1, kwarg2)
 
         self.assertEqual('func', func.__name__)
         self.assertEqual('docstring', func.__doc__)
 
-        result = func(1, 2, d=3)
+        result = func(1, 2, kwarg2=3)
         # Assert it handles args and kwargs correctly.
         self.assertEqual(result, (1, 2, 1, 3))
 
@@ -530,7 +532,7 @@ class TestDogStatsd(unittest.TestCase):
 
         self.assertEqual('ms', type_)
         self.assertEqual('tests.unit.dogstatsd.test_statsd.func', name)
-        self.assertAlmostEqual(0.5, float(value), 0.1)
+        self.assert_almost_equal(0.5, float(value), 0.1)
 
     @pytest.mark.skipif(not is_higher_py35(), reason="Coroutines are supported on Python 3.5 or higher.")
     def test_timed_coroutine(self):
@@ -541,7 +543,7 @@ class TestDogStatsd(unittest.TestCase):
         """
         import asyncio
 
-        source= """
+        source = """
 @self.statsd.timed('timed.test')
 async def print_foo():
     "docstring"
@@ -562,7 +564,7 @@ async def print_foo():
 
         self.assertEqual('ms', type_)
         self.assertEqual('timed.test', name)
-        self.assertAlmostEqual(0.5, float(value), 0.1)
+        self.assert_almost_equal(0.5, float(value), 0.1)
 
     def test_timed_context(self):
         """
@@ -579,8 +581,8 @@ async def print_foo():
 
         self.assertEqual('ms', type_)
         self.assertEqual('timed_context.test', name)
-        self.assertAlmostEqual(0.5, float(value), 0.1)
-        self.assertAlmostEqual(0.5, timer.elapsed, 0.1)
+        self.assert_almost_equal(0.5, float(value), 0.1)
+        self.assert_almost_equal(0.5, timer.elapsed, 0.1)
 
         # In milliseconds
         with self.statsd.timed('timed_context.test', use_ms=True) as timer:
@@ -592,8 +594,8 @@ async def print_foo():
 
         self.assertEqual('ms', type_)
         self.assertEqual('timed_context.test', name)
-        self.assertAlmostEqual(500, float(value), 100)
-        self.assertAlmostEqual(500, timer.elapsed, 100)
+        self.assert_almost_equal(500, float(value), 100)
+        self.assert_almost_equal(500, timer.elapsed, 100)
 
     def test_timed_context_exception(self):
         """
@@ -618,7 +620,7 @@ async def print_foo():
 
         self.assertEqual('ms', type_)
         self.assertEqual('timed_context.test.exception', name)
-        self.assertAlmostEqual(0.5, float(value), 0.1)
+        self.assert_almost_equal(0.5, float(value), 0.1)
 
     def test_timed_context_no_metric_exception(self):
         """Test that an exception occurs if using a context manager without a metric."""
@@ -648,7 +650,7 @@ async def print_foo():
 
         self.assertEqual('ms', type_)
         self.assertEqual('timed_context.test', name)
-        self.assertAlmostEqual(0.5, float(value), 0.1)
+        self.assert_almost_equal(0.5, float(value), 0.1)
 
         # In milliseconds
         timer = self.statsd.timed('timed_context.test', use_ms=True)
@@ -662,7 +664,7 @@ async def print_foo():
 
         self.assertEqual('ms', type_)
         self.assertEqual('timed_context.test', name)
-        self.assertAlmostEqual(500, float(value), 100)
+        self.assert_almost_equal(500, float(value), 100)
 
     def test_batched(self):
         self.statsd.open_buffer()
@@ -670,7 +672,7 @@ async def print_foo():
         self.statsd.timing('timer', 123)
         self.statsd.close_buffer()
         expected = "page.views:123|g\ntimer:123|ms"
-        self.assertEqualTelemetry(expected, self.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=len(expected)))
+        self.assert_equal_telemetry(expected, self.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=len(expected)))
 
     def test_telemetry(self):
         self.statsd.metrics_count = 1
@@ -687,9 +689,9 @@ async def print_foo():
 
         payload = "page.views:123|g"
         telemetry = telemetry_metrics(metrics=2, events=2, service_checks=3, bytes_sent=4 + len(payload),
-                                          bytes_dropped=5,  packets_sent=7, packets_dropped=7)
+                                      bytes_dropped=5, packets_sent=7, packets_dropped=7)
 
-        self.assertEqualTelemetry(payload, self.recv(2), telemetry=telemetry)
+        self.assert_equal_telemetry(payload, self.recv(2), telemetry=telemetry)
 
         self.assertEqual(0, self.statsd.metrics_count)
         self.assertEqual(0, self.statsd.events_count)
@@ -700,96 +702,97 @@ async def print_foo():
         self.assertEqual(0, self.statsd.packets_dropped)
 
     def test_telemetry_flush_interval(self):
-        statsd = DogStatsd()
+        dogstatsd = DogStatsd()
         fake_socket = FakeSocket()
-        statsd.socket = fake_socket
+        dogstatsd.socket = fake_socket
 
         # set the last flush time in the future to be sure we won't flush
-        statsd._last_flush_time = time.time() + statsd._telemetry_flush_interval
-        statsd.gauge('gauge', 123.4)
+        dogstatsd._last_flush_time = time.time() + dogstatsd._telemetry_flush_interval
+        dogstatsd.gauge('gauge', 123.4)
 
         metric = 'gauge:123.4|g'
         self.assertEqual(metric, fake_socket.recv())
 
-        t1 = time.time()
+        time1 = time.time()
         # setting the last flush time in the past to trigger a telemetry flush
-        statsd._last_flush_time = t1 - statsd._telemetry_flush_interval -1
-        statsd.gauge('gauge', 123.4)
-        self.assertEqualTelemetry(metric, fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=2*len(metric), packets_sent=2))
+        dogstatsd._last_flush_time = time1 - dogstatsd._telemetry_flush_interval -1
+        dogstatsd.gauge('gauge', 123.4)
+        self.assert_equal_telemetry(metric, fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=2*len(metric), packets_sent=2))
 
         # assert that _last_flush_time has been updated
-        self.assertTrue(t1 < statsd._last_flush_time)
+        self.assertTrue(time1 < dogstatsd._last_flush_time)
 
     def test_telemetry_flush_interval_alternate_destination(self):
-        statsd = DogStatsd(telemetry_host='foo')
+        dogstatsd = DogStatsd(telemetry_host='foo')
         fake_socket = FakeSocket()
-        statsd.socket = fake_socket
+        dogstatsd.socket = fake_socket
         fake_telemetry_socket = FakeSocket()
-        statsd.telemetry_socket = fake_telemetry_socket
+        dogstatsd.telemetry_socket = fake_telemetry_socket
 
-        self.assertIsNotNone(statsd.telemetry_host)
-        self.assertIsNotNone(statsd.telemetry_port)
-        self.assertTrue(statsd._dedicated_telemetry_destination())
+        self.assertIsNotNone(dogstatsd.telemetry_host)
+        self.assertIsNotNone(dogstatsd.telemetry_port)
+        self.assertTrue(dogstatsd._dedicated_telemetry_destination())
 
         # set the last flush time in the future to be sure we won't flush
-        statsd._last_flush_time = time.time() + statsd._telemetry_flush_interval
-        statsd.gauge('gauge', 123.4)
+        dogstatsd._last_flush_time = time.time() + dogstatsd._telemetry_flush_interval
+        dogstatsd.gauge('gauge', 123.4)
 
         self.assertEqual('gauge:123.4|g', fake_socket.recv())
 
-        t1 = time.time()
+        time1 = time.time()
         # setting the last flush time in the past to trigger a telemetry flush
-        statsd._last_flush_time = t1 - statsd._telemetry_flush_interval - 1
-        statsd.gauge('gauge', 123.4)
+        dogstatsd._last_flush_time = time1 - dogstatsd._telemetry_flush_interval - 1
+        dogstatsd.gauge('gauge', 123.4)
 
         self.assertEqual('gauge:123.4|g', fake_socket.recv())
-        self.assertEqualTelemetry('', fake_telemetry_socket.recv(), telemetry=telemetry_metrics(metrics=2, bytes_sent=13*2, packets_sent=2))
+        self.assert_equal_telemetry('', fake_telemetry_socket.recv(), telemetry=telemetry_metrics(metrics=2, bytes_sent=13*2, packets_sent=2))
+
         # assert that _last_flush_time has been updated
-        assert t1 < statsd._last_flush_time
+        self.assertTrue(time1 < dogstatsd._last_flush_time)
 
     def test_telemetry_flush_interval_batch(self):
-        statsd = DogStatsd()
+        dogstatsd = DogStatsd()
 
         fake_socket = FakeSocket()
-        statsd.socket = fake_socket
+        dogstatsd.socket = fake_socket
 
-        statsd.open_buffer()
-        statsd.gauge('gauge1', 1)
-        statsd.gauge('gauge2', 2)
+        dogstatsd.open_buffer()
+        dogstatsd.gauge('gauge1', 1)
+        dogstatsd.gauge('gauge2', 2)
 
-        t1 = time.time()
+        time1 = time.time()
         # setting the last flush time in the past to trigger a telemetry flush
-        statsd._last_flush_time = t1 - statsd._telemetry_flush_interval -1
+        dogstatsd._last_flush_time = time1 - statsd._telemetry_flush_interval -1
 
-        statsd.close_buffer()
+        dogstatsd.close_buffer()
 
         metric = 'gauge1:1|g\ngauge2:2|g'
-        self.assertEqualTelemetry(metric, fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=len(metric)))
+        self.assert_equal_telemetry(metric, fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=len(metric)))
         # assert that _last_flush_time has been updated
-        self.assertTrue(t1 < statsd._last_flush_time)
+        self.assertTrue(time1 < dogstatsd._last_flush_time)
 
     def test_context_manager(self):
         fake_socket = FakeSocket()
-        with DogStatsd(telemetry_min_flush_interval=0) as statsd:
-            statsd.socket = fake_socket
-            statsd.gauge('page.views', 123)
-            statsd.timing('timer', 123)
+        with DogStatsd(telemetry_min_flush_interval=0) as dogstatsd:
+            dogstatsd.socket = fake_socket
+            dogstatsd.gauge('page.views', 123)
+            dogstatsd.timing('timer', 123)
         metric = "page.views:123|g\ntimer:123|ms"
         self.assertEqual(metric, fake_socket.recv())
         self.assertEqual(telemetry_metrics(metrics=2, bytes_sent=len(metric)), fake_socket.recv())
-        # self.assertEqualTelemetry("page.views:123|g\ntimer:123|ms", fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2))
+        # self.assert_equal_telemetry("page.views:123|g\ntimer:123|ms", fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2))
 
     def test_batched_buffer_autoflush(self):
         fake_socket = FakeSocket()
         bytes_sent = 0
-        with DogStatsd(telemetry_min_flush_interval=0) as statsd:
+        with DogStatsd(telemetry_min_flush_interval=0) as dogstatsd:
             single_metric = 'mycounter:1|c'
-            self.assertEqual(statsd._max_payload_size, UDP_OPTIMAL_PAYLOAD_LENGTH)
-            metrics_per_packet = statsd._max_payload_size // (len(single_metric) + 1)
-            statsd.socket = fake_socket
-            for i in range(metrics_per_packet + 1):
-                statsd.increment('mycounter')
-            payload = '\n'.join([single_metric for i in range(metrics_per_packet)])
+            self.assertEqual(dogstatsd._max_payload_size, UDP_OPTIMAL_PAYLOAD_LENGTH)
+            metrics_per_packet = dogstatsd._max_payload_size // (len(single_metric) + 1)
+            dogstatsd.socket = fake_socket
+            for _ in range(metrics_per_packet + 1):
+                dogstatsd.increment('mycounter')
+            payload = '\n'.join([single_metric for _ in range(metrics_per_packet)])
 
             telemetry = telemetry_metrics(metrics=metrics_per_packet+1, bytes_sent=len(payload))
             bytes_sent += len(payload) + len(telemetry)
@@ -823,60 +826,62 @@ async def print_foo():
     def test_tags_from_environment(self):
         with preserve_environment_variable('DATADOG_TAGS'):
             os.environ['DATADOG_TAGS'] = 'country:china,age:45,blue'
-            statsd = DogStatsd(telemetry_min_flush_interval=0)
-        statsd.socket = FakeSocket()
-        statsd.gauge('gt', 123.4)
+            dogstatsd = DogStatsd(telemetry_min_flush_interval=0)
+        dogstatsd.socket = FakeSocket()
+        dogstatsd.gauge('gt', 123.4)
         metric = 'gt:123.4|g|#country:china,age:45,blue'
-        self.assertEqual(metric, statsd.socket.recv())
-        self.assertEqual(telemetry_metrics(tags="country:china,age:45,blue", bytes_sent=len(metric)), statsd.socket.recv())
+        self.assertEqual(metric, dogstatsd.socket.recv())
+        self.assertEqual(telemetry_metrics(tags="country:china,age:45,blue", bytes_sent=len(metric)), dogstatsd.socket.recv())
 
     def test_tags_from_environment_and_constant(self):
         with preserve_environment_variable('DATADOG_TAGS'):
             os.environ['DATADOG_TAGS'] = 'country:china,age:45,blue'
-            statsd = DogStatsd(constant_tags=['country:canada', 'red'], telemetry_min_flush_interval=0)
-        statsd.socket = FakeSocket()
-        statsd.gauge('gt', 123.4)
-        tags="country:canada,red,country:china,age:45,blue"
+            dogstatsd = DogStatsd(constant_tags=['country:canada', 'red'], telemetry_min_flush_interval=0)
+        dogstatsd.socket = FakeSocket()
+        dogstatsd.gauge('gt', 123.4)
+        tags = "country:canada,red,country:china,age:45,blue"
         metric = 'gt:123.4|g|#'+tags
-        self.assertEqual(metric, statsd.socket.recv())
-        self.assertEqual(telemetry_metrics(tags=tags, bytes_sent=len(metric)), statsd.socket.recv())
+        self.assertEqual(metric, dogstatsd.socket.recv())
+        self.assertEqual(telemetry_metrics(tags=tags, bytes_sent=len(metric)), dogstatsd.socket.recv())
 
     def test_entity_tag_from_environment(self):
         with preserve_environment_variable('DD_ENTITY_ID'):
             os.environ['DD_ENTITY_ID'] = '04652bb7-19b7-11e9-9cc6-42010a9c016d'
-            statsd = DogStatsd(telemetry_min_flush_interval=0)
-        statsd.socket = FakeSocket()
-        statsd.gauge('gt', 123.4)
+            dogstatsd = DogStatsd(telemetry_min_flush_interval=0)
+        dogstatsd.socket = FakeSocket()
+        dogstatsd.gauge('gt', 123.4)
         metric = 'gt:123.4|g|#dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d'
-        self.assertEqual(metric, statsd.socket.recv())
+        self.assertEqual(metric, dogstatsd.socket.recv())
         self.assertEqual(
             telemetry_metrics(tags="dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d", bytes_sent=len(metric)),
-            statsd.socket.recv())
+            dogstatsd.socket.recv())
 
     def test_entity_tag_from_environment_and_constant(self):
         with preserve_environment_variable('DD_ENTITY_ID'):
             os.environ['DD_ENTITY_ID'] = '04652bb7-19b7-11e9-9cc6-42010a9c016d'
-            statsd = DogStatsd(constant_tags=['country:canada', 'red'], telemetry_min_flush_interval=0)
-        statsd.socket = FakeSocket()
-        statsd.gauge('gt', 123.4)
+            dogstatsd = DogStatsd(constant_tags=['country:canada', 'red'], telemetry_min_flush_interval=0)
+        dogstatsd.socket = FakeSocket()
+        dogstatsd.gauge('gt', 123.4)
         metric = 'gt:123.4|g|#country:canada,red,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d'
-        self.assertEqual(metric, statsd.socket.recv())
+        self.assertEqual(metric, dogstatsd.socket.recv())
         self.assertEqual(
             telemetry_metrics(tags="country:canada,red,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d",
-            bytes_sent=len(metric)), statsd.socket.recv())
+                              bytes_sent=len(metric)),
+            dogstatsd.socket.recv()
+        )
 
     def test_entity_tag_and_tags_from_environment_and_constant(self):
         with preserve_environment_variable('DATADOG_TAGS'):
             os.environ['DATADOG_TAGS'] = 'country:china,age:45,blue'
             with preserve_environment_variable('DD_ENTITY_ID'):
                 os.environ['DD_ENTITY_ID'] = '04652bb7-19b7-11e9-9cc6-42010a9c016d'
-                statsd = DogStatsd(constant_tags=['country:canada', 'red'], telemetry_min_flush_interval=0)
-        statsd.socket = FakeSocket()
-        statsd.gauge('gt', 123.4)
+                dogstatsd = DogStatsd(constant_tags=['country:canada', 'red'], telemetry_min_flush_interval=0)
+        dogstatsd.socket = FakeSocket()
+        dogstatsd.gauge('gt', 123.4)
         tags = "country:canada,red,country:china,age:45,blue,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d"
         metric = 'gt:123.4|g|#'+tags
-        self.assertEqual(metric, statsd.socket.recv())
-        self.assertEqual(telemetry_metrics(tags=tags, bytes_sent=len(metric)), statsd.socket.recv())
+        self.assertEqual(metric, dogstatsd.socket.recv())
+        self.assertEqual(telemetry_metrics(tags=tags, bytes_sent=len(metric)), dogstatsd.socket.recv())
 
     def test_dogstatsd_initialization_with_dd_env_service_version(self):
         """
@@ -896,8 +901,8 @@ async def print_foo():
             ('prod', 'dog', 'abc123', '', ['env:prod2', 'type:app'], ['env:prod', 'env:prod2', 'service:dog', 'type:app', 'version:abc123']),
             ('prod', 'dog', 'abc123', 'env:prod3,custom_tag:cat', ['env:prod2', 'type:app'], ['custom_tag:cat', 'env:prod', 'env:prod2', 'env:prod3', 'service:dog', 'type:app', 'version:abc123']),
         ]
-        for c in cases:
-            dd_env, dd_service, dd_version, datadog_tags, constant_tags, global_tags = c
+        for case in cases:
+            dd_env, dd_service, dd_version, datadog_tags, constant_tags, global_tags = case
             with EnvVars(
                 env_vars={
                     'DATADOG_TAGS': datadog_tags,
@@ -906,48 +911,48 @@ async def print_foo():
                     'DD_VERSION': dd_version,
                 }
             ):
-                statsd = DogStatsd(constant_tags=constant_tags, telemetry_min_flush_interval=0)
-                statsd.socket = FakeSocket()
+                dogstatsd = DogStatsd(constant_tags=constant_tags, telemetry_min_flush_interval=0)
+                dogstatsd.socket = FakeSocket()
 
             # Guarantee consistent ordering, regardless of insertion order.
-            statsd.constant_tags.sort()
-            self.assertEqual(global_tags, statsd.constant_tags)
+            dogstatsd.constant_tags.sort()
+            self.assertEqual(global_tags, dogstatsd.constant_tags)
 
             # Make call with no tags passed; only the globally configured tags will be used.
             global_tags_str = ','.join([t for t in global_tags])
-            statsd.gauge('gt', 123.4)
+            dogstatsd.gauge('gt', 123.4)
 
             # Protect against the no tags case.
             metric = 'gt:123.4|g|#{}'.format(global_tags_str) if global_tags_str else 'gt:123.4|g'
-            self.assertEqual(metric, statsd.socket.recv())
-            self.assertEqual(telemetry_metrics(tags=global_tags_str, bytes_sent=len(metric)), statsd.socket.recv())
-            statsd._reset_telemetry()
+            self.assertEqual(metric, dogstatsd.socket.recv())
+            self.assertEqual(telemetry_metrics(tags=global_tags_str, bytes_sent=len(metric)), dogstatsd.socket.recv())
+            dogstatsd._reset_telemetry()
 
             # Make another call with local tags passed.
             passed_tags = ['env:prod', 'version:def456', 'custom_tag:toad']
             all_tags_str = ','.join([t for t in passed_tags + global_tags])
-            statsd.gauge('gt', 123.4, tags=passed_tags)
+            dogstatsd.gauge('gt', 123.4, tags=passed_tags)
 
             metric = 'gt:123.4|g|#{}'.format(all_tags_str)
-            self.assertEqual(metric, statsd.socket.recv())
-            self.assertEqual(telemetry_metrics(tags=global_tags_str, bytes_sent=len(metric)), statsd.socket.recv())
+            self.assertEqual(metric, dogstatsd.socket.recv())
+            self.assertEqual(telemetry_metrics(tags=global_tags_str, bytes_sent=len(metric)), dogstatsd.socket.recv())
 
-    def test_gauge_doesnt_send_None(self):
+    def test_gauge_does_not_send_none(self):
         self.statsd.gauge('metric', None)
         self.assertIsNone(self.statsd.socket.recv())
 
-    def test_increment_doesnt_send_None(self):
+    def test_increment_does_not_send_none(self):
         self.statsd.increment('metric', None)
         self.assertIsNone(self.statsd.socket.recv())
 
-    def test_decrement_doesnt_send_None(self):
+    def test_decrement_does_not_send_none(self):
         self.statsd.decrement('metric', None)
         self.assertIsNone(self.statsd.socket.recv())
 
-    def test_timing_doesnt_send_None(self):
+    def test_timing_does_not_send_none(self):
         self.statsd.timing('metric', None)
         self.assertIsNone(self.statsd.socket.recv())
 
-    def test_histogram_doesnt_send_None(self):
+    def test_histogram_does_not_send_none(self):
         self.statsd.histogram('metric', None)
         self.assertIsNone(self.statsd.socket.recv())


### PR DESCRIPTION
### What does this PR do?

In preparation for additional work for statsd client, some prep needs to be done to
the codebase to reduce chances of functionality breaking so tests of statsd have
been cleaned up in this PR

### Description of the Change

- No functional change on the client
- Unit tests were cleaned up to raise conformance score to pylint from ~6 to ~9
- Unit tests were reworked to use standard assertions instead of keyword assertions
- Some minor cleanup of the code was done (one test was fixed, some comments were outdated)

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process

Running the tests should give the exact same output as before

### Additional Notes

AC-34

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

