### PR TITLE
[codeowners] Add `agent-core` as co-owner of relevant paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,11 @@
 
 # Dogstatd
 /datadog/dogstatsd/              @DataDog/integrations-tools-and-libraries @DataDog/agent-core
+/datadog/util/                   @DataDog/integrations-tools-and-libraries @DataDog/agent-core
+/tests/integration/dogstatsd/    @DataDog/integrations-tools-and-libraries @DataDog/agent-core
 /tests/unit/dogstatsd/           @DataDog/integrations-tools-and-libraries @DataDog/agent-core
+/tests/unit/util/                @DataDog/integrations-tools-and-libraries @DataDog/agent-core
+/tests/util/                     @DataDog/integrations-tools-and-libraries @DataDog/agent-core
 /tests/performance/test_statsd_* @DataDog/integrations-tools-and-libraries @DataDog/agent-core
 
 # Threadstats


### PR DESCRIPTION
### What does this PR do?

Some utility and test paths were missing agent-core team as co-owners,
leading to unnecessary pings to the tools-and-libraries team. This
change adds agent-core as a co-owner team to paths that are frequently
worked on so that either team can provide approvals for PRs.

### Description of the Change

Additional paths added to the agent-core co-owners section

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

N/A

### Verification Process

N/A

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

