### PR TITLE
Update package metadata

### DIFF
--- a/.azure-pipelines/unit_tests.yml
+++ b/.azure-pipelines/unit_tests.yml
@@ -18,9 +18,6 @@ jobs:
       Py27:
         PYTHON_VERSION: "2.7"
         TOXENV: "py27"
-      Py36:
-        PYTHON_VERSION: "3.6"
-        TOXENV: "py36"
       Py37:
         PYTHON_VERSION: "3.7"
         TOXENV: "py37"

--- a/.azure-pipelines/unit_tests.yml
+++ b/.azure-pipelines/unit_tests.yml
@@ -24,12 +24,6 @@ jobs:
       Py38:
         PYTHON_VERSION: "3.8"
         TOXENV: "py38"
-      Pypy2:
-        PYTHON_VERSION: "pypy2"
-        TOXENV: "pypy2"
-      Pypy3:
-        PYTHON_VERSION: "pypy3"
-        TOXENV: "pypy3"
       Format:
         PYTHON_VERSION: "3.8"
         TOXENV: "black"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: test
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['pypy-2.7', 'pypy-3.8']
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+        # python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.8']
+
+    env:
+      TOXENV: ${{ matrix.python-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install tox
+      run: pip install tox
+
+    - name: Run unit tests
+      run: tox
+
+    - name: Run integration tests on cassettes
+      run: tox -e integration -- --vcr-record=none
+
+    - name: Run admin integration tests on cassettes
+      run: tox -e integration-admin -- --vcr-record=none

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include LICENSE
-include datadog/py.typed
-graft tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["hatchling>=0.15.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "datadog"
+description = "The Datadog Python library"
+readme = "README.md"
+license = "BSD-3-Clause"
+requires-python = ">=2.7,!=3.4,!=3.5,!=3.6"
+keywords = [
+    "datadog",
+]
+authors = [
+    { name = "Datadog, Inc.", email = "dev@datadoghq.com" },
+]
+classifiers = [
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    'Programming Language :: Python :: Implementation :: CPython',
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = [
+    "requests>=2.6.0",
+    "typing; python_version < '3.5'",
+    "configparser<5; python_version < '3.0'",
+]
+dynamic = ["version"]
+
+[project.urls]
+"Bug Tracker" = "https://github.com/DataDog/datadogpy/issues"
+Documentation = "https://datadogpy.readthedocs.io/en/latest/"
+"Source Code" = "https://github.com/DataDog/datadogpy"
+
+[project.scripts]
+dog = "datadog.dogshell:main"
+dogwrap = "datadog.dogshell.wrap:main"
+dogshell = "datadog.dogshell:main"
+dogshellwrap = "datadog.dogshell.wrap:main"
+
+[tool.hatch.version]
+path = "datadog/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/datadog",
+    "/tests",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "datadog"
 description = "The Datadog Python library"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=2.7,!=3.4,!=3.5,!=3.6"
+requires-python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 keywords = [
     "datadog",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.7.0
 skip_missing_interpreters = true
 envlist =
-    py{27,37,38,py2,py3}
+    py{27,37,38,py-2.7,py-3.8}
     flake8
     integration
     mypy

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.7.0
 skip_missing_interpreters = true
 envlist =
-    py{27,35,36,37,38,py2,py3}
+    py{27,37,38,py2,py3}
     flake8
     integration
     mypy


### PR DESCRIPTION
### What does this PR do?

This implements [PEP 621](https://www.python.org/dev/peps/pep-0621/), obviating the need for both `setup.py` and `MANIFEST.in`. Support has not landed in `setuptools`, so builds will now use `hatchling`. We also did this for all integrations: https://github.com/DataDog/integrations-core

This also drops support for EOL Python 3.x versions since `hatchling` and other build backends like `setuptools` have already done so. This will not break anything because `pip` only looks for version candidates that satisfy the `requires-python` field. Here are stats for the curious: https://pypistats.org/packages/datadog

Note that the `setup.py` file will be removed when we drop Python 2 since new-style editable installations require versions of `pip` that are Python 3-only. Basically, this is just for the `py27` test `tox` environment.