### PR TITLE
[statsd] Enable buffering by default for statsd

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -312,14 +312,14 @@ class DogStatsd(object):
 
         # If buffering is disabled, we bypass the buffer function.
         self._send = self._send_to_buffer
-        if disable_buffering is True:
+        if disable_buffering:
             log.info("Statsd buffering is disabled")
             self._send = self._send_to_server
 
         # Start the flush thread if buffering is enabled and the interval is above
         # a reasonable range. This both prevents thrashing and allow us to use "0.0"
         # as a value for disabling the automatic flush timer as well.
-        if disable_buffering is False and flush_interval >= MIN_FLUSH_INTERVAL:
+        if not disable_buffering and flush_interval >= MIN_FLUSH_INTERVAL:
             self._register_flush_thread(flush_interval)
             log.debug(
                 "Statsd flush thread registered with period of %s",
@@ -442,7 +442,7 @@ class DogStatsd(object):
         WARNING: Deprecated method - all operations are now buffered by default.
         Open a buffer to send a batch of metrics.
 
-        To take dvantage of automatic flushing, you should use the context manager instead
+        To take advantage of automatic flushing, you should use the context manager instead
 
         >>> with DogStatsd() as batch:
         >>>     batch.gauge("users.online", 123)
@@ -480,7 +480,7 @@ class DogStatsd(object):
 
     def flush(self):
         """
-        Flush the metrics buffer by sending the data to the server
+        Flush the metrics buffer by sending the data to the server.
         """
         with self._buffer_lock:
             # Only send packets if there are packets to send
@@ -855,7 +855,7 @@ class DogStatsd(object):
 
         if len(string) > 8 * 1024:
             raise Exception(
-                u'Event "{}" payload is too big (>=8KB). Event discarded'.format(
+                u'Event "{0}" payload is too big (>=8KB). Event discarded'.format(
                     title
                 )
             )

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-# Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
-# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Unless explicitly stated otherwise all files in this repository are licensed under
+# the BSD-3-Clause License. This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 """
 DogStatsd is a Python client for DogStatsd, a Statsd fork for Datadog.
@@ -12,8 +13,11 @@ import logging
 import os
 import socket
 import errno
+import threading
 import time
 from threading import Lock, RLock
+
+from typing import Optional, List, Text, Union
 
 # Datadog libraries
 from datadog.dogstatsd.context import (
@@ -22,9 +26,9 @@ from datadog.dogstatsd.context import (
 )
 from datadog.dogstatsd.route import get_default_route
 from datadog.util.compat import is_p3k, text
+from datadog.util.deprecation import deprecated
 from datadog.util.format import normalize_tags
 from datadog.version import __version__
-from typing import Optional, List, Text, Union
 
 # Logging
 log = logging.getLogger("datadog.dogstatsd")
@@ -33,10 +37,14 @@ log = logging.getLogger("datadog.dogstatsd")
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 8125
 
+# Buffering-related values (in seconds)
+DEFAULT_FLUSH_INTERVAL = 0.3
+MIN_FLUSH_INTERVAL = 0.0001
+
 # Tag name of entity_id
 ENTITY_ID_TAG_NAME = "dd.internal.entity_id"
 
-# Default buffer settings
+# Default buffer settings based on socket type
 UDP_OPTIMAL_PAYLOAD_LENGTH = 1432
 UDS_OPTIMAL_PAYLOAD_LENGTH = 8192
 
@@ -67,26 +75,30 @@ TELEMETRY_FORMATTING_STR = "\n".join(
 )
 
 
+# pylint: disable=useless-object-inheritance,too-many-instance-attributes
+# pylint: disable=too-many-arguments,too-many-locals
 class DogStatsd(object):
     OK, WARNING, CRITICAL, UNKNOWN = (0, 1, 2, 3)
 
     def __init__(
         self,
-        host=DEFAULT_HOST,  # type: Text
-        port=DEFAULT_PORT,  # type: int
-        max_buffer_size=None,  # type: None
-        namespace=None,  # type: Optional[Text]
-        constant_tags=None,  # type: Optional[List[str]]
-        use_ms=False,  # type: bool
-        use_default_route=False,  # type: bool
-        socket_path=None,  # type: Optional[Text]
-        default_sample_rate=1,  # type: float
-        disable_telemetry=False,  # type: bool
+        host=DEFAULT_HOST,                      # type: Text
+        port=DEFAULT_PORT,                      # type: int
+        max_buffer_size=None,                   # type: None
+        flush_interval=DEFAULT_FLUSH_INTERVAL,  # type: float
+        disable_buffering=False,                # type: bool
+        namespace=None,                         # type: Optional[Text]
+        constant_tags=None,                     # type: Optional[List[str]]
+        use_ms=False,                           # type: bool
+        use_default_route=False,                # type: bool
+        socket_path=None,                       # type: Optional[Text]
+        default_sample_rate=1,                  # type: float
+        disable_telemetry=False,                # type: bool
         telemetry_min_flush_interval=(DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL),  # type: int
-        telemetry_host=None,  # type: Text
-        telemetry_port=None,  # type: Union[str, int]
-        telemetry_socket_path=None,  # type: Text
-        max_buffer_len=0,  # type: int
+        telemetry_host=None,                    # type: Text
+        telemetry_port=None,                    # type: Union[str, int]
+        telemetry_socket_path=None,             # type: Text
+        max_buffer_len=0,                       # type: int
     ):  # type: (...) -> None
         """
         Initialize a DogStatsd object.
@@ -138,6 +150,15 @@ class DogStatsd(object):
 
         :max_buffer_size: Deprecated option, do not use it anymore.
         :type max_buffer_type: None
+
+        :flush_interval: Amount of time in seconds that the flush thread will
+        wait before trying to flush the buffered metrics to the server. If set,
+        it overrides the default value.
+        :type flush_interval: float
+
+        :disable_buffering: If set, metrics are no longered buffered by the client and
+        all data is sent synchronously to the server
+        :type disable_buffering: bool
 
         :param namespace: Namespace to prefix all metric names
         :type namespace: string
@@ -246,7 +267,6 @@ class DogStatsd(object):
         # Socket
         self.socket = None
         self.telemetry_socket = None
-        self._send = self._send_to_server
         self.encoding = "utf-8"
 
         # Options
@@ -274,8 +294,36 @@ class DogStatsd(object):
         self._reset_telemetry()
         self._telemetry_flush_interval = telemetry_min_flush_interval
         self._telemetry = not disable_telemetry
+        self._last_flush_time = time.time()
 
+        self._current_buffer_total_size = 0
+        self._buffer = []  # type: List[Text]
         self._buffer_lock = RLock()
+
+        self._reset_buffer()
+
+        # This lock is used for backwards compatibility to prevent concurrent
+        # changes to the buffer when the user is managing the buffer themselves
+        # via deprecated `open_buffer()` and `close_buffer()` functions.
+        self._manual_buffer_lock = RLock()
+
+        # If buffering is disabled, we bypass the buffer function.
+        self._send = self._send_to_buffer
+        if disable_buffering is True:
+            log.info("Statsd buffering is disabled")
+            self._send = self._send_to_server
+
+        # Start the flush thread if buffering is enabled and the interval is above
+        # a reasonable range. This both prevents thrashing and allow us to use "0.0"
+        # as a value for disabling the automatic flush timer as well.
+        if disable_buffering is False and flush_interval >= MIN_FLUSH_INTERVAL:
+            self._register_flush_thread(flush_interval)
+            log.debug(
+                "Statsd flush thread registered with period of %s",
+                flush_interval,
+            )
+        else:
+            log.info("Statsd periodic buffer flush is disabled")
 
     def disable_telemetry(self):
         self._telemetry = False
@@ -283,15 +331,29 @@ class DogStatsd(object):
     def enable_telemetry(self):
         self._telemetry = True
 
+    def _register_flush_thread(self, sleep_duration):
+        def _flush_thread_loop(self, sleep_duration):
+            while True:
+                time.sleep(sleep_duration)
+                self.flush()
+
+        self._flush_thread = threading.Thread(
+            name="{}_flush_thread".format(self.__class__.__name__),
+            target=_flush_thread_loop,
+            args=(self, sleep_duration,),
+        )
+        self._flush_thread.daemon = True
+        self._flush_thread.start()
+
     def _dedicated_telemetry_destination(self):
         return bool(self.telemetry_socket_path or self.telemetry_host)
 
     def __enter__(self):
-        self.open_buffer()
+        self._reset_buffer()
         return self
 
-    def __exit__(self, type, value, traceback):
-        self.close_buffer()
+    def __exit__(self, exc_type, value, traceback):
+        self.flush()
 
     @staticmethod
     def resolve_host(host, use_default_route):
@@ -300,7 +362,7 @@ class DogStatsd(object):
 
         :param host: host
         :type host: string
-        :param use_default_route: use the system default route as host (overrides the `host` parameter)
+        :param use_default_route: Use the system default route as host (overrides `host` parameter)
         :type use_default_route: bool
         """
         if not use_default_route:
@@ -319,9 +381,14 @@ class DogStatsd(object):
             if telemetry and self._dedicated_telemetry_destination():
                 if not self.telemetry_socket:
                     if self.telemetry_socket_path is not None:
-                        self.telemetry_socket = self._get_uds_socket(self.telemetry_socket_path)
+                        self.telemetry_socket = self._get_uds_socket(
+                            self.telemetry_socket_path,
+                        )
                     else:
-                        self.telemetry_socket = self._get_udp_socket_socket(self.telemetry_host, self.telemetry_port)
+                        self.telemetry_socket = self._get_udp_socket_socket(
+                            self.telemetry_host,
+                            self.telemetry_port,
+                        )
 
                 return self.telemetry_socket
 
@@ -329,7 +396,10 @@ class DogStatsd(object):
                 if self.socket_path is not None:
                     self.socket = self._get_uds_socket(self.socket_path)
                 else:
-                    self.socket = self._get_udp_socket(self.host, self.port)
+                    self.socket = self._get_udp_socket(
+                        self.host,
+                        self.port,
+                    )
 
             return self.socket
 
@@ -347,11 +417,13 @@ class DogStatsd(object):
         sock.connect((host, port))
         return sock
 
+    @deprecated("Statsd module now uses buffering by default.")
     def open_buffer(self, max_buffer_size=None):
         """
+        WARNING: Deprecated method - all operations are now buffered by default.
         Open a buffer to send a batch of metrics.
 
-        You can also use this as a context manager.
+        To take dvantage of automatic flushing, you should use the context manager instead
 
         >>> with DogStatsd() as batch:
         >>>     batch.gauge("users.online", 123)
@@ -360,33 +432,42 @@ class DogStatsd(object):
         Note: This method must be called before close_buffer() matching invocation.
         """
 
-        self._buffer_lock.acquire()
+        self._manual_buffer_lock.acquire()
 
         if max_buffer_size is not None:
             log.warning("The parameter max_buffer_size is now deprecated and is not used anymore")
-        self._current_buffer_total_size = 0
-        self.buffer = []
-        self._send = self._send_to_buffer
 
+        self._reset_buffer()
+
+    @deprecated("Statsd module now uses buffering by default.")
     def close_buffer(self):
         """
+        WARNING: Deprecated method - all operations are now buffered by default.
+
         Flush the buffer and switch back to single metric packets.
 
         Note: This method must be called after a matching open_buffer()
         invocation.
         """
-
-        if not hasattr(self, "buffer"):
-            raise BufferError("Cannot close buffer that was never opened")
-
         try:
-            self._send = self._send_to_server
-
-            if self.buffer:
-                # Only send packets if there are packets to send
-                self._flush_buffer()
+            self.flush()
         finally:
-            self._buffer_lock.release()
+            self._manual_buffer_lock.release()
+
+    def _reset_buffer(self):
+        with self._buffer_lock:
+            self._current_buffer_total_size = 0
+            self._buffer = []
+
+    def flush(self):
+        """
+        Flush the metrics buffer by sending the data to the server
+        """
+        with self._buffer_lock:
+            # Only send packets if there are packets to send
+            if self._buffer:
+                self._send_to_server("\n".join(self._buffer))
+                self._reset_buffer()
 
     def gauge(
         self,
@@ -610,7 +691,8 @@ class DogStatsd(object):
         )
 
     def _is_telemetry_flush_time(self):
-        return self._telemetry and self._last_flush_time + self._telemetry_flush_interval < time.time()
+        return self._telemetry and \
+            self._last_flush_time + self._telemetry_flush_interval < time.time()
 
     def _send_to_server(self, packet):
         self._xmit_packet(packet, False)
@@ -644,55 +726,64 @@ class DogStatsd(object):
         except socket.timeout:
             # dogstatsd is overflowing, drop the packets (mimicks the UDP behaviour)
             pass
-        except (socket.herror, socket.gaierror) as se:
+        except (socket.herror, socket.gaierror) as socket_err:
             log.warning(
                 "Error submitting packet: %s, dropping the packet and closing the socket",
-                se,
+                socket_err,
             )
             self.close_socket()
-        except socket.error as se:
-            if se.errno == errno.EAGAIN:
-                log.debug("Socket send would block: %s, dropping the packet", se)
+        except socket.error as socket_err:
+            if socket_err.errno == errno.EAGAIN:
+                log.debug("Socket send would block: %s, dropping the packet", socket_err)
+            elif socket_err.errno == errno.ENOBUFS:
+                log.debug("Socket buffer full: %s, dropping the packet", socket_err)
+            elif socket_err.errno == errno.EMSGSIZE:
+                log.debug(
+                    "Packet size too big (size: %d): %s, dropping the packet",
+                    len(packet.encode(self.encoding)),
+                    socket_err)
             else:
                 log.warning(
                     "Error submitting packet: %s, dropping the packet and closing the socket",
-                    se,
+                    socket_err,
                 )
                 self.close_socket()
         except Exception as e:
             log.error("Unexpected error: %s", str(e))
+
         if not is_telemetry and self._telemetry:
             self.bytes_dropped += len(packet)
             self.packets_dropped += 1
+
         return False
 
     def _send_to_buffer(self, packet):
         if self._should_flush(len(packet)):
-            self._flush_buffer()
-        self.buffer.append(packet)
-        # Update the current buffer length, including line break to anticipate the final packet size
-        self._current_buffer_total_size += len(packet) + 1
+            self.flush()
+
+        with self._buffer_lock:
+            self._buffer.append(packet)
+            # Update the current buffer length, including line break to anticipate
+            # the final packet size
+            self._current_buffer_total_size += len(packet) + 1
 
     def _should_flush(self, length_to_be_added):
         if self._current_buffer_total_size + length_to_be_added > self._max_payload_size:
             return True
         return False
 
-    def _flush_buffer(self):
-        self._send_to_server("\n".join(self.buffer))
-        self._current_buffer_total_size = 0
-        self.buffer = []
-
-    def _escape_event_content(self, string):
+    @staticmethod
+    def _escape_event_content(string):
         return string.replace("\n", "\\n")
 
-    def _escape_service_check_message(self, string):
+    @staticmethod
+    def _escape_service_check_message(string):
         return string.replace("\n", "\\n").replace("m:", "m\\:")
 
     def event(
         self,
         title,
-        text,
+        message,
         alert_type=None,
         aggregation_key=None,
         source_type_name=None,
@@ -706,25 +797,26 @@ class DogStatsd(object):
             http://docs.datadoghq.com/api/
 
         >>> statsd.event("Man down!", "This server needs assistance.")
-        >>> statsd.event("The web server restarted", "The web server is up again", alert_type="success")  # NOQA
+        >>> statsd.event("Web server restart", "The web server is up", alert_type="success")  # NOQA
         """
-        title = self._escape_event_content(title)
-        text = self._escape_event_content(text)
+        title = DogStatsd._escape_event_content(title)
+        message = DogStatsd._escape_event_content(message)
 
+        # pylint: disable=undefined-variable
         if not is_p3k():
-            if not isinstance(title, unicode):                              # noqa: F821
-                title = unicode(self._escape_event_content(title), 'utf8')  # noqa: F821
-            if not isinstance(text, unicode):                               # noqa: F821
-                text = unicode(self._escape_event_content(text), 'utf8')    # noqa: F821
+            if not isinstance(title, unicode):                                       # noqa: F821
+                title = unicode(DogStatsd._escape_event_content(title), 'utf8')      # noqa: F821
+            if not isinstance(message, unicode):                                     # noqa: F821
+                message = unicode(DogStatsd._escape_event_content(message), 'utf8')  # noqa: F821
 
         # Append all client level tags to every event
         tags = self._add_constant_tags(tags)
 
         string = u"_e{{{},{}}}:{}|{}".format(
             len(title.encode('utf8', 'replace')),
-            len(text.encode('utf8', 'replace')),
+            len(message.encode('utf8', 'replace')),
             title,
-            text,
+            message,
         )
 
         if date_happened:
@@ -743,19 +835,32 @@ class DogStatsd(object):
             string = "%s|#%s" % (string, ",".join(tags))
 
         if len(string) > 8 * 1024:
-            raise Exception(u'Event "%s" payload is too big (more than 8KB), ' "event discarded" % title)
+            raise Exception(
+                u'Event "{}" payload is too big (>=8KB). Event discarded'.format(
+                    title
+                )
+            )
 
         if self._telemetry:
             self.events_count += 1
+
         self._send(string)
 
-    def service_check(self, check_name, status, tags=None, timestamp=None, hostname=None, message=None):
+    def service_check(
+        self,
+        check_name,
+        status,
+        tags=None,
+        timestamp=None,
+        hostname=None,
+        message=None,
+    ):
         """
         Send a service check run.
 
         >>> statsd.service_check("my_service.check_name", DogStatsd.WARNING)
         """
-        message = self._escape_service_check_message(message) if message is not None else ""
+        message = DogStatsd._escape_service_check_message(message) if message is not None else ""
 
         string = u"_sc|{0}|{1}".format(check_name, status)
 
@@ -773,14 +878,15 @@ class DogStatsd(object):
 
         if self._telemetry:
             self.service_checks_count += 1
+
         self._send(string)
 
     def _add_constant_tags(self, tags):
         if self.constant_tags:
             if tags:
                 return tags + self.constant_tags
-            else:
-                return self.constant_tags
+
+            return self.constant_tags
         return tags
 
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -777,10 +777,10 @@ class DogStatsd(object):
         return False
 
     def _send_to_buffer(self, packet):
-        if self._should_flush(len(packet)):
-            self.flush()
-
         with self._buffer_lock:
+            if self._should_flush(len(packet)):
+                self.flush()
+
             self._buffer.append(packet)
             # Update the current buffer length, including line break to anticipate
             # the final packet size

--- a/datadog/util/deprecation.py
+++ b/datadog/util/deprecation.py
@@ -1,0 +1,24 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2015-Present Datadog, Inc
+
+import warnings
+from functools import wraps
+
+
+def deprecated(message):
+    def deprecated_decorator(func):
+        @wraps(func)
+        def deprecated_func(*args, **kwargs):
+            warnings.warn(
+                "'{}' is a deprecated function. {}".format(func.__name__, message),
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            warnings.simplefilter('default', DeprecationWarning)
+
+            return func(*args, **kwargs)
+
+        return deprecated_func
+
+    return deprecated_decorator

--- a/datadog/util/deprecation.py
+++ b/datadog/util/deprecation.py
@@ -11,7 +11,7 @@ def deprecated(message):
         @wraps(func)
         def deprecated_func(*args, **kwargs):
             warnings.warn(
-                "'{}' is a deprecated function. {}".format(func.__name__, message),
+                "'{0}' is a deprecated function. {1}".format(func.__name__, message),
                 category=DeprecationWarning,
                 stacklevel=2,
             )

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -10,12 +10,12 @@ Tests for dogstatsd.py
 # Standard libraries
 from collections import deque
 from threading import Thread
+import errno
 import os
 import socket
-import errno
-
 import time
 import unittest
+import warnings
 
 # Third-party libraries
 import mock
@@ -25,7 +25,7 @@ import pytest
 # Datadog libraries
 from datadog import initialize, statsd
 from datadog import __version__ as version
-from datadog.dogstatsd.base import DogStatsd, UDP_OPTIMAL_PAYLOAD_LENGTH
+from datadog.dogstatsd.base import DEFAULT_FLUSH_INTERVAL, DogStatsd, UDP_OPTIMAL_PAYLOAD_LENGTH
 from datadog.dogstatsd.context import TimedContextManagerDecorator
 from datadog.util.compat import is_higher_py35, is_p3k
 from tests.util.contextmanagers import preserve_environment_variable, EnvVars
@@ -35,8 +35,13 @@ from tests.unit.dogstatsd.fixtures import load_fixtures
 class FakeSocket(object):
     """ A fake socket for testing. """
 
-    def __init__(self):
+    FLUSH_GRACE_PERIOD = 0.2
+
+    def __init__(self, flush_interval=DEFAULT_FLUSH_INTERVAL):
         self.payloads = deque()
+
+        self._flush_interval = flush_interval
+        self._flush_wait = False
 
     def send(self, payload):
         if is_p3k():
@@ -46,14 +51,21 @@ class FakeSocket(object):
 
         self.payloads.append(payload)
 
-    def recv(self, count=1):
-        try:
-            out = []
-            for _ in range(count):
-                out.append(self.payloads.popleft().decode('utf-8'))
-            return '\n'.join(out)
-        except IndexError:
+    def recv(self, count=1, reset_wait=False, no_wait=False):
+        # Initial receive should wait for the flush thread timeout unless we
+        # specifically want either a follow-up wait or no waiting at all
+        if not self._flush_wait or reset_wait:
+            if not no_wait:
+                time.sleep(self._flush_interval+self.FLUSH_GRACE_PERIOD)
+            self._flush_wait = True
+
+        if count > len(self.payloads):
             return None
+
+        out = []
+        for _ in range(count):
+            out.append(self.payloads.popleft().decode('utf-8'))
+        return '\n'.join(out)
 
     def close(self):
         pass
@@ -63,17 +75,23 @@ class FakeSocket(object):
 
 
 class BrokenSocket(FakeSocket):
+    def __init__(self, error_number=None):
+        super(BrokenSocket, self).__init__()
+
+        self.error_number = error_number
 
     def send(self, payload):
-        raise socket.error("Socket error")
+        error = socket.error("Socket error [Errno {}]".format(self.error_number))
+        if self.error_number:
+            error.errno = self.error_number
 
-
-class OverflownSocket(FakeSocket):
-
-    def send(self, payload):
-        error = socket.error("Socket error")
-        error.errno = errno.EAGAIN
         raise error
+
+
+class OverflownSocket(BrokenSocket):
+
+    def __init__(self):
+        super(OverflownSocket, self).__init__(errno.EAGAIN)
 
 
 def telemetry_metrics(metrics=1, events=0, service_checks=0, bytes_sent=0, bytes_dropped=0, packets_sent=1, packets_dropped=0, transport="udp", tags=""):
@@ -123,13 +141,22 @@ class TestDogStatsd(unittest.TestCase):
         return self.assertEqual(expected_payload, actual_payload)
 
     def assert_almost_equal(self, val1, val2, delta):
-        return self.assertTrue(0 <= abs(val1 - val2) <= delta, "%s - %s not within %s" % (val1, val2, delta))
+        """
+        Calculates a delta between first and second value and ensures
+        that this difference falls within the delta range
+        """
+        return self.assertTrue(
+            0 <= abs(val1 - val2) <= delta,
+            "Absolute difference of {} and {} ({}) is not within {}".format(
+                val1,
+                val2,
+                abs(val1-val2),
+                delta,
+            ),
+        )
 
-    def recv(self, count=1):
-        packets = []
-        for _ in range(count):
-            packets.append(self.statsd.socket.recv())
-        return "\n".join(packets)
+    def recv(self, *args, **kwargs):
+        return self.statsd.socket.recv(*args, **kwargs)
 
     def test_initialization(self):
         """
@@ -203,18 +230,22 @@ class TestDogStatsd(unittest.TestCase):
 
     def test_counter(self):
         self.statsd.increment('page.views')
+        self.statsd.flush()
         self.assert_equal_telemetry('page.views:1|c', self.recv(2))
 
         self.statsd._reset_telemetry()
         self.statsd.increment('page.views', 11)
+        self.statsd.flush()
         self.assert_equal_telemetry('page.views:11|c', self.recv(2))
 
         self.statsd._reset_telemetry()
         self.statsd.decrement('page.views')
+        self.statsd.flush()
         self.assert_equal_telemetry('page.views:-1|c', self.recv(2))
 
         self.statsd._reset_telemetry()
         self.statsd.decrement('page.views', 12)
+        self.statsd.flush()
         self.assert_equal_telemetry('page.views:-12|c', self.recv(2))
 
     def test_histogram(self):
@@ -238,44 +269,93 @@ class TestDogStatsd(unittest.TestCase):
         self.assert_equal_telemetry('h:1|h|#red', self.recv(2))
 
     def test_sample_rate(self):
-        self.statsd._telemetry = False # disabling telemetry since sample_rate imply randomness
+        # Disabling telemetry since sample_rate imply randomness
+        self.statsd._telemetry = False
+
         self.statsd.increment('c', sample_rate=0)
-        self.assertFalse(self.statsd.socket.recv())
+        self.assertFalse(self.recv())
+
         for _ in range(10000):
             self.statsd.increment('sampled_counter', sample_rate=0.3)
-        self.assert_almost_equal(3000, len(self.statsd.socket.payloads), 150)
-        self.assertEqual('sampled_counter:1|c|@0.3', self.recv())
+
+        self.statsd.flush()
+
+        total_metrics = 0
+        payload = self.recv()
+        while payload:
+            metrics = payload.split('\n')
+            for metric in metrics:
+                self.assertEqual('sampled_counter:1|c|@0.3', metric)
+            total_metrics += len(metrics)
+            payload = self.recv()
+
+        self.assert_almost_equal(3000, total_metrics, 150)
 
     def test_default_sample_rate(self):
-        self.statsd._telemetry = False # disabling telemetry since sample_rate imply randomness
+        # Disabling telemetry since sample_rate imply randomness
+        self.statsd._telemetry = False
+
         self.statsd.default_sample_rate = 0.3
         for _ in range(10000):
             self.statsd.increment('sampled_counter')
-        self.assert_almost_equal(3000, len(self.statsd.socket.payloads), 150)
-        self.assertEqual('sampled_counter:1|c|@0.3', self.recv())
+
+        total_metrics = 0
+        payload = self.recv()
+        while payload:
+            metrics = payload.split('\n')
+            for metric in metrics:
+                self.assertEqual('sampled_counter:1|c|@0.3', metric)
+
+            total_metrics += len(metrics)
+            payload = self.recv()
+
+        self.assert_almost_equal(3000, total_metrics, 150)
 
     def test_tags_and_samples(self):
-        self.statsd._telemetry = False # disabling telemetry since sample_rate imply randomness
+        # Disabling telemetry since sample_rate imply randomness
+        self.statsd._telemetry = False
+
         for _ in range(100):
             self.statsd.gauge('gst', 23, tags=["sampled"], sample_rate=0.9)
 
-        self.assertEqual('gst:23|g|@0.9|#sampled', self.recv())
+        self.assertEqual('gst:23|g|@0.9|#sampled', self.recv().split('\n')[0])
 
     def test_timing(self):
         self.statsd.timing('t', 123)
         self.assert_equal_telemetry('t:123|ms', self.recv(2))
 
     def test_event(self):
-        self.statsd.event('Title', u'L1\nL2', priority='low', date_happened=1375296969)
-        event = u'_e{5,6}:Title|L1\\nL2|d:1375296969|p:low'
-        self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
+        self.statsd.event(
+            'Title',
+            u'L1\nL2',
+            priority='low',
+            date_happened=1375296969,
+        )
+        event2 = u'_e{5,6}:Title|L1\\nL2|d:1375296969|p:low'
+        self.assert_equal_telemetry(
+            event2,
+            self.recv(2),
+            telemetry=telemetry_metrics(
+                metrics=0,
+                events=1,
+                bytes_sent=len(event2),
+            ),
+        )
 
         self.statsd._reset_telemetry()
 
         self.statsd.event('Title', u'♬ †øU †øU ¥ºu T0µ ♪',
                           aggregation_key='key', tags=['t1', 't2:v2'])
-        event = u'_e{5,32}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2'
-        self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
+        event3 = u'_e{5,32}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2'
+        self.assert_equal_telemetry(
+            event3,
+            self.recv(2, reset_wait=True),
+            telemetry=telemetry_metrics(
+                metrics=0,
+                events=1,
+                bytes_sent=len(event3),
+            ),
+        )
 
     def test_unicode_event(self):
         self.statsd.event(
@@ -283,7 +363,15 @@ class TestDogStatsd(unittest.TestCase):
                 'Delivered — destination.csv')
         event = u'_e{89,29}:my.prefix.Delivery - Daily Settlement Summary Report Delivery — Invoice Cloud succeeded|' + \
             u'Delivered — destination.csv'
-        self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, bytes_sent=len(event)))
+        self.assert_equal_telemetry(
+            event,
+            self.recv(2),
+            telemetry=telemetry_metrics(
+                metrics=0,
+                events=1,
+                bytes_sent=len(event),
+            ),
+        )
 
         self.statsd._reset_telemetry()
 
@@ -291,14 +379,32 @@ class TestDogStatsd(unittest.TestCase):
         self.statsd.constant_tags = ['bar:baz', 'foo']
         self.statsd.event('Title', u'L1\nL2', priority='low', date_happened=1375296969)
         event = u'_e{5,6}:Title|L1\\nL2|d:1375296969|p:low|#bar:baz,foo'
-        self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo", bytes_sent=len(event)))
+        self.assert_equal_telemetry(
+            event,
+            self.recv(2),
+            telemetry=telemetry_metrics(
+                metrics=0,
+                events=1,
+                tags="bar:baz,foo",
+                bytes_sent=len(event),
+            ),
+        )
 
         self.statsd._reset_telemetry()
 
         self.statsd.event('Title', u'♬ †øU †øU ¥ºu T0µ ♪',
                           aggregation_key='key', tags=['t1', 't2:v2'])
         event = u'_e{5,32}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2,bar:baz,foo'
-        self.assert_equal_telemetry(event, self.recv(2), telemetry=telemetry_metrics(metrics=0, events=1, tags="bar:baz,foo", bytes_sent=len(event)))
+        self.assert_equal_telemetry(
+            event,
+            self.recv(2, reset_wait=True),
+            telemetry=telemetry_metrics(
+                metrics=0,
+                events=1,
+                tags="bar:baz,foo",
+                bytes_sent=len(event),
+            ),
+        )
 
     def test_service_check(self):
         now = int(time.time())
@@ -307,7 +413,15 @@ class TestDogStatsd(unittest.TestCase):
             tags=['key1:val1', 'key2:val2'], timestamp=now,
             hostname='i-abcd1234', message=u"♬ †øU \n†øU ¥ºu|m: T0µ ♪")
         check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")
-        self.assert_equal_telemetry(check, self.recv(2), telemetry=telemetry_metrics(metrics=0, service_checks=1, bytes_sent=len(check)))
+        self.assert_equal_telemetry(
+            check,
+            self.recv(2),
+            telemetry=telemetry_metrics(
+                metrics=0,
+                service_checks=1,
+                bytes_sent=len(check),
+            ),
+        )
 
     def test_service_check_constant_tags(self):
         self.statsd.constant_tags = ['bar:baz', 'foo']
@@ -319,8 +433,13 @@ class TestDogStatsd(unittest.TestCase):
         check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#bar:baz,foo|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")
         self.assert_equal_telemetry(
             check,
-            self.recv(2),
-            telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo", bytes_sent=len(check))
+            self.recv(2, True),
+            telemetry=telemetry_metrics(
+                metrics=0,
+                service_checks=1,
+                tags="bar:baz,foo",
+                bytes_sent=len(check),
+            ),
         )
 
         self.statsd._reset_telemetry()
@@ -332,8 +451,13 @@ class TestDogStatsd(unittest.TestCase):
         check = u'_sc|my_check.name|{0}|d:{1}|h:i-abcd1234|#key1:val1,key2:val2,bar:baz,foo|m:{2}'.format(self.statsd.WARNING, now, u"♬ †øU \\n†øU ¥ºu|m\\: T0µ ♪")
         self.assert_equal_telemetry(
             check,
-            self.recv(2),
-            telemetry=telemetry_metrics(metrics=0, service_checks=1, tags="bar:baz,foo", bytes_sent=len(check))
+            self.recv(2, True),
+            telemetry=telemetry_metrics(
+                metrics=0,
+                service_checks=1,
+                tags="bar:baz,foo",
+                bytes_sent=len(check),
+            ),
         )
 
     def test_metric_namespace(self):
@@ -362,7 +486,14 @@ class TestDogStatsd(unittest.TestCase):
         self.statsd.constant_tags = ['bar:baz']
         self.statsd.gauge('gauge', 123.4, tags=metric_level_tag)
         metric = 'gauge:123.4|g|#foo:bar,bar:baz'
-        self.assert_equal_telemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz", bytes_sent=len(metric)))
+        self.assert_equal_telemetry(
+            metric,
+            self.recv(2),
+            telemetry=telemetry_metrics(
+                tags="bar:baz",
+                bytes_sent=len(metric),
+            ),
+        )
 
         self.statsd._reset_telemetry()
 
@@ -370,12 +501,21 @@ class TestDogStatsd(unittest.TestCase):
         # should not duplicate the tags being sent
         self.statsd.gauge('gauge', 123.4, tags=metric_level_tag)
         metric = "gauge:123.4|g|#foo:bar,bar:baz"
-        self.assert_equal_telemetry(metric, self.recv(2), telemetry=telemetry_metrics(tags="bar:baz", bytes_sent=len(metric)))
+        self.assert_equal_telemetry(
+            metric,
+            self.recv(2, reset_wait=True),
+            telemetry=telemetry_metrics(
+                tags="bar:baz",
+                bytes_sent=len(metric),
+            ),
+        )
 
     def test_socket_error(self):
         self.statsd.socket = BrokenSocket()
         with mock.patch("datadog.dogstatsd.base.log") as mock_log:
             self.statsd.gauge('no error', 1)
+            self.statsd.flush()
+
             mock_log.error.assert_not_called()
             mock_log.warning.assert_called_once_with(
                 "Error submitting packet: %s, dropping the packet and closing the socket",
@@ -386,8 +526,36 @@ class TestDogStatsd(unittest.TestCase):
         self.statsd.socket = OverflownSocket()
         with mock.patch("datadog.dogstatsd.base.log") as mock_log:
             self.statsd.gauge('no error', 1)
+            self.statsd.flush()
+
             mock_log.error.assert_not_called()
             calls = [call("Socket send would block: %s, dropping the packet", mock.ANY)]
+            mock_log.debug.assert_has_calls(calls * 2)
+
+    def test_socket_message_too_long(self):
+        self.statsd.socket = BrokenSocket(error_number=errno.EMSGSIZE)
+        with mock.patch("datadog.dogstatsd.base.log") as mock_log:
+            self.statsd.gauge('no error', 1)
+            self.statsd.flush()
+
+            mock_log.error.assert_not_called()
+            calls = [
+                call(
+                    "Packet size too big (size: %d): %s, dropping the packet",
+                    mock.ANY,
+                    mock.ANY,
+                ),
+            ]
+            mock_log.debug.assert_has_calls(calls * 2)
+
+    def test_socket_no_buffer_space(self):
+        self.statsd.socket = BrokenSocket(error_number=errno.ENOBUFS)
+        with mock.patch("datadog.dogstatsd.base.log") as mock_log:
+            self.statsd.gauge('no error', 1)
+            self.statsd.flush()
+
+            mock_log.error.assert_not_called()
+            calls = [call("Socket buffer full: %s, dropping the packet", mock.ANY)]
             mock_log.debug.assert_has_calls(calls * 2)
 
     def test_distributed(self):
@@ -398,7 +566,7 @@ class TestDogStatsd(unittest.TestCase):
         @self.statsd.distributed('distributed.test')
         def func(arg1, arg2, kwarg1=1, kwarg2=1):
             """docstring"""
-            time.sleep(0.5)
+            time.sleep(0.1)
             return (arg1, arg2, kwarg1, kwarg2)
 
         self.assertEqual('func', func.__name__)
@@ -414,7 +582,7 @@ class TestDogStatsd(unittest.TestCase):
 
         self.assertEqual('d', type_)
         self.assertEqual('distributed.test', name)
-        self.assert_almost_equal(0.5, float(value), 0.1)
+        self.assert_almost_equal(0.1, float(value), 0.09)
 
         # Repeat, force timer value in milliseconds
         @self.statsd.distributed('distributed.test', use_ms=True)
@@ -425,14 +593,14 @@ class TestDogStatsd(unittest.TestCase):
 
         func(1, 2, kwarg2=3)
 
-        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
+        # Ignore telemetry packet
+        packet = self.recv(2, reset_wait=True).split("\n")[0]
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
         self.assertEqual('d', type_)
         self.assertEqual('distributed.test', name)
         self.assert_almost_equal(500, float(value), 100)
-
 
     def test_timed(self):
         """
@@ -468,8 +636,10 @@ class TestDogStatsd(unittest.TestCase):
             return (arg1, arg2, kwarg1, kwarg2)
 
         func(1, 2, kwarg2=3)
+        self.statsd.flush()
 
-        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
+        # Ignore telemetry packet
+        packet = self.recv(2).split("\n")[0]
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -510,6 +680,7 @@ class TestDogStatsd(unittest.TestCase):
             return (arg1, arg2, kwarg1, kwarg2)
 
         func(1, 2, kwarg2=3)
+        self.statsd.flush()
 
         packet = self.recv()
         name_value, type_ = packet.split('|')
@@ -545,7 +716,7 @@ class TestDogStatsd(unittest.TestCase):
         self.assertEqual('tests.unit.dogstatsd.test_statsd.func', name)
         self.assert_almost_equal(0.5, float(value), 0.1)
 
-    @pytest.mark.skipif(not is_higher_py35(), reason="Coroutines are supported on Python 3.5 or higher.")
+    @unittest.skipIf(not is_higher_py35(), reason="Coroutines are supported on Python 3.5 or higher.")
     def test_timed_coroutine(self):
         """
         Measure the distribution of a coroutine function's run time.
@@ -599,7 +770,7 @@ async def print_foo():
         with self.statsd.timed('timed_context.test', use_ms=True) as timer:
             time.sleep(0.5)
 
-        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2, reset_wait=True).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -669,7 +840,7 @@ async def print_foo():
         time.sleep(0.5)
         timer.stop()
 
-        packet = self.recv(2).split("\n")[0] # ignore telemetry packet
+        packet = self.recv(2, reset_wait=True).split("\n")[0] # ignore telemetry packet
         name_value, type_ = packet.split('|')
         name, value = name_value.split(':')
 
@@ -688,6 +859,68 @@ async def print_foo():
                 self.recv(2),
                 telemetry=telemetry_metrics(metrics=2, bytes_sent=len(expected))
         )
+
+    def test_flush(self):
+        self.statsd.increment('page.views')
+        self.assertIsNone(self.recv(no_wait=True))
+        self.statsd.flush()
+        self.assert_equal_telemetry('page.views:1|c', self.recv(2))
+
+    def test_flush_interval(self):
+        dogstatsd = DogStatsd(flush_interval=1, telemetry_min_flush_interval=0)
+        fake_socket = FakeSocket()
+        dogstatsd.socket = fake_socket
+
+        dogstatsd.increment('page.views')
+        self.assertIsNone(fake_socket.recv(no_wait=True))
+
+        time.sleep(0.3)
+        self.assertIsNone(fake_socket.recv(no_wait=True))
+
+        time.sleep(1)
+        self.assert_equal_telemetry(
+            'page.views:1|c',
+            fake_socket.recv(2, no_wait=True)
+        )
+
+    def test_disable_buffering(self):
+        dogstatsd = DogStatsd(disable_buffering=True, telemetry_min_flush_interval=0)
+        fake_socket = FakeSocket()
+        dogstatsd.socket = fake_socket
+
+        dogstatsd.increment('page.views')
+        self.assert_equal_telemetry(
+            'page.views:1|c',
+            fake_socket.recv(2, no_wait=True)
+        )
+
+    def test_flush_disable(self):
+        dogstatsd = DogStatsd(
+            flush_interval=0,
+            telemetry_min_flush_interval=0
+        )
+        fake_socket = FakeSocket()
+        dogstatsd.socket = fake_socket
+
+        dogstatsd.increment('page.views')
+        self.assertIsNone(fake_socket.recv(no_wait=True))
+
+        time.sleep(DEFAULT_FLUSH_INTERVAL)
+        self.assertIsNone(fake_socket.recv(no_wait=True))
+
+        time.sleep(0.3)
+        self.assertIsNone(fake_socket.recv(no_wait=True))
+
+    @patch("warnings.warn")
+    def test_manual_buffer_ops_deprecation(self, mock_warn):
+        self.assertFalse(mock_warn.called)
+
+        self.statsd.open_buffer()
+        self.assertTrue(mock_warn.called)
+        self.assertEqual(mock_warn.call_count, 1)
+
+        self.statsd.close_buffer()
+        self.assertEqual(mock_warn.call_count, 2)
 
     def test_batching_sequential(self):
         self.statsd.open_buffer()
@@ -722,6 +955,10 @@ async def print_foo():
         num_threads = 4
         threads = []
 
+        dogstatsd = DogStatsd(telemetry_min_flush_interval=0)
+        fake_socket = FakeSocket()
+        dogstatsd.socket = fake_socket
+
         def batch_metrics(index, dsd):
             time.sleep(0.3 * index)
 
@@ -737,84 +974,67 @@ async def print_foo():
             dsd.close_buffer()
 
         for idx in range(num_threads):
-            threads.append(Thread(target=batch_metrics, args=(idx, self.statsd)))
+            thread = Thread(
+                name="{}_sender_thread_{}".format(self.__class__.__name__, idx),
+                target=batch_metrics,
+                args=(idx, dogstatsd)
+            )
+            thread.daemon = True
+
+            threads.append(thread)
 
         for thread in threads:
             thread.start()
 
+        time.sleep(5)
+
         for thread in threads:
             if thread.is_alive():
-                thread.join()
+                thread.join(0.1)
 
-        # This is a bit of a tricky thing to test for - initially only our data packet is
-        # sent but then telemetry is flushed/reset and the subsequent metric xmit includes
-        # the telemetry data for the previous packet.
-        expected_xfer_metrics = [(33, 1)]
-        for i in range(num_threads - 1):
-            expected_xfer_metrics.append(
-                (33 + len(telemetry_metrics(
-                    metrics=2, bytes_sent=expected_xfer_metrics[i][0], packets_sent=expected_xfer_metrics[i][1]
-                )), 2))
+        previous_telemetry_packet_size = 0
+        thread_idx = 0
 
-        for idx in range(num_threads):
-            expected_message = "page.%d.views:123|g\ntimer.%d:123|ms" % (idx, idx)
-            bytes_sent, packets_sent = expected_xfer_metrics[idx]
+        while thread_idx < num_threads:
+            first_message = "page.{}.views:123|g".format(thread_idx)
+            first_message_len = len(first_message)
+            second_message = "timer.{}:123|ms".format(thread_idx)
+            second_message_len = len(second_message)
 
-            self.assert_equal_telemetry(
-                expected_message,
-                self.recv(2),
-                telemetry=telemetry_metrics(
-                    metrics=2,
+            received_payload = fake_socket.recv(1)
+
+            # Base assumption is that we got both messages but
+            # we may get metrics split depending on when the flush thread triggers
+            if received_payload == first_message:
+                message = first_message
+                packet_size = first_message_len
+                num_metrics = 1
+            elif received_payload == second_message:
+                message = second_message
+                packet_size = second_message_len
+                num_metrics = 1
+                thread_idx += 1
+            else:
+                message = '\n'.join([first_message, second_message])
+                packet_size = len(message)
+                num_metrics = 2
+                thread_idx += 1
+
+            self.assertEqual(received_payload, message)
+
+            packet_sent = 2
+            if previous_telemetry_packet_size == 0:
+                packet_sent = 1
+
+            bytes_sent = previous_telemetry_packet_size + packet_size
+            telemetry = telemetry_metrics(
+                    metrics=num_metrics,
                     bytes_sent=bytes_sent,
-                    packets_sent=packets_sent,
-                )
+                    packets_sent=packet_sent,
             )
+            self.assertEqual(telemetry, fake_socket.recv(1))
 
-    def test_close_buffer_without_open(self):
-        dogstatsd = DogStatsd()
-        with self.assertRaises(BufferError):
-            dogstatsd.close_buffer()
-
-    def test_threaded_close_buffer_without_open(self):
-        def batch_metrics(dsd):
-            time.sleep(0.3)
-            dsd.open_buffer()
-
-            dsd.gauge('page.views', 123)
-            dsd.timing('timer', 123)
-
-            time.sleep(0.5)
-            dsd.close_buffer()
-
-        def close_async_buffer(self, dsd):
-            # Ensures that buffer is defined
-            dsd.open_buffer()
-            dsd.close_buffer()
-
-            time.sleep(0.5)
-            with self.assertRaises(RuntimeError):
-                dsd.close_buffer()
-
-        thread1 = Thread(target=batch_metrics, args=(self.statsd,))
-        thread2 = Thread(target=close_async_buffer, args=(self, self.statsd,))
-
-        for thread in [thread1, thread2]:
-            thread.start()
-
-        for thread in [thread1, thread2]:
-            if thread.is_alive():
-                thread.join()
-
-        expected_message = "page.views:123|g\ntimer:123|ms"
-        self.assert_equal_telemetry(
-            expected_message,
-            self.recv(2),
-            telemetry=telemetry_metrics(
-                metrics=2,
-                bytes_sent=29,
-                packets_sent=1,
-            )
-        )
+            previous_telemetry_packet_size = len(telemetry)
 
     def test_telemetry(self):
         self.statsd.metrics_count = 1
@@ -848,7 +1068,7 @@ async def print_foo():
         fake_socket = FakeSocket()
         dogstatsd.socket = fake_socket
 
-        # set the last flush time in the future to be sure we won't flush
+        # Set the last flush time in the future to be sure we won't flush
         dogstatsd._last_flush_time = time.time() + dogstatsd._telemetry_flush_interval
         dogstatsd.gauge('gauge', 123.4)
 
@@ -856,10 +1076,18 @@ async def print_foo():
         self.assertEqual(metric, fake_socket.recv())
 
         time1 = time.time()
-        # setting the last flush time in the past to trigger a telemetry flush
+        # Setting the last flush time in the past to trigger a telemetry flush
         dogstatsd._last_flush_time = time1 - dogstatsd._telemetry_flush_interval -1
         dogstatsd.gauge('gauge', 123.4)
-        self.assert_equal_telemetry(metric, fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=2*len(metric), packets_sent=2))
+        self.assert_equal_telemetry(
+            metric,
+            fake_socket.recv(2, reset_wait=True),
+            telemetry=telemetry_metrics(
+                metrics=2,
+                bytes_sent=2*len(metric),
+                packets_sent=2,
+            ),
+        )
 
         # assert that _last_flush_time has been updated
         self.assertTrue(time1 < dogstatsd._last_flush_time)
@@ -886,8 +1114,16 @@ async def print_foo():
         dogstatsd._last_flush_time = time1 - dogstatsd._telemetry_flush_interval - 1
         dogstatsd.gauge('gauge', 123.4)
 
-        self.assertEqual('gauge:123.4|g', fake_socket.recv())
-        self.assert_equal_telemetry('', fake_telemetry_socket.recv(), telemetry=telemetry_metrics(metrics=2, bytes_sent=13*2, packets_sent=2))
+        self.assertEqual('gauge:123.4|g', fake_socket.recv(reset_wait=True))
+        self.assert_equal_telemetry(
+            '',
+            fake_telemetry_socket.recv(),
+            telemetry=telemetry_metrics(
+                metrics=2,
+                bytes_sent=13*2,
+                packets_sent=2,
+            ),
+        )
 
         # assert that _last_flush_time has been updated
         self.assertTrue(time1 < dogstatsd._last_flush_time)
@@ -919,28 +1155,46 @@ async def print_foo():
             dogstatsd.socket = fake_socket
             dogstatsd.gauge('page.views', 123)
             dogstatsd.timing('timer', 123)
-        metric = "page.views:123|g\ntimer:123|ms"
-        self.assertEqual(metric, fake_socket.recv())
-        self.assertEqual(telemetry_metrics(metrics=2, bytes_sent=len(metric)), fake_socket.recv())
-        # self.assert_equal_telemetry("page.views:123|g\ntimer:123|ms", fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2))
+            dogstatsd.increment('my_counter', 3)
+
+        metric1 = "page.views:123|g"
+        metric2 = "timer:123|ms"
+        metric3 = "my_counter:3|c"
+
+        metrics = '\n'.join([metric1, metric2, metric3])
+        self.assertEqual(metrics, fake_socket.recv(no_wait=True))
+
+        metrics_packet = telemetry_metrics(
+            metrics=3,
+            bytes_sent=len(metrics),
+            packets_sent=1,
+        )
+        self.assertEqual(metrics_packet, fake_socket.recv(no_wait=True))
 
     def test_batched_buffer_autoflush(self):
         fake_socket = FakeSocket()
         bytes_sent = 0
         with DogStatsd(telemetry_min_flush_interval=0) as dogstatsd:
-            single_metric = 'mycounter:1|c'
-            self.assertEqual(dogstatsd._max_payload_size, UDP_OPTIMAL_PAYLOAD_LENGTH)
-            metrics_per_packet = dogstatsd._max_payload_size // (len(single_metric) + 1)
             dogstatsd.socket = fake_socket
+
+            self.assertEqual(dogstatsd._max_payload_size, UDP_OPTIMAL_PAYLOAD_LENGTH)
+
+            single_metric = 'mycounter:1|c'
+            metrics_per_packet = dogstatsd._max_payload_size // (len(single_metric) + 1)
             for _ in range(metrics_per_packet + 1):
                 dogstatsd.increment('mycounter')
             payload = '\n'.join([single_metric for _ in range(metrics_per_packet)])
 
-            telemetry = telemetry_metrics(metrics=metrics_per_packet+1, bytes_sent=len(payload))
+            telemetry = telemetry_metrics(
+                metrics=metrics_per_packet+1,
+                bytes_sent=len(payload),
+            )
             bytes_sent += len(payload) + len(telemetry)
             self.assertEqual(payload, fake_socket.recv())
             self.assertEqual(telemetry, fake_socket.recv())
+
         self.assertEqual(single_metric, fake_socket.recv())
+
         telemetry = telemetry_metrics(metrics=0, packets_sent=2, bytes_sent=len(single_metric) + len(telemetry))
         self.assertEqual(telemetry, fake_socket.recv())
 
@@ -1063,38 +1317,52 @@ async def print_foo():
             # Make call with no tags passed; only the globally configured tags will be used.
             global_tags_str = ','.join([t for t in global_tags])
             dogstatsd.gauge('gt', 123.4)
+            dogstatsd.flush()
 
             # Protect against the no tags case.
             metric = 'gt:123.4|g|#{}'.format(global_tags_str) if global_tags_str else 'gt:123.4|g'
             self.assertEqual(metric, dogstatsd.socket.recv())
-            self.assertEqual(telemetry_metrics(tags=global_tags_str, bytes_sent=len(metric)), dogstatsd.socket.recv())
+            self.assertEqual(
+                telemetry_metrics(
+                    tags=global_tags_str,
+                    bytes_sent=len(metric)
+                ),
+                dogstatsd.socket.recv(),
+            )
             dogstatsd._reset_telemetry()
 
             # Make another call with local tags passed.
             passed_tags = ['env:prod', 'version:def456', 'custom_tag:toad']
             all_tags_str = ','.join([t for t in passed_tags + global_tags])
             dogstatsd.gauge('gt', 123.4, tags=passed_tags)
+            dogstatsd.flush()
 
             metric = 'gt:123.4|g|#{}'.format(all_tags_str)
             self.assertEqual(metric, dogstatsd.socket.recv())
-            self.assertEqual(telemetry_metrics(tags=global_tags_str, bytes_sent=len(metric)), dogstatsd.socket.recv())
+            self.assertEqual(
+                telemetry_metrics(
+                    tags=global_tags_str,
+                    bytes_sent=len(metric),
+                ),
+                dogstatsd.socket.recv(),
+            )
 
     def test_gauge_does_not_send_none(self):
         self.statsd.gauge('metric', None)
-        self.assertIsNone(self.statsd.socket.recv())
+        self.assertIsNone(self.recv())
 
     def test_increment_does_not_send_none(self):
         self.statsd.increment('metric', None)
-        self.assertIsNone(self.statsd.socket.recv())
+        self.assertIsNone(self.recv())
 
     def test_decrement_does_not_send_none(self):
         self.statsd.decrement('metric', None)
-        self.assertIsNone(self.statsd.socket.recv())
+        self.assertIsNone(self.recv())
 
     def test_timing_does_not_send_none(self):
         self.statsd.timing('metric', None)
-        self.assertIsNone(self.statsd.socket.recv())
+        self.assertIsNone(self.recv())
 
     def test_histogram_does_not_send_none(self):
         self.statsd.histogram('metric', None)
-        self.assertIsNone(self.statsd.socket.recv())
+        self.assertIsNone(self.recv())

--- a/tests/util/fake_statsd_server.py
+++ b/tests/util/fake_statsd_server.py
@@ -78,7 +78,6 @@ class FakeServer(object):
                         self.MIN_RECV_BUFFER_SIZE,
                     )
 
-                    recv_buff_size = sock.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
             sock.bind(socket_path)
 
             # We are using ctypes for shmem so we have to use a consistent


### PR DESCRIPTION
### What does this PR do?

On a high-level, this PR:
- Enables buffering-by-default for `statsd` (300ms automatic flush cycle)
- Adds a `statsd.flush()` helper method
- Deprecates `statsd.open_buffer()` and `statsd.close_buffer()`
- Closes https://github.com/DataDog/datadogpy/issues/669

### Description of the Change

This change turns all sync handling of statsd data into buffered handling
with a thread that forces flushes at a specified interval (default:
300ms, configurable via `flush_interval` kwarg). Because we now do this
buffering by default, the functions `open_buffer()` and `close_buffer()`
are effectively low-level operations and have been deprecated.

To help backwards compatibility where a context manager (which flushes
automatically on exit of the context) is not used, we also now have a
`flush()` function that can be used to force the sending of the metrics
to the server and a `disable_buffering` kwarg in the statsd constructor.

### Alternate Designs

### Possible Drawbacks

- Users of `open_buffer`/`close_buffer` will now start seeing deprecation warnings
- In specific cases where:
   - Context manager is not used
   - `statsd.flush()` is not used
   - Short scripts that exit the interpreter quickly after sending may not have the flush thread able to flush the data to the socket in time before the interpreter exits
 - `statsd` tests run a bit slower since we have to ensure that flushing works as expected in most of the test cases

### Verification Process

- Run the unit tests
- Ensure there are no failures
- (optional) Run the performance benchmark and ensure that you see `Received packets:  100.00%` in the final totals
:
```sh-session
BENCHMARK_TRANSPORT="UDP" \
    BENCHMARK_NUM_THREADS="1" \
    BENCHMARK_NUM_RUNS="10"  \
    BENCHMARK_NUM_DATAPOINTS="50000" \
    python3 -m unittest -vvv tests.performance.test_statsd_throughput 
```

### Additional Notes

#### Benchmark Data Summary

- ~20-35% reductions across the board in:
  - Overall benchmark duration
  - Sending latency
  - Benchmark CPU usage
- Increased memory usage by the benchmark of about 5-60kb
- Reduction in multithreaded packet drop by almost 100%

#### Detailed Benchmark Data

[Source data](https://gist.github.com/sgnn7/db10961ce8ac8459839548434a9161c6)

```
Python2 - 1 thread - UDP
Duration: -28%
latency: -28%
CPU: -27%
Mem: +16kb

 Python2 - 1 thread - UDS
 Duration: -26%
Latency: -24%
CPU: -22%
Mem: +60kb

Python3 - 1 thread - UDP
Duration: -32%
Latency: -37%
CPU: -36%
Mem: +7kb

Python3 - 1 thread - UDS
Duration: -30%
Latency: -31%
CPU: -29%
 Mem: +12kb
```

### Release Notes

- `statsd` now uses buffering by default (300ms automatic flush interval)
- `statsd.open_buffer()` and `statsd.close_buffer()` methods are superfluous and have been deprecated. Use via a context manager is highly recommended.
- `statsd.flush()` has been added for manual buffer flushing
- `disable_buffer` has been added as a named argument to `DogStatsd()` to revert to old functionality where data was sent synchronously.
- `flush_interval` has been added as a named argument to `DogStatsd()` to allow configuration of auto-flush interval
- `statsd`-created sockets now have a buffer lower limit of 32kb on posix platforms

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

