### PR TITLE
Make it possible to post related events

### DIFF
--- a/datadog/dogshell/event.py
+++ b/datadog/dogshell/event.py
@@ -81,7 +81,7 @@ class EventClient(object):
         post_parser.add_argument("--handle", help="user to post as. if unset, submits " "as the generic API user.")
         post_parser.add_argument("--priority", help='"normal" or "low". defaults to "normal"', default="normal")
         post_parser.add_argument(
-            "--related_event_id", help="event to post as a child of." " if unset, posts a top-level event"
+            "--related_event_id", help="event to post as a child of." " if unset, posts a top-level event", type=int
         )
         post_parser.add_argument("--tags", help="comma separated list of tags")
         post_parser.add_argument("--host", help="related host (default to the local host name)", default="")


### PR DESCRIPTION
The current version of `dogshell` interprets `--related_event_id` as a string, not an integer, which means the backend refuses to work with it.  The fix is simple; to tell argparse that it's an int.

### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Fix #785 by adding typing to related event IDs in argparse.

### Description of the Change

To ensure that the JSON API is sent an integer and not a string, we add `type=int` to the relevant argparse declaration.

### Alternate Designs

You could do it at the call site, or otherwise parse it, but argparse makes this relatively easy.

### Possible Drawbacks

If you were in the habit of posting random garbage to related event ID and expecting it to fail, it will now fail slightly earlier.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

