### PR TITLE
[tests] Use memory diffs from baseline in observer helper module stats

### DIFF
--- a/tests/performance/test_statsd_throughput.py
+++ b/tests/performance/test_statsd_throughput.py
@@ -108,7 +108,7 @@ class TestDogStatsdThroughput(unittest.TestCase):
 
     RUN_MESSAGE = (
         "Run #{:2d}/{:2d}: {:.4f}s (latency: {:.2f}μs, cpu: {:.4f},"
-        + " mem.rss: {:.0f}kb, recv: {:.2f}%)"
+        + " mem.rss_diff: {:.0f}kb, recv: {:.2f}%)"
     )
 
     def setUp(self):
@@ -192,14 +192,14 @@ class TestDogStatsdThroughput(unittest.TestCase):
                     duration,
                     avg_latency,
                     sys_stats["cpu.user"] + sys_stats["cpu.system"],
-                    sys_stats["mem.rss_kb"],
+                    sys_stats["mem.rss_diff_kb"],
                     received_packet_pct,
                 )
             )
 
             run_durations.append(duration)
             run_cpu_stats.append(sys_stats["cpu.user"] + sys_stats["cpu.system"])
-            run_memory_stats.append(sys_stats["mem.rss_kb"])
+            run_memory_stats.append(sys_stats["mem.rss_diff_kb"])
             run_latencies.append(float(avg_latency))
             received_packet_pcts.append(received_packet_pct)
 
@@ -207,7 +207,7 @@ class TestDogStatsdThroughput(unittest.TestCase):
         result_msg += "\tDuration:\t\t{:.4f}s\n"
         result_msg += "\tLatency:\t\t{:.2f}μs\n"
         result_msg += "\tCPU:\t\t\t{:.4f}\n"
-        result_msg += "\tMemory:\t\t\t{:.0f}kb\n"
+        result_msg += "\tMemory (rss) diff:\t{:.0f}kb\n"
         result_msg += "\tReceived packets:\t{:.2f}%"
         print(
             result_msg.format(


### PR DESCRIPTION
### What does this PR do?

Absolute values of RSS memory are not really useful as the setup may be
different before the observer is run.

### Description of the Change

We now initialize baseline rss/vms values
when the observer is created and we only record the relative difference
of the context-managed block.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

