### PR TITLE
Pin pyyaml for py2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Set constrains for python2.7
+      # Latest PyYaml supported version for python 2.7 is 5.4.1 which requires
+      # cython<3 to build. See: https://github.com/yaml/pyyaml/issues/724
       if: ${{ matrix.python-version == 'pypy2.7' }}
       run: |
         echo "cython<3" > /tmp/constraints.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,6 @@ jobs:
         python-version: ['pypy2.7', '3.7', 'pypy3.8']
         # os: [ubuntu-latest, windows-latest, macos-latest]
         # python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.8']
-
     env:
       TOXENV: ${{ matrix.python-version }}
 
@@ -63,8 +62,11 @@ jobs:
     - name: Install tox
       run: pip install tox
 
-    - name: Install tox
-      run: pip install tox
+    - name: Set constrains for python2.7
+      if: ${{ matrix.python-version == 'pypy2.7' }}
+      run: |
+        echo "cython<3" > constaints.txt
+        echo "PIP_CONSTRAINT=constraints.txt" >> $GITHUB_ENV
 
     - name: Run unit tests
       run: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,14 +59,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install tox
-      run: pip install tox
-
     - name: Set constrains for python2.7
       if: ${{ matrix.python-version == 'pypy2.7' }}
       run: |
-        echo "cython<3" > constaints.txt
-        echo "PIP_CONSTRAINT=constraints.txt" >> $GITHUB_ENV
+        echo "cython<3" > /tmp/constraints.txt
+        echo "PIP_CONSTRAINT=/tmp/constraints.txt" >> $GITHUB_ENV
+
+    - name: Install tox
+      run: pip install tox
 
     - name: Run unit tests
       run: tox


### PR DESCRIPTION
PyYaml 5.4.1 fails to build on py2.7 using cython >= 3. Unfortunately PyYaml 5.3.1 causes test breakage so we are unable to pin to that version.

See: https://github.com/yaml/pyyaml/issues/724

Since this is an outdated version of python and test specific transitive dependency, I think it should be okay for us to use constraints to build PyYaml using cython<3 without overhauling the tox configuration.