### PR TITLE
[threadstats] argument `metric_name` -> `metric`

### DIFF
--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -211,7 +211,7 @@ class ThreadStats(object):
                 host=hostname,
             )
 
-    def gauge(self, metric_name, value, timestamp=None, tags=None, sample_rate=1, host=None):
+    def gauge(self, metric=None, value=None, timestamp=None, tags=None, sample_rate=1, host=None, metric_name=None):
         """
         Record the current ``value`` of a metric. The most recent value in
         a given flush interval will be recorded. Optionally, specify a set of
@@ -222,12 +222,14 @@ class ThreadStats(object):
         >>> stats.gauge("process.uptime", time.time() - process_start_time)
         >>> stats.gauge("cache.bytes.free", cache.get_free_bytes(), tags=["version:1.0"])
         """
+        if value is None or (metric or metric_name) is None:
+            raise TypeError("Value and metric/metric_name must be set")
         if not self._disabled:
             self._metric_aggregator.add_point(
-                metric_name, tags, timestamp or time(), value, Gauge, sample_rate=sample_rate, host=host
+                metric or metric_name, tags, timestamp or time(), value, Gauge, sample_rate=sample_rate, host=host
             )
 
-    def set(self, metric_name, value, timestamp=None, tags=None, sample_rate=1, host=None):
+    def set(self, metric=None, value=None, timestamp=None, tags=None, sample_rate=1, host=None, metric_name=None):
         """
         Add ``value`` to the current set. The length of the set is
         flushed as a gauge to Datadog. Optionally, specify a set of
@@ -235,12 +237,14 @@ class ThreadStats(object):
 
         >>> stats.set("example_metric.set", "value_1", tags=["environement:dev"])
         """
+        if value is None or (metric or metric_name) is None:
+            raise TypeError("Value and metric/metric_name must be set")
         if not self._disabled:
             self._metric_aggregator.add_point(
-                metric_name, tags, timestamp or time(), value, Set, sample_rate=sample_rate, host=host
+                metric or metric_name, tags, timestamp or time(), value, Set, sample_rate=sample_rate, host=host
             )
 
-    def increment(self, metric_name, value=1, timestamp=None, tags=None, sample_rate=1, host=None):
+    def increment(self, metric=None, value=1, timestamp=None, tags=None, sample_rate=1, host=None, metric_name=None):
         """
         Increment the counter by the given ``value``. Optionally, specify a list of
         ``tags`` to associate with the metric. This is useful for counting things
@@ -249,12 +253,14 @@ class ThreadStats(object):
         >>> stats.increment('home.page.hits')
         >>> stats.increment('bytes.processed', file.size())
         """
+        if (metric or metric_name) is None:
+            raise TypeError("metric or metric_name must be set")
         if not self._disabled:
             self._metric_aggregator.add_point(
-                metric_name, tags, timestamp or time(), value, Counter, sample_rate=sample_rate, host=host
+                metric or metric_name, tags, timestamp or time(), value, Counter, sample_rate=sample_rate, host=host
             )
 
-    def decrement(self, metric_name, value=1, timestamp=None, tags=None, sample_rate=1, host=None):
+    def decrement(self, metric=None, value=1, timestamp=None, tags=None, sample_rate=1, host=None, metric_name=None):
         """
         Decrement a counter, optionally setting a value, tags and a sample
         rate.
@@ -262,12 +268,14 @@ class ThreadStats(object):
         >>> stats.decrement("files.remaining")
         >>> stats.decrement("active.connections", 2)
         """
+        if (metric or metric_name) is None:
+            raise TypeError("metric or metric_name must be set")
         if not self._disabled:
             self._metric_aggregator.add_point(
-                metric_name, tags, timestamp or time(), -value, Counter, sample_rate=sample_rate, host=host
+                metric or metric_name, tags, timestamp or time(), -value, Counter, sample_rate=sample_rate, host=host
             )
 
-    def histogram(self, metric_name, value, timestamp=None, tags=None, sample_rate=1, host=None):
+    def histogram(self, metric=None, value=None, timestamp=None, tags=None, sample_rate=1, host=None, metric_name=None):
         """
         Sample a histogram value. Histograms will produce metrics that
         describe the distribution of the recorded values, namely the maximum, mininum,
@@ -276,12 +284,16 @@ class ThreadStats(object):
 
         >>> stats.histogram("uploaded_file.size", uploaded_file.size())
         """
+        if value is None or (metric or metric_name) is None:
+            raise TypeError("Value and metric/metric_name must be set")
         if not self._disabled:
             self._metric_aggregator.add_point(
-                metric_name, tags, timestamp or time(), value, Histogram, sample_rate=sample_rate, host=host
+                metric or metric_name, tags, timestamp or time(), value, Histogram, sample_rate=sample_rate, host=host
             )
 
-    def distribution(self, metric_name, value, timestamp=None, tags=None, sample_rate=1, host=None):
+    def distribution(
+        self, metric=None, value=None, timestamp=None, tags=None, sample_rate=1, host=None, metric_name=None
+    ):
         """
         Sample a distribution value. Distributions will produce metrics that
         describe the distribution of the recorded values, namely the maximum,
@@ -290,24 +302,34 @@ class ThreadStats(object):
 
         >>> stats.distribution("uploaded_file.size", uploaded_file.size())
         """
+        if value is None or (metric or metric_name) is None:
+            raise TypeError("Value and metric/metric_name must be set")
         if not self._disabled:
             self._metric_aggregator.add_point(
-                metric_name, tags, timestamp or time(), value, Distribution, sample_rate=sample_rate, host=host
+                metric or metric_name,
+                tags,
+                timestamp or time(),
+                value,
+                Distribution,
+                sample_rate=sample_rate,
+                host=host,
             )
 
-    def timing(self, metric_name, value, timestamp=None, tags=None, sample_rate=1, host=None):
+    def timing(self, metric=None, value=None, timestamp=None, tags=None, sample_rate=1, host=None, metric_name=None):
         """
         Record a timing, optionally setting tags and a sample rate.
 
         >>> stats.timing("query.response.time", 1234)
         """
+        if value is None or (metric or metric_name) is None:
+            raise TypeError("Value and metric/metric_name must be set")
         if not self._disabled:
             self._metric_aggregator.add_point(
-                metric_name, tags, timestamp or time(), value, Timing, sample_rate=sample_rate, host=host
+                metric or metric_name, tags, timestamp or time(), value, Timing, sample_rate=sample_rate, host=host
             )
 
     @contextmanager
-    def timer(self, metric_name, sample_rate=1, tags=None, host=None):
+    def timer(self, metric=None, sample_rate=1, tags=None, host=None, metric_name=None):
         """
         A context manager that will track the distribution of the contained code's run time.
         Optionally specify a list of tags to associate with the metric.
@@ -327,14 +349,16 @@ class ThreadStats(object):
                 finally:
                     stats.histogram("user.query.time", time.time() - start)
         """
+        if (metric or metric_name) is None:
+            raise TypeError("Metric or metric_name must be set")
         start = monotonic()
         try:
             yield
         finally:
             end = monotonic()
-            self.timing(metric_name, end - start, time(), tags=tags, sample_rate=sample_rate, host=host)
+            self.timing(metric or metric_name, end - start, time(), tags=tags, sample_rate=sample_rate, host=host)
 
-    def timed(self, metric_name, sample_rate=1, tags=None, host=None):
+    def timed(self, metric=None, sample_rate=1, tags=None, host=None, metric_name=None):
         """
         A decorator that will track the distribution of a function's run time.
         Optionally specify a list of tags to associate with the metric.
@@ -356,12 +380,14 @@ class ThreadStats(object):
         def wrapper(func):
             @wraps(func)
             def wrapped(*args, **kwargs):
-                with self.timer(metric_name, sample_rate, tags, host):
+                with self.timer(metric or metric_name, sample_rate, tags, host):
                     result = func(*args, **kwargs)
                     return result
 
             return wrapped
 
+        if (metric or metric_name) is None:
+            raise TypeError("Metric or metric_name must be set")
         return wrapper
 
     def flush(self, timestamp=None):


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?
I was inspired to submit this pull request after running into the disparity between the DogStatsD and ThreadStats classes. I did some quick googling to find there was an issue for this and prior art as well

https://github.com/DataDog/datadogpy/issues/175 originally opened by @dblackdblack in 2016
https://github.com/DataDog/datadogpy/pull/184 originally submitted by @yannmh in 2017

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change
The intended consequence is to allow consistency between the DogStatsD and ThreadStats APIs so we can use the same API calls during local development as in production and name all of the arguments in each call.

I incorporated the [previously suggested feedback](https://github.com/DataDog/datadogpy/pull/184#pullrequestreview-346137436)

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Alternatives were discussed on the original MR but this design was submitted by me now to respect the maintainer's requirement for backwards compatibility.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

Additional context in the docstrings would probably be helpful to prevent ambiguity in the future by the inclusion of both `metric` and `metric_name` I can go ahead and add more exposition in another commit

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

What kinds of verification would you like to see?

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

Thanks for considering this change!

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

