### PR TITLE
[statsd] Fix dedicated-endpoint telemetry shipping when used with UDP

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -388,7 +388,7 @@ class DogStatsd(object):
                             self.telemetry_socket_path,
                         )
                     else:
-                        self.telemetry_socket = self._get_udp_socket_socket(
+                        self.telemetry_socket = self._get_udp_socket(
                             self.telemetry_host,
                             self.telemetry_port,
                         )

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -9,10 +9,14 @@ Tests for dogstatsd.py
 """
 # Standard libraries
 from collections import deque
+from contextlib import closing
 from threading import Thread
 import errno
 import os
+import shutil
 import socket
+import tempfile
+import threading
 import time
 import unittest
 import warnings
@@ -1188,6 +1192,67 @@ async def print_foo():
         self.assert_equal_telemetry(metric, fake_socket.recv(2), telemetry=telemetry_metrics(metrics=2, bytes_sent=len(metric)))
         # assert that _last_flush_time has been updated
         self.assertTrue(time1 < dogstatsd._last_flush_time)
+
+
+    def test_dedicated_udp_telemetry_dest(self):
+        listener_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        listener_sock.bind(('localhost', 0))
+
+        def wait_for_data():
+            global udp_thread_telemetry_data
+            udp_thread_telemetry_data = listener_sock.recvfrom(UDP_OPTIMAL_PAYLOAD_LENGTH)[0].decode('utf-8')
+
+        with closing(listener_sock):
+            port = listener_sock.getsockname()[1]
+
+            dogstatsd = DogStatsd(
+                host="localhost",
+                port=12345,
+                telemetry_min_flush_interval=0,
+                telemetry_host="localhost",
+                telemetry_port=port,
+            )
+
+            server = threading.Thread(target=wait_for_data)
+            server.start()
+
+            dogstatsd.increment('abc')
+
+            server.join(3)
+
+            expected_telemetry = telemetry_metrics(metrics=1, packets_sent=1, bytes_sent=8)
+            self.assertEqual(udp_thread_telemetry_data, expected_telemetry)
+
+    def test_dedicated_uds_telemetry_dest(self):
+        tempdir = tempfile.mkdtemp()
+        socket_path = os.path.join(tempdir, 'socket.sock')
+
+        listener_sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        listener_sock.bind(socket_path)
+
+        def wait_for_data():
+            global uds_thread_telemetry_data
+            uds_thread_telemetry_data = listener_sock.recvfrom(UDS_OPTIMAL_PAYLOAD_LENGTH)[0].decode('utf-8')
+
+        with closing(listener_sock):
+            dogstatsd = DogStatsd(
+                host="localhost",
+                port=12345,
+                telemetry_min_flush_interval=0,
+                telemetry_socket_path=socket_path,
+            )
+
+            server = threading.Thread(target=wait_for_data)
+            server.start()
+
+            dogstatsd.increment('def')
+
+            server.join(3)
+
+            expected_telemetry = telemetry_metrics(metrics=1, packets_sent=1, bytes_sent=8)
+            self.assertEqual(uds_thread_telemetry_data, expected_telemetry)
+
+        shutil.rmtree(tempdir)
 
     def test_context_manager(self):
         fake_socket = FakeSocket()


### PR DESCRIPTION
### What does this PR do?

Old code had a miswritten function name for telemetry UDP socket
creation when separate endpoints were used for the client vs telemetry.
This change fixes the issue and adds additional tests around dedicated
telemetry socket operations.

Fixes https://github.com/DataDog/datadogpy/issues/689

### Description of the Change

- Fixes telemetry shipping to dedicated UDP endpoint
- Adds logging of unexpected socket errors to stdout
- Adds tests around dedicated telemetry socket creation logic

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process

See linked issue for reproduction steps

### Additional Notes

N/A

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

