### PR TITLE
[tests] Improve statsd performance benchmark on MacOS platforms

### DIFF
--- a/tests/performance/test_statsd_throughput.py
+++ b/tests/performance/test_statsd_throughput.py
@@ -298,15 +298,6 @@ class TestDogStatsdThroughput(unittest.TestCase):
                 )
             )
 
-        # Verify that dropped metric count is matching our statsd expectations. Note
-        # that in some scenarios, some data is expected to be dropped.
-        if server.metrics_captured != statsd_instance.packets_sent:
-            error_msg = "WARN: Statsd sent packet count ({}) did not match the server "
-            error_msg += "captured metric count ({})!\n"
-            warnings.warn(
-                error_msg.format(statsd_instance.packets_sent, server.metrics_captured)
-            )
-
         # Verify that received metric count is matching our metric totals expectations. Note
         # that in some scenarios, some data is expected to be dropped.
         if server.metrics_captured != expected_metrics:
@@ -332,5 +323,8 @@ class TestDogStatsdThroughput(unittest.TestCase):
             StatsdSender.send(metric, statsd_instance, metric_idx)
 
             duration += timeit.default_timer() - start_time
+
+        if hasattr(statsd_instance, 'flush'):
+            statsd_instance.flush()
 
         latency_results.put(duration)


### PR DESCRIPTION
### What does this PR do?

Few issues were noticed when running the statsd benchmark on MacOS that needed
fixing

### Description of the Change

- Receive buffer of the socket is now increased to reasonable levels
(32k from 4k)
- Packet count warning was moot since we may send multiple metrics per
packet
- If `statsd.flush` method is available, call it when the threaded
sender exits to ensure that we are accounting for all of the metrics in
the results.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Run benchmark on MacOS with 10 threads via UDS and see the reduction in packet drops

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

