### PR TITLE
[statsd] Disable statsd buffering by default

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -26,7 +26,6 @@ from datadog.dogstatsd.context import (
 )
 from datadog.dogstatsd.route import get_default_route
 from datadog.util.compat import is_p3k, text
-from datadog.util.deprecation import deprecated
 from datadog.util.format import normalize_tags
 from datadog.version import __version__
 
@@ -89,7 +88,7 @@ class DogStatsd(object):
         port=DEFAULT_PORT,                      # type: int
         max_buffer_size=None,                   # type: None
         flush_interval=DEFAULT_FLUSH_INTERVAL,  # type: float
-        disable_buffering=False,                # type: bool
+        disable_buffering=True,                 # type: bool
         namespace=None,                         # type: Optional[Text]
         constant_tags=None,                     # type: Optional[List[str]]
         use_ms=False,                           # type: bool
@@ -436,10 +435,8 @@ class DogStatsd(object):
 
         return sock
 
-    @deprecated("Statsd module now uses buffering by default.")
     def open_buffer(self, max_buffer_size=None):
         """
-        WARNING: Deprecated method - all operations are now buffered by default.
         Open a buffer to send a batch of metrics.
 
         To take advantage of automatic flushing, you should use the context manager instead
@@ -453,16 +450,16 @@ class DogStatsd(object):
 
         self._manual_buffer_lock.acquire()
 
+        # XXX Remove if `disable_buffering` default is changed to False
+        self._send = self._send_to_buffer
+
         if max_buffer_size is not None:
             log.warning("The parameter max_buffer_size is now deprecated and is not used anymore")
 
         self._reset_buffer()
 
-    @deprecated("Statsd module now uses buffering by default.")
     def close_buffer(self):
         """
-        WARNING: Deprecated method - all operations are now buffered by default.
-
         Flush the buffer and switch back to single metric packets.
 
         Note: This method must be called after a matching open_buffer()
@@ -471,6 +468,9 @@ class DogStatsd(object):
         try:
             self.flush()
         finally:
+            # XXX Remove if `disable_buffering` default is changed to False
+            self._send = self._send_to_server
+
             self._manual_buffer_lock.release()
 
     def _reset_buffer(self):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -351,11 +351,11 @@ class DogStatsd(object):
         return bool(self.telemetry_socket_path or self.telemetry_host)
 
     def __enter__(self):
-        self._reset_buffer()
+        self.open_buffer()
         return self
 
     def __exit__(self, exc_type, value, traceback):
-        self.flush()
+        self.close_buffer()
 
     @staticmethod
     def resolve_host(host, use_default_route):

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -159,28 +159,8 @@ an instance of :class:`datadog.threadstats.ThreadStats`::
 
 datadog.dogstatsd
 =================
-:mod:`datadog.dogstatsd` is a Python client for DogStatsd that automatically
-buffers submitted metrics and submits them to the server asynchronously or at
-maximum sizes for a packet that would prevent fragmentation.
-
-.. note::
-
-    To ensure that all the metrics are sent to the server, either use the
-    context-managed instance of :class:`~datadog.dogstatsd.base.DogStatsd`
-    or when you are finished with the client perform a manual :code:`flush()`.
-    Otherwise the buffered data may get de-allocated before being sent.
-
-
-.. warning::
-
-    :class:`~datadog.dogstatsd.base.DogStatsd` instances are not :code:`fork()`-safe
-    because the automatic buffer flushing occurs in a thread only on the
-    process that created the :class:`~datadog.dogstatsd.base.DogStatsd`
-    instance. Because of this, instances of those clients must not be copied
-    from a parent process to a child process. Instead, the parent process and
-    each child process must create their own instances of the client or the
-    buffering must be globally disabled by using the :code:`disable_buffering`
-    initialization flag.
+:mod:`datadog.dogstatsd` is a Python client for DogStatsd that submits metrics
+to the Agent.
 
 
 Usage
@@ -192,7 +172,6 @@ Usage
     
     client = DogStatsd()
     client.increment("home.page.hits")
-    client.flush()
 
 
 .. autoclass::  datadog.dogstatsd.base.DogStatsd
@@ -208,15 +187,6 @@ Usage
     >>> from datadog import initialize, statsd
     >>> initialize(statsd_host="localhost", statsd_port=8125)
     >>> statsd.increment("home.page.hits")
-
-.. warning::
-
-    Global :class:`~datadog.dogstatsd.base.DogStatsd` is not :code:`fork()`-safe
-    because the automatic buffer flushing occurs in a thread only on the
-    process that created the :class:`~datadog.dogstatsd.base.DogStatsd`
-    instance. Because of this, the parent process and each child process must
-    create their own instances of the client or the buffering must be globally
-    disabled by using the :code:`disable_buffering` initialization flag.
 
 
 Get in Touch

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -1262,7 +1262,7 @@ async def print_foo():
 
     def test_context_manager(self):
         fake_socket = FakeSocket()
-        with DogStatsd(disable_buffering=False, telemetry_min_flush_interval=0) as dogstatsd:
+        with DogStatsd(telemetry_min_flush_interval=0) as dogstatsd:
             dogstatsd.socket = fake_socket
             dogstatsd.gauge('page.views', 123)
             dogstatsd.timing('timer', 123)


### PR DESCRIPTION
### What does this PR do?

Due to impact on users of other clients where buffering was enabled by
default, especially in environments and frameworks where `fork()` is
used we will for the time being disable buffering by default until a
decision is made on the path forward. Buffering can still be turned on
with `disable_buffering = False` flag it's just that for now it is
defaulted to `True`.

### Description of the Change

- Use of `DogStatsd` via `statsd` module-level object defaults to synchronous (un-buffered) metric sending.
- Use of `DogStatsd` via the default constructor defaults to synchronous (un-buffered) metric sending.

### Alternate Designs

In discussion (TBD). We may revert this and use automated ways to detect environments
that are incompatible to thread-based buffering.

### Possible Drawbacks

Lower performance in high-throughput environments.

### Verification Process

Unit tests cover most of this:

```sh-session
python$(python --version 2>&1 | cut -c8-8)" -m unittest -vvv tests.unit.dogstatsd.test_statsd
```

### Additional Notes

This change may be reversed in the future but for now, the risk is too high
for user disruption.

### Release Notes

Disable statsd buffering by default. Buffering can be enabled with `disable_buffering = False` flag.

_Note: Since this is just a partial revert of https://github.com/DataDog/datadogpy/pull/670, removal of both release notes can be done as it's a net-0 change_

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

