### PR TITLE
[statsd] Improve tag normalization speed

### DIFF
--- a/datadog/util/format.py
+++ b/datadog/util/format.py
@@ -30,4 +30,4 @@ def force_to_epoch_seconds(epoch_sec_or_dt):
 
 
 def normalize_tags(tag_list):
-    return [re.sub(TAG_INVALID_CHARS_RE, TAG_INVALID_CHARS_SUBS, tag) for tag in tag_list]
+    return [TAG_INVALID_CHARS_RE.sub(TAG_INVALID_CHARS_SUBS, tag) for tag in tag_list]

--- a/tests/unit/util/test_format.py
+++ b/tests/unit/util/test_format.py
@@ -1,9 +1,12 @@
+# coding: utf8
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+import unittest
+
 import pytest
 
-from datadog.util.format import construct_url
+from datadog.util.format import construct_url, normalize_tags
 
 
 class TestConstructURL:
@@ -30,3 +33,20 @@ class TestConstructURL:
     @pytest.mark.parametrize("host,api_version,path,expected", test_data)
     def test_construct_url(self, host, api_version, path, expected):
         assert construct_url(host, api_version, path) == expected
+
+class TestNormalizeTags:
+    """
+    Test of the format's `normalize_tags` functionality
+    """
+    test_data = [
+        (['this is a tag'], ['this_is_a_tag']),
+        (['abc!@#$%^&*()0987654321{}}{'], ['abc__________0987654321____']),
+        (['abc!@#', '^%$#3456#'], ['abc___', '____3456_']),
+        (['mutliple', 'tags', 'included'], ['mutliple', 'tags', 'included']),
+        ([u'абвгдежзийкл', u'абв' , 'test123'], [u'абвгдежзийкл', u'абв' , 'test123']),
+        ([u'абвгд西😃ежзийкл', u'аб😃西в' , u'a😃😃b'],  [u'абвгд西_ежзийкл', u'аб_西в', u'a__b']),
+    ]
+
+    @pytest.mark.parametrize("original_tags,expected_tags", test_data)
+    def test_normalize_tags(self, original_tags, expected_tags):
+            assert normalize_tags(original_tags) == expected_tags


### PR DESCRIPTION
### What does this PR do?

Speeds up the tag normalization function. By being in the hot path in `statsd`, this improves the
performance of `statsd` significantly (~30% reduction in latency, CPU utilization, and benchmark duration across the board). 

Since this function is used in the [`submit()` API too](https://github.com/DataDog/datadogpy/blob/master/datadog/api/api_client.py#L153), it may offer significant performance improvement there as well.

### Description of the Change

- Old code uses a string for sanitization of tags instead of a compiled regex, causing an excessive CPU overhead. This has now been changed to use the pre-compiled version.
- Adds profiling support to the statsd benchmark
- Adds tests for `normalize_tags` function

Fixes https://github.com/DataDog/datadogpy/issues/671

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

None

### Verification Process

- Run the attached tests with `python3 -m unittest -vvv tests.unit.util.test_format.TestNormalizeTags` and/or `python2 -m unittest -vvv tests.unit.util.test_format.TestNormalizeTags`
- Ensure that tests pass

### Additional Notes

Benchmark results vs main branch:

- Python 3 - single thread - UDS: **-28% in latency/CPU/duration**
- Python 3 - single thread - UDP: **-28% in latency/CPU/duration**
- Python 2 - single thread - UDS: **-33% in latency/CPU/duration**
- Python 2 - single thread - UDP: **-30% in latency/CPU/duration**

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [x] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

