### PR TITLE
[Internal] Remove unused decorator dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,6 @@ install_reqs = [
     'configparser<5;python_version<"3.0"',
 ]
 
-if sys.version_info < (3, 0):
-    install_reqs.insert(0, "decorator<5.0.0")
-else:
-    install_reqs.append("decorator>=3.3.2")
-
 setup(
     name="datadog",
     version=version["__version__"],


### PR DESCRIPTION
### What does this PR do?

This PR removes the unused dependency on [decorator](https://pypi.org/project/decorator/), which as far as I can tell is completely unused. It appears this library was introduced as a dependency in the first commit to this repo but never actually used directly.

This will help make installations faster and slimmer as well as reducing some maintenance (eg. see #646, where the datadogpy build was broken due to environment mismatches in this dependency).

### Description of the Change

Removes the unused dependency from the `setup.py` file. This will prevent it from being included at installation time of `datadogpy`.

### Alternate Designs

N/A

### Possible Drawbacks

If the decorator library is being used in some non-standard way, this could remove something we're relying on (note: see "Verification Process" for why I don't think this is the case).

### Verification Process

I verified this change through:
* manual audit of `datadogpy`: no instances of accessing the `decorator` library were found
* running the tox unit and admin-only tests on all compatible cpython and pypy versions: all passed
* auditing the `decorator` codebase for anything "unusual" such as install-time side-effects or other such things we might be "magically" relying on: did not find any

### Additional Notes

N/A

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

