### PR TITLE
[statsd] Always terminate packets with newline

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -75,7 +75,7 @@ TELEMETRY_FORMATTING_STR = "\n".join(
         "datadog.dogstatsd.client.packets_sent:%s|c|#%s",
         "datadog.dogstatsd.client.packets_dropped:%s|c|#%s",
     ]
-)
+) + "\n"
 
 
 # pylint: disable=useless-object-inheritance,too-many-instance-attributes
@@ -714,7 +714,7 @@ class DogStatsd(object):
             self._last_flush_time + self._telemetry_flush_interval < time.time()
 
     def _send_to_server(self, packet):
-        self._xmit_packet(packet, False)
+        self._xmit_packet(packet + '\n', False)
         if self._is_telemetry_flush_time():
             telemetry = self._flush_telemetry()
             if self._xmit_packet(telemetry, True):
@@ -787,7 +787,7 @@ class DogStatsd(object):
             self._current_buffer_total_size += len(packet) + 1
 
     def _should_flush(self, length_to_be_added):
-        if self._current_buffer_total_size + length_to_be_added > self._max_payload_size:
+        if self._current_buffer_total_size + length_to_be_added + 1 > self._max_payload_size:
             return True
         return False
 


### PR DESCRIPTION
### What does this PR do?

Adds newline (`\n`) to all packets sent to the DogStatsd endpoint

### Description of the Change

To prevent processing of packets that are incomplete by the time they
reach the server for whatever reason, we now add a newline to end of
all of our packets so that the server can recognize and discard partial
messages/metrics.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

One character additionally sent with each packet (minimal impact on buffered clients)

### Verification Process

- Run the test suite (`python3 -m unittest -vvv tests.unit.dogstatsd.test_statsd.TestDogStatsd`)

Alternatively:
- Start a fake statsd server on a separate terminal (`./tests/util/fake_statsd_server.py UDP`) 
- Send a metric and ensure it has a newline at the end on the server's received packet output:
```sh-session
$ python3
>>> from datadog import initialize,statsd
>>> initialize(statsd_host="localhost", statsd_port=<port_from_server>)
>>> statsd.increment("home.page.hits")
```

### Additional Notes

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

