### PR TITLE
[tests] Remove Python 3.5 from unit-tested versions

### DIFF
--- a/.azure-pipelines/unit_tests.yml
+++ b/.azure-pipelines/unit_tests.yml
@@ -18,9 +18,6 @@ jobs:
       Py27:
         PYTHON_VERSION: "2.7"
         TOXENV: "py27"
-      Py35:
-        PYTHON_VERSION: "3.5"
-        TOXENV: "py35"
       Py36:
         PYTHON_VERSION: "3.6"
         TOXENV: "py36"


### PR DESCRIPTION
### What does this PR do?

Remove Python 3.5 from the unit test matrix

### Description of the Change

Azure builders do not have this Python version anymore so they cannot
run against it. Given that 3.5 is EOL we will remove it from the test
matrix.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

Python 3.5 support may get stale over time

### Verification Process

CI/CD passes

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

