### PR TITLE
[statsd] Add ability to toggle `statsd.disable_buffering` state during runtime

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -37,6 +37,7 @@ def initialize(
     api_host=None,  # type: Optional[str]
     statsd_host=None,  # type: Optional[str]
     statsd_port=None,  # type: Optional[int]
+    statsd_disable_buffering=True,  # type: bool
     statsd_use_default_route=False,  # type: bool
     statsd_socket_path=None,  # type: Optional[str]
     statsd_namespace=None,  # type: Optional[str]
@@ -70,6 +71,10 @@ def initialize(
 
     :param statsd_port: Port of DogStatsd server or statsd daemon
     :type statsd_port: port
+
+    :param statsd_disable_buffering: Enable/disable statsd client buffering support
+                                     (default: True).
+    :type statsd_disable_buffering: boolean
 
     :param statsd_use_default_route: Dynamically set the statsd host to the default route
                                      (Useful when running the client in a container)
@@ -121,6 +126,8 @@ def initialize(
         statsd.namespace = text(statsd_namespace)
     if statsd_constant_tags:
         statsd.constant_tags += statsd_constant_tags
+
+    statsd.disable_buffering = statsd_disable_buffering
 
     api._return_raw_response = return_raw_response
 


### PR DESCRIPTION
### What does this PR do?

- Adds ability to set `statsd_instance.disable_buffering` flag after initialization
- Adds said flag as a argument to `initialize()` to be usable for the module-level `statsd` instance

### Description of the Change

While not likely to be useful currently, if/when we enable buffering on the `DogStatsd` clients
by default again we will want to have this feature already in place since the module level `statsd`
may not behave as expected in `fork()`-based environments. Because `datadog.initialize()` cannot
recreate the instance of the module-level `statsd`, we need a runtime setting for `disable_buffering`
instead of recreating the instance, making the implementation somewhat constrained in how it is
done.

As a side-effect, this change allow use of the module-level `statsd` instance with buffering enabled
which was previously not possible.

### Alternate Designs

None that would make sense with the limitations provided.

### Possible Drawbacks

Assumptions were made in the logic that `datadog.initialize()` would be only called once for
the application. While there are protections around concurrent invocations, there could be edge
cases not covered if multiple concurrent calls to `initialize are made to change this flag or if the
data is being added to the buffer while the buffering is being disabled.

### Verification Process

Tests covers the underlying functionality of this feature but it can be tested with:
- Using either:
  - `datadog.initialize()` and setting `statsd_disable_buffering` flag
  - Instantiating `DogStatsd`
- Verifying that data flows through

### Additional Notes

This feature will be gradually documented as it is expected to be
useful only in very niche high-throughput cases.

### Release Notes

- [statsd] Add ability to toggle `statsd.disable_buffering` state during runtime
- [datadog] Add ability to use `statsd_disable_buffering` as an argument to `datadog.initialize()`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

