### PR TITLE
[ISSUE-644] Ensure target socket connection is properly considered in initialize

### DIFF
--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -147,6 +147,10 @@ class TestDogStatsd(unittest.TestCase):
         initialize(**options)
         self.assertEqual(statsd.host, "myhost")
         self.assertEqual(statsd.port, 1234)
+        self.assertIsNone(statsd.socket)
+        with mock.patch('socket.socket'):
+            statsd.get_socket()
+            statsd.socket.connect.assert_called_with(("myhost", 1234))
 
         # Add namespace
         options['statsd_namespace'] = "mynamespace"
@@ -166,6 +170,10 @@ class TestDogStatsd(unittest.TestCase):
         self.assertEqual(statsd.socket_path, options['statsd_socket_path'])
         self.assertIsNone(statsd.host)
         self.assertIsNone(statsd.port)
+        self.assertIsNone(statsd.socket)
+        with mock.patch('socket.socket'):
+            statsd.get_socket()
+            statsd.socket.connect.assert_called_with('/var/run/dogstatsd.sock')
 
     def test_dogstatsd_initialization_with_env_vars(self):
         """


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

It was discovered during an incident that an issue is present in the current initialize method:
* If the socket was already opened with the previous configuration and is not closed
* If the peer configuration is updated (host, port or socket_path)
then:
* If going from UDS to UDP, the change is always ignored
* If updating UDS or UDP and the socket is not closed, the change is ignored

The problem can lead to bad issues if the initial socket does not work (as we are using non-blocking UDP, the library does not detect if the socket is not properly connected)
A current workaround is for the user to call the "close_socket" method after calling initialize

### Description of the Change

Two main changes are done
* Properly reset some variables to ensure users can switch from UDS to UDP
* If a change on host, port or socket_path is done, close the socket to enforce the behavior to change

### Alternate Designs

* Document user to call close_socket after calling initialize (bad user experience)
* Systematically call close_socket in initialize, even if no change is done. As it might impact performance and initialize may be call often to update other flags, this was avoided

### Possible Drawbacks

Might reset the socket more often if users are often changing the target, though that seems like a surprising usecase

### Verification Process

Started with an initial socket targeting a dropped UDP port (through iptables) and send some metrics
Then update the port to a proper port and send further metrics
Confirmed nothing was received by the listener and lsof still reported the socket opened to the initial port

Same test was redone with a UDS setup

### Additional Notes

### Release Notes

Fix update of target in initialize method when some metrics have already been sent through the dogstatsd client

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

