### PR TITLE
[tests] Statsd fake server can now be run as a standalone script

### DIFF
--- a/tests/util/fake_statsd_server.py
+++ b/tests/util/fake_statsd_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the BSD-3-Clause License. This product includes software developed at
 # Datadog (https://www.datadoghq.com/).


### PR DESCRIPTION
### What does this PR do?

Allows the `./tests/util/fake_statsd_server` module to be run directly from the shell

### Description of the Change

There may be times where having a quick fake standalone statsd server is
advantageous (e.g. writing/updating client docs). While this can be
achieved with some python scripts or the interpreter shell, it's much
easier for the user/developer just to invoke the script itself if
possible which is what this change enables.

To use this fake server you just invoke the script:

```
$ # UDS Server (default)
$ ./tests/util/fake_statsd_server.py
Listening via UDS on /tmp/dir/path/FakeServerabcd1234/fake_statsd_server_socket

$ # UDP Server
$ ./tests/util/fake_statsd_server.py udp
Listening via UDP on port 58445
```

Debugging is enabled by default which should print out the received packets to the
console when run.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

- Run `./tests/util/fake_statsd_server.py`
- Use `statsd` module to try to send data to this endpoint
- Ensure that the fake server prints the received packets

### Additional Notes

`is_p3k` use was changed to use stdlib to ensure we didn't need to import helpers from parent modules
which would have required `sys.path` mangling.

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

