### PR TITLE
[github] Add agent-core as co-owners to statsd performance tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,25 +4,26 @@
 # pattern is the one used.
 
 # Default owners of everything in the repo
-*                            @DataDog/integrations-tools-and-libraries
+*                                @DataDog/integrations-tools-and-libraries
 
 # API
-/datadog/api/                @DataDog/integrations-tools-and-libraries
-/tests/integration/api/      @DataDog/integrations-tools-and-libraries
-/tests/unit/api/             @DataDog/integrations-tools-and-libraries
+/datadog/api/                    @DataDog/integrations-tools-and-libraries
+/tests/integration/api/          @DataDog/integrations-tools-and-libraries
+/tests/unit/api/                 @DataDog/integrations-tools-and-libraries
 
 # Dogshell
-/datadog/dogshell/           @DataDog/integrations-tools-and-libraries
-/tests/integration/dogshell/ @DataDog/integrations-tools-and-libraries
+/datadog/dogshell/               @DataDog/integrations-tools-and-libraries
+/tests/integration/dogshell/     @DataDog/integrations-tools-and-libraries
 
 # Dogstatd
-/datadog/dogstatsd/          @DataDog/integrations-tools-and-libraries @DataDog/agent-core
-/tests/unit/dogstatsd/       @DataDog/integrations-tools-and-libraries @DataDog/agent-core
+/datadog/dogstatsd/              @DataDog/integrations-tools-and-libraries @DataDog/agent-core
+/tests/unit/dogstatsd/           @DataDog/integrations-tools-and-libraries @DataDog/agent-core
+/tests/performance/test_statsd_* @DataDog/integrations-tools-and-libraries @DataDog/agent-core
 
 # Threadstats
-/datadog/threadstats/        @DataDog/integrations-tools-and-libraries @DataDog/agent-core
-/tests/unit/threadstats/     @DataDog/integrations-tools-and-libraries @DataDog/agent-core
+/datadog/threadstats/            @DataDog/integrations-tools-and-libraries @DataDog/agent-core
+/tests/unit/threadstats/         @DataDog/integrations-tools-and-libraries @DataDog/agent-core
 
 # Documentation
-*.md                         @DataDog/baklava @DataDog/integrations-tools-and-libraries
-LICENSE                      @DataDog/baklava @DataDog/integrations-tools-and-libraries
+*.md                             @DataDog/baklava @DataDog/integrations-tools-and-libraries
+LICENSE                          @DataDog/baklava @DataDog/integrations-tools-and-libraries


### PR DESCRIPTION
### What does this PR do?

Adds `agent-core` team to owners of `tests/perofrmance/test_statsd_*` files

### Description of the Change

Since these tests are effectively the counterpart to the statsd code
that is owned by agent-core, this change ensures that the performance
test ownership is consistent too.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

