### PR TITLE
Tox error workaround with alternate pypy version names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['pypy-2.7', 'pypy-3.8']
+        python-version: ['pypy2.7', 'pypy3.8']
         # os: [ubuntu-latest, windows-latest, macos-latest]
         # python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.8']
 
@@ -28,10 +28,10 @@ jobs:
       TOXENV: ${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "datadog"
 description = "The Datadog Python library"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 keywords = [
     "datadog",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.7.0
 skip_missing_interpreters = true
 envlist =
-    py{27,37,38,py-2.7,py-3.8}
+    py{27,37,38,py2.7,py3.8}
     flake8
     integration
     mypy


### PR DESCRIPTION
Tox failing due to a bug with factor names, considers "pypy" and "3.8" conflicting. This changes the actions workflow to use pypy3.8 and pypy2.7 as the names instead, and also updates the github actions dependency versions.