### PR TITLE
[tests] Fix `fake_statsd_server.py` received metric counting

### DIFF
--- a/tests/util/fake_statsd_server.py
+++ b/tests/util/fake_statsd_server.py
@@ -125,13 +125,18 @@ class FakeServer(object):
                     raise ste
 
                 payload_counter += 1
-                metric_counter += len(payload.split(b"\n"))
+
+                offset = 0
+                if payload[-1] == b"\n":
+                    offset = -1
+
+                metric_counter += len(payload[:offset].split(b"\n"))
 
                 if self.debug:
                     print(
                         "Got '{}' (pkts: {}, payloads: {}, metrics: {})".format(
-                            payload,
-                            len(payload.split(b"\n")),
+                            payload.decode('utf-8'),
+                            len(payload[:offset].split(b"\n")),
                             payload_counter,
                             metric_counter,
                         )


### PR DESCRIPTION
### What does this PR do?

Fixes counting of received metrics in manual test modules

### Motivation

Since the introduction of newlines to the end of all sent statsd
messages, our fake_statsd_server and statsd_throughput test modules
have been miscounting the metrics received. While this has no impact on
the users, we need the accurate numbers in manually-run tests.

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process

- `P=3 BENCHMARK_TRANSPORT="UDP" BENCHMARK_NUM_THREADS=10 BENCHMARK_NUM_RUNS=5 BENCHMARK_NUM_DATAPOINTS=5 "python${P}" -m unittest -vvv tests.performance.test_statsd_throughput`
- Ensure that metrics received percentage is close to 100% rather than 200%

### Additional Notes

N/A

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

