### PR TITLE
Add an option to change Datadog site to call API

### DIFF
--- a/datadog/dogshell/__init__.py
+++ b/datadog/dogshell/__init__.py
@@ -71,6 +71,14 @@ def main():
         "-v", "--version", help="Dog API version", action="version", version="%(prog)s {0}".format(__version__)
     )
 
+    parser.add_argument(
+        "--site",
+        help="Datadog site to send data, us (datadoghq.com), eu (datadoghq.eu) or us3 (us3.datadoghq.com), default: us",
+        dest="site",
+        default=os.environ.get("DD_SITE", os.environ.get("DATADOG_HOST")),
+        choices=["datadoghq.com", "us", "datadoghq.eu", "eu", "us3.datadoghq.com", "us3"],
+    )
+
     config = DogshellConfig()
 
     # Set up subparsers for each service
@@ -93,7 +101,8 @@ def main():
     ServiceLevelObjectiveClient.setup_parser(subparsers)
 
     args = parser.parse_args()
-    config.load(args.config, args.api_key, args.app_key)
+
+    config.load(args.config, args.api_key, args.app_key, args.site)
 
     # Initialize datadog.api package
     initialize(**config)

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -43,8 +43,16 @@ def report_warnings(res):
 
 
 class DogshellConfig(IterableUserDict):
-    def load(self, config_file, api_key, app_key):
+    def load(self, config_file, api_key, app_key, site):
         config = configparser.ConfigParser()
+        
+        if site is not None:
+            if site in ("us" or "datadoghq.com"):
+                self["api_host"] = "https://datadoghq.com"
+            elif site in ("datadoghq.eu", "eu"):
+                self["api_host"] = "https://datadoghq.eu"
+            elif site in ("us3.datadoghq.com", "us3"):
+                self["api_host"] = "https://us3.datadoghq.com"
 
         if api_key is not None and app_key is not None:
             self["api_key"] = api_key


### PR DESCRIPTION
### What does this PR do?

Issue to fix
https://github.com/DataDog/datadogpy/issues/652

### Description of the Change

Adding `--site` option to change the site to call the API

### Verification Process

Tested with my sandbox account in EU and US3 site.