### PR TITLE
[statsd] Add performance benchmark test for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,30 @@ Those metrics will not be counted as custom and will not be billed. This feature
 
 See [Telemetry documentation](https://docs.datadoghq.com/developers/dogstatsd/high_throughput/?tab=python#client-side-telemetry) to learn more about it.
 
+### Benchmarks
+
+_Note: You will need to install `psutil` package before running the benchmarks._
+
+If you would like to get an approximate idea on the throughput that your DogStatsD library
+can handle on your system, you can run the included local benchmark code:
+
+```sh-session
+$ # Python 2 Example
+$ python2 -m unittest -vvv tests.performance.test_statsd_throughput
+
+$ # Python 3 Example
+$ python3 -m unittest -vvv tests.performance.test_statsd_throughput
+```
+
+You can also add set `BENCHMARK_*` to customize the runs:
+```sh-session
+$ # Example #1
+$ BENCHMARK_NUM_RUNS=10 BENCHMARK_NUM_THREADS=1 BENCHMARK_NUM_DATAPOINTS=5000 BENCHMARK_TRANSPORT="UDP" python2 -m unittest -vvv tests.performance.test_statsd_throughput
+
+$ # Example #2
+$ BENCHMARK_NUM_THREADS=10 BENCHMARK_TRANSPORT="UDS" python3 -m unittest -vvv tests.performance.test_statsd_throughput
+```
+
 ## Maximum packets size in high-throughput scenarios
 
 In order to have the most efficient use of this library in high-throughput scenarios,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     name="datadog",
     version=version["__version__"],
     install_requires=install_reqs,
-    tests_require=["pytest", "mock", "freezegun"],
+    tests_require=["pytest", "mock", "freezegun", "psutil"],
     packages=["datadog", "datadog.api", "datadog.dogstatsd", "datadog.threadstats", "datadog.util", "datadog.dogshell"],
     package_data={"datadog": ["py.typed"]},
     author="Datadog, Inc.",

--- a/tests/performance/test_statsd_throughput.py
+++ b/tests/performance/test_statsd_throughput.py
@@ -1,0 +1,336 @@
+# coding: utf8
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the BSD-3-Clause License. This product includes software developed at
+# Datadog (https://www.datadoghq.com/).
+
+# Copyright 2015-Present Datadog, Inc
+
+# stdlib
+import logging
+import os
+import random
+import sys
+import threading
+import timeit
+import unittest
+import warnings
+
+try:
+    import queue
+except ImportError:
+    import Queue as queue
+
+# datadog
+from datadog.dogstatsd.base import DogStatsd
+
+# test utils
+from tests.util.fake_statsd_server import FakeServer
+from tests.util.system_info_observer import SysInfoObserver
+
+
+# StatsdSender is a static helper for sending mock metrics to statsd via a simple API
+# pylint: disable=too-few-public-methods,useless-object-inheritance
+class StatsdSender(object):
+    EXTRA_TAGS = ["bar = barval", "baz = bazval"]
+    STATIC_TIMING_SET = set(range(100))
+
+    # Enums are not part of 2.7 built-ins
+    METRICS_TYPE = [
+        "decrement",
+        "distribution",
+        "gauge",
+        "histogram",
+        "increment",
+        "set",
+        "timing",
+    ]
+
+    @staticmethod
+    def send(metric, statsd_instance, value):
+        getattr(StatsdSender, "_submit_{}".format(StatsdSender.METRICS_TYPE[metric]))(
+            statsd_instance, threading.current_thread().name, value
+        )
+
+    @staticmethod
+    def _submit_decrement(statsd_instance, metric_prefix, _):
+        statsd_instance.decrement(
+            "{}.counter".format(metric_prefix), tags=StatsdSender.EXTRA_TAGS
+        )
+
+    @staticmethod
+    def _submit_distribution(statsd_instance, metric_prefix, value):
+        statsd_instance.distribution(
+            "{}.distribution".format(metric_prefix), value, tags=StatsdSender.EXTRA_TAGS
+        )
+
+    @staticmethod
+    def _submit_gauge(statsd_instance, metric_prefix, value):
+        statsd_instance.gauge(
+            "{}.gauge".format(metric_prefix), value, tags=StatsdSender.EXTRA_TAGS
+        )
+
+    @staticmethod
+    def _submit_histogram(statsd_instance, metric_prefix, value):
+        statsd_instance.histogram(
+            "{}.histogram".format(metric_prefix), value, tags=StatsdSender.EXTRA_TAGS
+        )
+
+    @staticmethod
+    def _submit_increment(statsd_instance, metric_prefix, _):
+        statsd_instance.increment(
+            "{}.counter".format(metric_prefix), tags=StatsdSender.EXTRA_TAGS
+        )
+
+    @staticmethod
+    def _submit_set(statsd_instance, metric_prefix, value):
+        statsd_instance.set(
+            "{}.set".format(metric_prefix), value, tags=StatsdSender.EXTRA_TAGS
+        )
+
+    @staticmethod
+    def _submit_timing(statsd_instance, metric_prefix, _):
+        statsd_instance.timing(
+            "{}.set".format(metric_prefix),
+            StatsdSender.STATIC_TIMING_SET,
+            tags=StatsdSender.EXTRA_TAGS,
+        )
+
+
+class TestDogStatsdThroughput(unittest.TestCase):
+    """
+    DogStatsd throughput tests.
+    """
+
+    DEFAULT_NUM_DATAPOINTS = 50000
+    DEFAULT_NUM_THREADS = 1
+    DEFAULT_NUM_RUNS = 5
+    DEFAULT_TRANSPORT = "udp"
+
+    RUN_MESSAGE = (
+        "Run #{:2d}/{:2d}: {:.4f}s (latency: {:.2f}μs, cpu: {:.4f},"
+        + " mem.rss: {:.0f}kb, recv: {:.2f}%)"
+    )
+
+    def setUp(self):
+        # Parse the benchmark parameters and use sensible defaults for values
+        # that are not configured
+        self.num_datapoints = int(
+            os.getenv("BENCHMARK_NUM_DATAPOINTS", str(self.DEFAULT_NUM_DATAPOINTS))
+        )
+        self.num_threads = int(
+            os.getenv("BENCHMARK_NUM_THREADS", str(self.DEFAULT_NUM_THREADS))
+        )
+        self.num_runs = int(os.getenv("BENCHMARK_NUM_RUNS", str(self.DEFAULT_NUM_RUNS)))
+        self.transport = os.getenv(
+            "BENCHMARK_TRANSPORT", str(self.DEFAULT_TRANSPORT)
+        ).upper()
+
+        # We do want to see any problems if they occur in the statsd library
+        logger = logging.getLogger()
+        logger.level = logging.DEBUG
+        logger.addHandler(logging.StreamHandler(sys.stdout))
+
+        # Ensure that warnings don't print the stack trace
+        def one_line_warning(message, category, filename, lineno, *_):
+            return "%s:%s: %s: %s" % (filename, lineno, category.__name__, message)
+
+        warnings.formatwarning = one_line_warning
+
+        # Add a newline so that we don't get clobbered by the test output
+        print("")
+
+    # pylint: disable=too-many-locals
+    def test_statsd_performance(self):
+        print(
+            "Starting: {} run(s), {} threads, {} points/thread via {}...".format(
+                self.num_runs,
+                self.num_threads,
+                self.num_datapoints,
+                self.transport,
+            )
+        )
+
+        # We want a stable random sequence so that parallel runs
+        # are consistent and repeatable
+        random.seed(1234)
+
+        # Pre-calculate a random order of metric types for each thread
+        metrics_order = []
+        for _ in range(self.num_threads):
+            thread_metrics_order = []
+            for _ in range(self.num_datapoints):
+                thread_metrics_order.append(
+                    random.randrange(len(StatsdSender.METRICS_TYPE))
+                )
+
+            metrics_order.append(thread_metrics_order)
+
+        run_cpu_stats = []
+        run_durations = []
+        run_latencies = []
+        run_memory_stats = []
+        received_packet_pcts = []
+
+        for run_idx in range(self.num_runs):
+            (
+                duration,
+                total_latency,
+                sys_stats,
+                received_packet_pct,
+            ) = self._execute_test_run(
+                FakeServer(transport=self.transport),
+                metrics_order,
+                self.num_threads,
+                self.num_datapoints,
+            )
+            avg_latency_secs = total_latency / (self.num_threads * self.num_datapoints)
+            avg_latency = avg_latency_secs * 1000000
+            print(
+                self.RUN_MESSAGE.format(
+                    run_idx + 1,
+                    self.num_runs,
+                    duration,
+                    avg_latency,
+                    sys_stats["cpu.user"] + sys_stats["cpu.system"],
+                    sys_stats["mem.rss_kb"],
+                    received_packet_pct,
+                )
+            )
+
+            run_durations.append(duration)
+            run_cpu_stats.append(sys_stats["cpu.user"] + sys_stats["cpu.system"])
+            run_memory_stats.append(sys_stats["mem.rss_kb"])
+            run_latencies.append(float(avg_latency))
+            received_packet_pcts.append(received_packet_pct)
+
+        result_msg = "\nTotal for {} run(s), {} threads, {} points/thread via {}:\n"
+        result_msg += "\tDuration:\t\t{:.4f}s\n"
+        result_msg += "\tLatency:\t\t{:.2f}μs\n"
+        result_msg += "\tCPU:\t\t\t{:.4f}\n"
+        result_msg += "\tMemory:\t\t\t{:.0f}kb\n"
+        result_msg += "\tReceived packets:\t{:.2f}%"
+        print(
+            result_msg.format(
+                self.num_runs,
+                self.num_threads,
+                self.num_datapoints,
+                self.transport,
+                sum(run_durations) / len(run_durations),
+                sum(run_latencies) / len(run_latencies),
+                sum(run_cpu_stats) / len(run_cpu_stats),
+                sum(run_memory_stats) / len(run_memory_stats),
+                sum(received_packet_pcts) / len(received_packet_pcts),
+            )
+        )
+
+    # pylint: disable=too-many-locals,no-self-use
+    def _execute_test_run(self, server, metrics_order, num_threads, num_datapoints):
+        # Setup all the threads and get them in a waiting state
+        threads = []
+        start_signal = threading.Event()
+
+        latency_results = queue.Queue()
+        observer = SysInfoObserver()
+
+        with server:
+            # Create a DogStatsd client with a mocked socket
+            statsd_instance = DogStatsd(
+                constant_tags=["foo = {}".format(random.random())],
+                host="localhost",
+                port=server.port,
+                socket_path=server.socket_path,
+            )
+
+            for thread_idx in range(num_threads):
+                thread = threading.Thread(
+                    name="test_statsd_throughput_thread_{}".format(thread_idx),
+                    target=TestDogStatsdThroughput._thread_runner,
+                    args=(
+                        statsd_instance,
+                        start_signal,
+                        metrics_order[thread_idx],
+                        latency_results,
+                    ),
+                )
+                thread.daemon = True
+                threads.append(thread)
+                thread.start()
+
+            # `timeit.timeit` is not easily usable here since we need to pass in state
+            # and Python 2 version of `timeit()` does not accept the `global` keyword.
+            start_time = timeit.default_timer()
+
+            # Let the thread know that it can start sending metrics
+            start_signal.set()
+
+            # Observe system utilization while we wait for the threads to exit
+            with observer:
+                for thread in threads:
+                    thread.join()
+
+            total_latency = 0.0
+            for thread in threads:
+                if latency_results.empty():
+                    warnings.warn("One or more threads did not report their results!")
+                    continue
+
+                total_latency += latency_results.get()
+
+            duration = timeit.default_timer() - start_time
+
+        # Sanity checks: Verify that metric transfer expectations are correct
+        expected_metrics = num_threads * num_datapoints
+
+        # Verify that dropped metric count is matching our statsd expectations. This
+        # type of inconsistency should never happen.
+        if (
+            expected_metrics - server.metrics_captured
+            != statsd_instance.packets_dropped
+        ):
+            error_msg = (
+                "WARN: Statsd dropped packet count ({}) did not match the server "
+            )
+            error_msg += "missing received packet count expectation ({})!\n"
+            warnings.warn(
+                error_msg.format(
+                    statsd_instance.packets_dropped,
+                    expected_metrics - server.metrics_captured,
+                )
+            )
+
+        # Verify that dropped metric count is matching our statsd expectations. Note
+        # that in some scenarios, some data is expected to be dropped.
+        if server.metrics_captured != statsd_instance.packets_sent:
+            error_msg = "WARN: Statsd sent packet count ({}) did not match the server "
+            error_msg += "captured metric count ({})!\n"
+            warnings.warn(
+                error_msg.format(statsd_instance.packets_sent, server.metrics_captured)
+            )
+
+        # Verify that received metric count is matching our metric totals expectations. Note
+        # that in some scenarios, some data is expected to be dropped.
+        if server.metrics_captured != expected_metrics:
+            error_msg = "WARN: Received metrics count ({}) did not match the sent "
+            error_msg += "metrics count ({})!\n"
+            warnings.warn(error_msg.format(server.metrics_captured, expected_metrics))
+
+        received_packet_pct = server.metrics_captured * 100.0 / expected_metrics
+
+        return (duration, total_latency, observer.stats, received_packet_pct)
+
+    @staticmethod
+    def _thread_runner(
+        statsd_instance, start_event, thread_metrics_order, latency_results
+    ):
+        # We wait for a global signal to start running our events
+        start_event.wait(5)
+
+        duration = 0.0
+        for metric_idx, metric in enumerate(thread_metrics_order):
+            start_time = timeit.default_timer()
+
+            StatsdSender.send(metric, statsd_instance, metric_idx)
+
+            duration += timeit.default_timer() - start_time
+
+        latency_results.put(duration)

--- a/tests/util/fake_statsd_server.py
+++ b/tests/util/fake_statsd_server.py
@@ -1,0 +1,167 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the BSD-3-Clause License. This product includes software developed at
+# Datadog (https://www.datadoghq.com/).
+
+# Copyright 2021-Present Datadog, Inc
+
+import ctypes
+import os
+import shutil
+import socket
+import tempfile
+import threading
+import time
+from multiprocessing import Array, Event, Process, Value
+
+from datadog.util.compat import is_p3k
+
+# pylint: disable=too-many-instance-attributes,useless-object-inheritance
+class FakeServer(object):
+    """
+    Fake statsd server that can be used for testing/benchmarking. Implementation
+    Uses a separate process to run and manage the context to not poison the
+    benchmarking results.
+    """
+
+    SOCKET_NAME = "fake_statsd_server_socket"
+    ALLOWED_TRANSPORTS = ["UDS", "UDP"]
+
+    def __init__(self, transport="UDS", debug=False):
+        if transport not in self.ALLOWED_TRANSPORTS:
+            raise ValueError(
+                "Transport {} is not a valid transport type. Only {} are allowed!".format(
+                    transport,
+                    self.ALLOWED_TRANSPORTS,
+                )
+            )
+
+        self.transport = transport
+        self.debug = debug
+
+        self.server_process = None
+        self.socket_dir = None
+
+        # Inter-process coordination events
+        self.exit = Event()
+        self.ready = Event()
+
+        # Shared-mem property value holders for inter-process communication
+        self._socket_path = Array(ctypes.c_char, 1024, lock=True)
+        self._port = Value(ctypes.c_long, 0, lock=True)
+        self._metric_counter_shmem_var = Value(ctypes.c_long, 0, lock=True)
+        self._payload_counter_shmem_var = Value(ctypes.c_long, 0, lock=True)
+
+    def _run_server(self):
+        payload_counter = 0
+        metric_counter = 0
+
+        if self.transport == "UDS":
+            self.socket_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
+            socket_path = os.path.join(self.socket_dir, self.SOCKET_NAME)
+
+            if os.path.exists(socket_path):
+                os.unlink(socket_path)
+
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+            sock.settimeout(3)
+            sock.bind(socket_path)
+
+            # We are using ctypes for shmem so we have to use a consistent
+            # datatype across Python versions
+            if is_p3k():
+                self._socket_path.value = socket_path.encode("utf-8")
+            else:
+                self._socket_path.value = socket_path
+
+        elif self.transport == "UDP":
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.settimeout(3)
+            sock.bind(("", 0))
+
+            _, self._port.value = sock.getsockname()
+
+        # Run an async thread to update our shared-mem counters. We don't want to update
+        # the shared memory values when we get data due to performance reasons.
+        def _update_counters():
+            while not self.exit.is_set():
+                self._payload_counter_shmem_var.value = payload_counter
+                self._metric_counter_shmem_var.value = metric_counter
+                time.sleep(0.2)
+
+        counter_update_timer = threading.Thread(target=_update_counters)
+        counter_update_timer.daemon = True
+        counter_update_timer.start()
+
+        try:
+            self.ready.set()
+
+            while not self.exit.is_set():
+                payload, _ = sock.recvfrom(8192)
+
+                payload_counter += 1
+                metric_counter += len(payload.split(b"\n"))
+
+                if self.debug:
+                    print(
+                        "Got '{}' (pkts: {}, payloads: {}, metrics: {}".format(
+                            payload,
+                            len(payload.split(b"\n")),
+                            payload_counter,
+                            metric_counter,
+                        )
+                    )
+
+        except socket.timeout as ste:
+            if not self.exit.is_set():
+                raise ste
+        finally:
+            counter_update_timer.join()
+            sock.close()
+
+    def __enter__(self):
+        if self.server_process:
+            raise RuntimeError("Server already running")
+
+        self.server_process = Process(
+            target=self._run_server,
+            name=FakeServer.__class__.__name__,
+            args=(),
+        )
+        self.server_process.daemon = True
+        self.server_process.start()
+
+        self.ready.wait(5)
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        # Allow grace time to capture all metrics
+        time.sleep(2)
+
+        self.exit.set()
+        self.server_process.join(10)
+
+        if self.socket_dir:
+            shutil.rmtree(self.socket_dir, ignore_errors=True)
+
+        if self.server_process.exitcode != 0:
+            raise RuntimeError("Server process did not exit successfully!")
+
+    @property
+    def port(self):
+        return self._port.value
+
+    @property
+    def socket_path(self):
+        return self._socket_path.value or None
+
+    @property
+    def payloads_captured(self):
+        return self._payload_counter_shmem_var.value
+
+    @property
+    def metrics_captured(self):
+        return self._metric_counter_shmem_var.value
+
+    def __repr__(self):
+        return "<FakeThreadedUDPServer(Packets RX: {}, Metrics RX: {}".format(
+            self._payload_counter_shmem_var.value, self._metric_counter_shmem_var.value
+        )

--- a/tests/util/system_info_observer.py
+++ b/tests/util/system_info_observer.py
@@ -1,0 +1,101 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the BSD-3-Clause License. This product includes software developed at
+# Datadog (https://www.datadoghq.com/).
+
+# Copyright 2021-Present Datadog, Inc
+
+from threading import Event, Thread
+import os
+import time
+
+# pylint: disable=import-error
+import psutil
+
+
+# pylint: disable=useless-object-inheritance
+class SysInfoObserver(object):
+    """
+    SysInfoObserver collects timed CPU and memory usage stats in a separate
+    thread about the current process.
+    """
+
+    def __init__(self, interval=0.1):
+        self._stats = []
+
+        self.interval = interval
+
+        self.exit = None
+        self.initial_cpu_user = None
+        self.initial_cpu_system = None
+        self.observer_thread = None
+        self.proc_info = None
+
+    def __enter__(self):
+        if self.observer_thread:
+            raise RuntimeError("Observer already running")
+
+        self.exit = Event()
+
+        pid = os.getpid()
+        self.proc_info = psutil.Process(pid)
+
+        self.initial_cpu_user = self.proc_info.cpu_times().user
+        self.initial_cpu_system = self.proc_info.cpu_times().system
+
+        self.observer_thread = Thread(
+            name=self.__class__.__name__,
+            target=self.poll_system_info,
+            args=(
+                self.proc_info,
+                self.interval,
+            ),
+        )
+        self.observer_thread.daemon = True
+        self.observer_thread.start()
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        self.exit.set()
+        self.observer_thread.join()
+
+    def poll_system_info(self, proc_info, interval):
+        while not self.exit.is_set():
+            time.sleep(interval)
+
+            mem_info = proc_info.memory_full_info()
+            datapoint = {
+                "interval": interval,
+                "mem.rss_kb": mem_info.rss / 1024,
+                "mem.vms_kb": mem_info.vms / 1024,
+            }
+
+            self._stats.append(datapoint)
+
+    @property
+    def stats(self):
+        # CPU data is cumulative
+        agg_stats = {
+            "cpu.user": self.proc_info.cpu_times().user - self.initial_cpu_user,
+            "cpu.system": self.proc_info.cpu_times().system - self.initial_cpu_system,
+        }
+
+        if not self.exit.is_set():
+            raise RuntimeError(
+                "You can only collect aggregated stats after context manager exits"
+            )
+
+        datapoints = len(self._stats)
+        for datapoint in self._stats:
+            for key, val in datapoint.items():
+                if key.startswith("cpu"):
+                    continue
+
+                if key not in agg_stats:
+                    agg_stats[key] = 0.0
+
+                agg_stats[key] += val
+
+        for key, val in agg_stats.items():
+            if not key.startswith("cpu"):
+                agg_stats[key] = val / datapoints
+
+        return agg_stats


### PR DESCRIPTION
### What does this PR do?

We previously had no good way to do a reasonably-accurate local benchmark
of the statsd code so this benchmark should allow us to collect some of
that data easily.

Features:
  - Supports both Python2 and Python3
  - Has multi-threading support
  - Supports env var configuration
  - Collects CPU, memory, latency, duration, packet metrics
  - Has an included separate-process fake server to collect the data
  - Server runs in a separate process from test code
  - Both server and benchmark support UDP _and_ UDS transports
  - Includes various sanity checks and warnings to highlight issues
    with transport and/or packet drop
  - Averages data over multiple runs and threads

Closes https://github.com/DataDog/datadogpy/issues/662

### Description of the Change

Addition of a benchmarking test for `statsd`

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Install `psutil`
2. Run `python2 -m unittest -vvv tests.performance.test_statsd_throughput` or `python3 -m unittest -vvv tests.performance.test_statsd_throughput` depending on the interpreter version you are running.

### Additional Notes

Part of `agent-core` OKR 5

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [x] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

