### PR TITLE
[statsd] Raise ValueError instead of Exception when payload is too large

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -977,7 +977,7 @@ class DogStatsd(object):
             string = "%s|c:%s" % (string, self._container_id)
 
         if len(string) > 8 * 1024:
-            raise Exception(
+            raise ValueError(
                 u'Event "{0}" payload is too big (>=8KB). Event discarded'.format(
                     title
                 )

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -488,6 +488,23 @@ class TestDogStatsd(unittest.TestCase):
             ),
         )
 
+    def test_event_payload_error(self):
+        def func(fail: bool):
+            # define an event payload that is > 8 * 1024
+            message = ["l" for i in range(8 * 1024)]
+            message = "".join(message)
+            payload = {"title": "title", "message": message}
+
+            self.statsd.event(**payload)
+
+        # check that the method fails when the payload is too large
+        with pytest.raises(TypeError):
+            func()
+
+        # check that the method does not fail with a small payload
+        self.statsd.event("title", "message")
+
+
     def test_service_check(self):
         now = int(time.time())
         self.statsd.service_check(

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -489,7 +489,7 @@ class TestDogStatsd(unittest.TestCase):
         )
 
     def test_event_payload_error(self):
-        def func(fail: bool):
+        def func():
             # define an event payload that is > 8 * 1024
             message = ["l" for i in range(8 * 1024)]
             message = "".join(message)

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -489,7 +489,7 @@ class TestDogStatsd(unittest.TestCase):
         )
 
     def test_event_payload_error(self):
-        def func(self):
+        def func():
             # define an event payload that is > 8 * 1024
             message = ["l" for i in range(8 * 1024)]
             message = "".join(message)
@@ -498,8 +498,8 @@ class TestDogStatsd(unittest.TestCase):
             self.statsd.event(**payload)
 
         # check that the method fails when the payload is too large
-        with pytest.raises(TypeError):
-            func(self)
+        with pytest.raises(ValueError):
+            func()
 
         # check that the method does not fail with a small payload
         self.statsd.event("title", "message")

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -489,7 +489,7 @@ class TestDogStatsd(unittest.TestCase):
         )
 
     def test_event_payload_error(self):
-        def func():
+        def func(self):
             # define an event payload that is > 8 * 1024
             message = ["l" for i in range(8 * 1024)]
             message = "".join(message)
@@ -499,7 +499,7 @@ class TestDogStatsd(unittest.TestCase):
 
         # check that the method fails when the payload is too large
         with pytest.raises(TypeError):
-            func()
+            func(self)
 
         # check that the method does not fail with a small payload
         self.statsd.event("title", "message")


### PR DESCRIPTION
### What does this PR do?
As noted in #725, statsd.event() raises a general Exception in the event that an event payload is too long. This can lead to error swallowing. This PR changes this error block to raise a ValueError instead.
<!-- 

What inspired you to submit this pull request?
Issue #725

-->

### Description of the Change
The statsd.event() method throws a different Exception (ValueError) in the event that a payload is too large. A test was added to test_statsd.py in order to ensure that the proper error is raised when appropriate.
<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
Any exception could theoretically be raised, but ValueError seemed the most appropriate according to [Python's guidelines](https://docs.python.org/3/library/exceptions.html#TypeError). Alternatively, users of the datadog library could just catch the Exception but that is poor practice.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
Users of the library who currently have code in place to catch a general Exception may have to change their libraries to catch the more specific ValueError.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
A new test was added to test_statsd.py in order to ensure the viability of the error change. It tests that a payload that is too large raises the ValueError, and that a payload of allowable length does not raise a ValueError. This can be double checked by running the following from the datadogpy directory: `pytest tests/unit/dogstatsd/test_statsd.py -k test_event_payload_error`.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes
Thank you for being open source!
<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

