### PR TITLE
[statsd] Fix buffer operation thread-safety

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -363,6 +363,9 @@ class DogStatsd(object):
         """
         Flush the buffer and switch back to single metric packets.
         """
+        if not hasattr(self, 'buffer'):
+            raise BufferError('Cannot close buffer that was never opened')
+
         self._send = self._send_to_server
 
         if self.buffer:

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -674,6 +674,10 @@ async def print_foo():
         expected = "page.views:123|g\ntimer:123|ms"
         self.assert_equal_telemetry(expected, self.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=len(expected)))
 
+    def test_close_buffer_without_open(self):
+        with self.assertRaises(BufferError) as be:
+            self.statsd.close_buffer()
+
     def test_telemetry(self):
         self.statsd.metrics_count = 1
         self.statsd.events_count = 2

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -9,6 +9,7 @@ Tests for dogstatsd.py
 """
 # Standard libraries
 from collections import deque
+from threading import Thread
 import os
 import socket
 import errno
@@ -666,17 +667,146 @@ async def print_foo():
         self.assertEqual('timed_context.test', name)
         self.assert_almost_equal(500, float(value), 100)
 
-    def test_batched(self):
+    def test_batching(self):
         self.statsd.open_buffer()
         self.statsd.gauge('page.views', 123)
         self.statsd.timing('timer', 123)
         self.statsd.close_buffer()
         expected = "page.views:123|g\ntimer:123|ms"
-        self.assert_equal_telemetry(expected, self.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=len(expected)))
+        self.assert_equal_telemetry(
+                expected,
+                self.recv(2),
+                telemetry=telemetry_metrics(metrics=2, bytes_sent=len(expected))
+        )
+
+    def test_batching_sequential(self):
+        self.statsd.open_buffer()
+        self.statsd.gauge('discarded.data', 123)
+        self.statsd.close_buffer()
+
+        self.statsd.open_buffer()
+        self.statsd.gauge('page.views', 123)
+        self.statsd.timing('timer', 123)
+        self.statsd.close_buffer()
+
+        expected1 = 'discarded.data:123|g'
+        expected_metrics1=telemetry_metrics(metrics=1, bytes_sent=len(expected1))
+        self.assert_equal_telemetry(
+            expected1,
+            self.recv(2),
+            telemetry=expected_metrics1)
+
+
+        expected2 = "page.views:123|g\ntimer:123|ms"
+        self.assert_equal_telemetry(
+            expected2,
+            self.recv(2),
+            telemetry=telemetry_metrics(
+                metrics=2,
+                packets_sent=2,
+                bytes_sent=len(expected2 + expected_metrics1)
+            )
+        )
+
+    def test_threaded_batching(self):
+        num_threads = 4
+        threads = []
+
+        def batch_metrics(index, dsd):
+            time.sleep(0.3 * index)
+
+            dsd.open_buffer()
+
+            time.sleep(0.1)
+            dsd.gauge('page.%d.views' % index, 123)
+
+            time.sleep(0.1)
+            dsd.timing('timer.%d' % index, 123)
+
+            time.sleep(0.5)
+            dsd.close_buffer()
+
+        for idx in range(num_threads):
+            threads.append(Thread(target=batch_metrics, args=(idx, self.statsd)))
+
+        for thread in threads:
+            thread.start()
+
+        for thread in threads:
+            if thread.is_alive():
+                thread.join()
+
+        # This is a bit of a tricky thing to test for - initially only our data packet is
+        # sent but then telemetry is flushed/reset and the subsequent metric xmit includes
+        # the telemetry data for the previous packet. The reason for 726 -> 727 increase is
+        # because packet #2 sends a three digit byte count ("726") that then increases the
+        # next metric size by 1 byte.
+        expected_xfer_metrics = [
+            (33, 1),
+            (726, 2),
+            (727, 2),
+            (727, 2),
+        ]
+
+        for idx in range(num_threads):
+            expected_message = "page.%d.views:123|g\ntimer.%d:123|ms" % (idx, idx)
+            bytes_sent, packets_sent = expected_xfer_metrics[idx]
+
+            self.assert_equal_telemetry(
+                expected_message,
+                self.recv(2),
+                telemetry=telemetry_metrics(
+                    metrics=2,
+                    bytes_sent=bytes_sent,
+                    packets_sent=packets_sent,
+                )
+            )
 
     def test_close_buffer_without_open(self):
-        with self.assertRaises(BufferError) as be:
-            self.statsd.close_buffer()
+        dogstatsd = DogStatsd()
+        with self.assertRaises(BufferError):
+            dogstatsd.close_buffer()
+
+    def test_threaded_close_buffer_without_open(self):
+        def batch_metrics(dsd):
+            time.sleep(0.3)
+            dsd.open_buffer()
+
+            dsd.gauge('page.views', 123)
+            dsd.timing('timer', 123)
+
+            time.sleep(0.5)
+            dsd.close_buffer()
+
+        def close_async_buffer(self, dsd):
+            # Ensures that buffer is defined
+            dsd.open_buffer()
+            dsd.close_buffer()
+
+            time.sleep(0.5)
+            with self.assertRaises(RuntimeError):
+                dsd.close_buffer()
+
+        thread1 = Thread(target=batch_metrics, args=(self.statsd,))
+        thread2 = Thread(target=close_async_buffer, args=(self, self.statsd,))
+
+        for thread in [thread1, thread2]:
+            thread.start()
+
+        for thread in [thread1, thread2]:
+            if thread.is_alive():
+                thread.join()
+
+        expected_message = "page.views:123|g\ntimer:123|ms"
+        self.assert_equal_telemetry(
+            expected_message,
+            self.recv(2),
+            telemetry=telemetry_metrics(
+                metrics=2,
+                bytes_sent=29,
+                packets_sent=1,
+            )
+        )
 
     def test_telemetry(self):
         self.statsd.metrics_count = 1


### PR DESCRIPTION
### What does this PR do?

Old code did not have locking around its `open_buffer()` and
`close_buffer()` operations which made those two methods not
thread-safe. This change fixes this and aligns this module with the
documentation.

Fixes https://github.com/DataDog/datadogpy/issues/439
Fixes https://github.com/DataDog/datadogpy/issues/601

### Description of the Change

We now have an `RLock` around buffer operations that prevents threads
from changing the buffer owned by another thread.

Overall performance decrease when sending 2+ metrics is within the `+/- 5%` margin of error:
```sh
$ /time_buffer_ops.py 
Using Python3
baseline: 6.19679 (baseline)
mod     : 6.02907 (97.29%, 2.78% perf increase)
baseline: 6.20096 (baseline)
mod     : 6.04097 (97.42%, 2.65% perf increase)
baseline: 6.05407 (baseline)
mod     : 6.12549 (101.18%, -1.17% perf increase)
baseline: 6.16327 (baseline)
mod     : 6.16413 (100.01%, -0.01% perf increase)
baseline: 5.94379 (baseline)
mod     : 6.18436 (104.05%, -3.89% perf increase)

$ ./time_buffer_ops.py 
Using Python2
baseline: 5.24699 (baseline)
mod     : 5.25159 (100.09%, -0.09% perf increase)
baseline: 5.17050 (baseline)
mod     : 5.27538 (102.03%, -1.99% perf increase)
baseline: 5.46608 (baseline)
mod     : 5.56813 (101.87%, -1.83% perf increase)
baseline: 5.10800 (baseline)
mod     : 5.41473 (106.01%, -5.66% perf increase)
baseline: 5.06513 (baseline)
mod     : 5.27768 (104.20%, -4.03% perf increase)

```

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks


### Verification Process

Unit tests cover the full scope of changes

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

