### PR TITLE
[statsd] Restore buffering state when exiting context manager

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -519,7 +519,8 @@ class DogStatsd(object):
             self.flush()
         finally:
             # XXX Remove if `disable_buffering` default is changed to False
-            self._send = self._send_to_server
+            if self._disable_buffering:
+                self._send = self._send_to_server
 
             self._buffering_toggle_lock.release()
 


### PR DESCRIPTION
### What does this PR do?

When exiting the context or when manual close_buffer is invoked, we
should restore the buffering state that existed before the
context/manual buffer changes were applied.

Fixes: https://github.com/DataDog/datadogpy/issues/714

### Description of the Change

Buffering state is restored when buffer is manually closed or the managed context is left.

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process

Unit tests cover the functionality but manual test can be done by following directions in the [upstream issue](https://github.com/DataDog/datadogpy/issues/714)

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

