### PR TITLE
[threadstats] Ensure `ThreadStats` and `DogStatsd` `event()` signatures match

### DIFF
--- a/datadog/threadstats/base.py
+++ b/datadog/threadstats/base.py
@@ -174,7 +174,7 @@ class ThreadStats(object):
     def event(
         self,
         title,
-        text,
+        message,
         alert_type=None,
         aggregation_key=None,
         source_type_name=None,
@@ -184,7 +184,7 @@ class ThreadStats(object):
         hostname=None,
     ):
         """
-        Send an event. Attributes are the same as the Event API. (http://docs.datadoghq.com/api/)
+        Send an event. See http://docs.datadoghq.com/api/ for more info.
 
         >>> stats.event("Man down!", "This server needs assistance.")
         >>> stats.event("The web server restarted", \
@@ -201,7 +201,7 @@ class ThreadStats(object):
 
             self._event_aggregator.add_event(
                 title=title,
-                text=text,
+                text=message,
                 alert_type=alert_type,
                 aggregation_key=aggregation_key,
                 source_type_name=source_type_name,

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -441,6 +441,22 @@ class TestDogStatsd(unittest.TestCase):
 
         self.statsd._reset_telemetry()
 
+    # Positional arg names should match threadstats
+    def test_event_matching_signature(self):
+        self.statsd.event(title="foo", message="bar1")
+        event = u'_e{3,4}:foo|bar1\n'
+        self.assert_equal_telemetry(
+            event,
+            self.recv(2),
+            telemetry=telemetry_metrics(
+                metrics=0,
+                events=1,
+                bytes_sent=len(event),
+            ),
+        )
+
+        self.statsd._reset_telemetry()
+
     def test_event_constant_tags(self):
         self.statsd.constant_tags = ['bar:baz', 'foo']
         self.statsd.event('Title', u'L1\nL2', priority='low', date_happened=1375296969)

--- a/tests/unit/threadstats/test_threadstats.py
+++ b/tests/unit/threadstats/test_threadstats.py
@@ -150,7 +150,8 @@ class TestUnitThreadStats(unittest.TestCase):
         event1_text = "Event 1 text"
         event2_text = "Event 2 text"
         dog.event(event1_title, event1_text)
-        dog.event(event2_title, event2_text)
+        # Positional arg names should match statsd
+        dog.event(title=event2_title, message=event2_text)
 
         # Flush and test
         dog.flush()


### PR DESCRIPTION
### What does this PR do?

Changes `text` positional arg in threadstats to `message`

Closes: #707

### Description of the Change

Since 0.43, `statsd` has renamed a positional argument `text` to
`message`. When a user is invoking the API of this method with `kwargs` for named
parameters it no longer can be used to swap seamlessly between
`ThreadStats` and `DogStatsd`. This change ensures that both positional args
have the same names.

For more info: https://github.com/DataDog/datadogpy/issues/707#issuecomment-1028148626

### Alternate Designs

### Possible Drawbacks

Potentially a breaking change for users of ThreadStats if they use `event()` with
named positional args. Release notes are updated to make that clear.

### Verification Process

CI/CD tests

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

- `ThreadStats().event()` and `DogStatsd.event()` now both use `message` instead of `text` as the name of the second positional argument

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

