### PR TITLE
[dogstatsd] Fix unicode handling of event text

### DIFF
--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -274,8 +274,18 @@ class TestDogStatsd(unittest.TestCase):
 
         self.statsd.event('Title', u'♬ †øU †øU ¥ºu T0µ ♪',
                           aggregation_key='key', tags=['t1', 't2:v2'])
-        event = u'_e{5,19}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2'
+        event = u'_e{5,32}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2'
         self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
+
+    def test_unicode_event(self):
+        self.statsd.event(
+                'my.prefix.Delivery - Daily Settlement Summary Report Delivery — Invoice Cloud succeeded',
+                'Delivered — destination.csv')
+        event = u'_e{89,29}:my.prefix.Delivery - Daily Settlement Summary Report Delivery — Invoice Cloud succeeded|' + \
+            u'Delivered — destination.csv'
+        self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
+
+        self.statsd._reset_telemetry()
 
     def test_event_constant_tags(self):
         self.statsd.constant_tags = ['bar:baz', 'foo']
@@ -287,7 +297,7 @@ class TestDogStatsd(unittest.TestCase):
 
         self.statsd.event('Title', u'♬ †øU †øU ¥ºu T0µ ♪',
                           aggregation_key='key', tags=['t1', 't2:v2'])
-        event = u'_e{5,19}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2,bar:baz,foo'
+        event = u'_e{5,32}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2,bar:baz,foo'
         self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo", bytes_sent=len(event)))
 
     def test_service_check(self):


### PR DESCRIPTION
### What does this PR do?

Fixes handling of unicode data when sending events in dogstatsd

### Description of the Change

We now properly handle both the type and length calculation of such strings

Closes https://github.com/DataDog/datadogpy/issues/660

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

Tiny reduction in throughput

### Verification Process

1. Add `print` to string composed in [`event()`](https://github.com/DataDog/datadogpy/blob/master/datadog/dogstatsd/base.py#L738)
2. Python2: `python2 -m unittest -vvv tests.unit.dogstatsd.test_statsd.TestDogStatsd.test_unicode_event`
3. Python3: `python3 -m unittest -vvv tests.unit.dogstatsd.test_statsd.TestDogStatsd.test_unicode_event`

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [x] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

