### PR TITLE
[statsd] Improve performance of telemetry serialization

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -51,6 +51,19 @@ DD_ENV_TAGS_MAPPING = {
 # Telemetry minimum flush interval in seconds
 DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL = 10
 
+# Telemetry pre-computed formatting string. Pre-computation
+# increases throughput of composing the result by 2-15% from basic
+# '%'-based formatting with a `join`.
+TELEMETRY_FORMATTING_STR = "\n".join([
+    "datadog.dogstatsd.client.metrics:%s|c|#%s",
+    "datadog.dogstatsd.client.events:%s|c|#%s",
+    "datadog.dogstatsd.client.service_checks:%s|c|#%s",
+    "datadog.dogstatsd.client.bytes_sent:%s|c|#%s",
+    "datadog.dogstatsd.client.bytes_dropped:%s|c|#%s",
+    "datadog.dogstatsd.client.packets_sent:%s|c|#%s",
+    "datadog.dogstatsd.client.packets_dropped:%s|c|#%s",
+])
+
 
 class DogStatsd(object):
     OK, WARNING, CRITICAL, UNKNOWN = (0, 1, 2, 3)
@@ -559,16 +572,15 @@ class DogStatsd(object):
 
     def _flush_telemetry(self):
         telemetry_tags = ",".join(self._add_constant_tags(self._client_tags))
-        return "\n".join(
-            (
-                "datadog.dogstatsd.client.metrics:%s|c|#%s" % (self.metrics_count, telemetry_tags),
-                "datadog.dogstatsd.client.events:%s|c|#%s" % (self.events_count, telemetry_tags),
-                "datadog.dogstatsd.client.service_checks:%s|c|#%s" % (self.service_checks_count, telemetry_tags),
-                "datadog.dogstatsd.client.bytes_sent:%s|c|#%s" % (self.bytes_sent, telemetry_tags),
-                "datadog.dogstatsd.client.bytes_dropped:%s|c|#%s" % (self.bytes_dropped, telemetry_tags),
-                "datadog.dogstatsd.client.packets_sent:%s|c|#%s" % (self.packets_sent, telemetry_tags),
-                "datadog.dogstatsd.client.packets_dropped:%s|c|#%s" % (self.packets_dropped, telemetry_tags),
-            )
+
+        return TELEMETRY_FORMATTING_STR % (
+            self.metrics_count, telemetry_tags,
+            self.events_count, telemetry_tags,
+            self.service_checks_count, telemetry_tags,
+            self.bytes_sent, telemetry_tags,
+            self.bytes_dropped, telemetry_tags,
+            self.packets_sent, telemetry_tags,
+            self.packets_dropped, telemetry_tags
         )
 
     def _is_telemetry_flush_time(self):


### PR DESCRIPTION
### What does this PR do?

By precomputing the telemetry formatting string, we are able to gain
2-15% increase in throughput over the old code in both Python2 and
Python3.

Sample timing data:
```
 $ ./time_flush.py
Using Python3
_flush_telemetry_orig: 6.24254 (baseline)
_flush_telemetry_new : 5.56866 (89.21%, 12.10% increase)
_flush_telemetry_orig: 5.78443 (baseline)
_flush_telemetry_new : 5.57556 (96.39%, 3.75% increase)

$ ./time_flush.py
Using Python2
_flush_telemetry_orig: 3.78670 (baseline)
_flush_telemetry_new : 3.47990 (91.90%, 8.82% increase)
_flush_telemetry_orig: 3.84288 (baseline)
_flush_telemetry_new : 3.51469 (91.46%, 9.34% increase)
```

Benchmark runner:
```python
#!/usr/bin/env python3

import sys
import timeit

print("Using Python" + str(sys.version_info[0]))

x = timeit.Timer("""
from datadog import DogStatsd
DogStatsd()._flush_telemetry_orig()
""")
base_timing = x.timeit(100000)
base_timing += x.timeit(100000)
base_timing += x.timeit(100000)
print("_flush_telemetry_orig: %.5f (baseline)" % base_timing)

x = timeit.Timer("""
from datadog import DogStatsd
DogStatsd()._flush_telemetry()
""")
timing = x.timeit(100000)
timing += x.timeit(100000)
timing += x.timeit(100000)
print("_flush_telemetry_new : %.5f (%.2f%%, %.2f%% increase)" % (timing, timing / base_timing * 100, (base_timing / timing * 100) - 100))

x = timeit.Timer("""
from datadog import DogStatsd
DogStatsd()._flush_telemetry_orig()
""")
base_timing = x.timeit(100000)
base_timing += x.timeit(100000)
base_timing += x.timeit(100000)
print("_flush_telemetry_orig: %.5f (baseline)" % base_timing)

x = timeit.Timer("""
from datadog import DogStatsd
DogStatsd()._flush_telemetry()
""")
timing = x.timeit(100000)
timing += x.timeit(100000)
timing += x.timeit(100000)
print("_flush_telemetry_new : %.5f (%.2f%%, %.2f%% increase)" % (timing, timing / base_timing * 100, (base_timing / timing * 100) - 100))
```

### Description of the Change

Small optimization in string composition in a hot path that uses less CPU cycles

### Alternate Designs

Experimented with various other ways to compose a string (`.format`, `.format` with keyed data, `StringIO`, etc) - this one was the most performant.

### Possible Drawbacks

N/A

### Verification Process

Tests already cover this functionality via unit tests

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

