### PR TITLE
[github] Fix precedence order in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
 # See https://help.github.com/articles/about-codeowners/ for syntax
-# Rules are matched bottom-to-top, so one team can own subdirectories
-# and another team can own the rest of the directory.
+# Rules are matched top-to-bottom, so one team can own subdirectories
+# and another team can own the rest of the directory. Last matching
+# pattern is the one used.
+
+# Default owners of everything in the repo
+*                            @DataDog/integrations-tools-and-libraries
 
 # API
 /datadog/api/                @DataDog/integrations-tools-and-libraries
@@ -18,9 +22,6 @@
 # Threadstats
 /datadog/threadstats/        @DataDog/integrations-tools-and-libraries @DataDog/agent-core
 /tests/unit/threadstats/     @DataDog/integrations-tools-and-libraries @DataDog/agent-core
-
-# All the rest
-*                            @DataDog/integrations-tools-and-libraries
 
 # Documentation
 *.md                         @DataDog/baklava @DataDog/integrations-tools-and-libraries


### PR DESCRIPTION
### What does this PR do?

Since the order of items in the CODEOWNERS is important (last matching
line takes precedence), having the `*` line near the bottom of the file
negates any specific patterns above it. By moving this pattern up to the
top of the file, we now ensure that the precedence of ownership is
correctly evaluated.

### Description of the Change

Moved global owner pattern to the top of the CODEOWNERS file

### Alternate Designs

N/A

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Can only be tested in subsequent PRs. When a PR is open from a matching pattern for an external team, a review from that external team should be adequate to merge the PR.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

