### PR TITLE
Add setters to configure the global instance

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -590,6 +590,18 @@ class DogStatsd(object):
 
             return self.socket
 
+    def set_socket_timeout(self, timeout):
+        """
+        Set timeout for socket operations, in seconds.
+
+        If set to zero, never wait if operation can not be completed immediately. If set to None, wait forever.
+        This option does not affect hostname resolution when using UDP.
+        """
+        with self._socket_lock:
+            self.socket_timeout = timeout
+            if self.socket:
+                self.socket.settimeout(timeout)
+
     @classmethod
     def _ensure_min_send_buffer_size(cls, sock, min_size=MIN_SEND_BUFFER_SIZE):
         # Increase the receiving buffer size where needed (e.g. MacOS has 4k RX

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -415,6 +415,37 @@ class DogStatsd(object):
 
         self._queue = None
         if not disable_background_sender:
+            self.enable_background_sender(sender_queue_size, sender_queue_timeout)
+
+    def enable_background_sender(self, sender_queue_size=0, sender_queue_timeout=0):
+        """
+        Use a background thread to communicate with the dogstatsd server.
+        When enabled, a background thread will be used to send metric payloads to the Agent.
+
+        Applications should call wait_for_pending() before exiting to make sure all pending payloads are sent.
+
+        This method is not thread safe and should not be called concurrently with other methods on the current object.
+        Normally, this should be called shortly after process initialization (for example from a post-fork hook in a
+        forking server).
+
+        :param sender_queue_size: Set the maximum number of packets to queue for the sender. Optional
+        How may packets to queue before blocking or dropping the packet if the packet queue is already full.
+        Default: 0 (unlimited).
+        :type sender_queue_size: integer
+
+        :param sender_queue_timeout: Set timeout for packet queue operations, in seconds. Optional.
+        How long the application thread is willing to wait for the queue clear up before dropping the metric packet.
+        If set to None, wait forever.
+        If set to zero drop the packet immediately if the queue is full.
+        Default: 0 (no wait)
+        :type sender_queue_timeout: float
+        """
+
+        # Avoid a race on _queue with the background buffer flush thread that reads _queue.
+        with self._buffer_lock:
+            if self._queue is not None:
+                return
+
             self._queue = queue.Queue(sender_queue_size)
             self._start_sender_thread()
             if sender_queue_timeout is None:

--- a/tests/integration/dogstatsd/test_statsd_sender.py
+++ b/tests/integration/dogstatsd/test_statsd_sender.py
@@ -37,3 +37,12 @@ def test_sender_mode(disable_background_sender, disable_buffering, wait_for_pend
 
     t.join(timeout=10)
     assert not t.is_alive()
+
+def test_set_socket_timeout():
+    statsd = DogStatsd(socket_timeout=0)
+    assert statsd.get_socket().gettimeout() == 0
+    statsd.set_socket_timeout(1)
+    assert statsd.get_socket().gettimeout() == 1
+    statsd.close_socket()
+    assert statsd.get_socket().gettimeout() == 1
+

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -1875,6 +1875,9 @@ async def print_foo():
         statsd = DogStatsd(disable_background_sender=True)
         self.assertIsNone(statsd._queue)
 
+        statsd.enable_background_sender()
+        self.assertIsNotNone(statsd._queue)
+
         statsd = DogStatsd(disable_background_sender=False)
         self.assertIsNotNone(statsd._queue)
 

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -46,6 +46,7 @@ class FakeSocket(object):
 
         self._flush_interval = flush_interval
         self._flush_wait = False
+        self.timeout = () # unit tuple = settimeout was not called
 
     def send(self, payload):
         if is_p3k():
@@ -77,6 +78,8 @@ class FakeSocket(object):
     def __repr__(self):
         return str(self.payloads)
 
+    def settimeout(self, timeout):
+        self.timeout = timeout
 
 class BrokenSocket(FakeSocket):
     def __init__(self, error_number=None):
@@ -1889,3 +1892,10 @@ async def print_foo():
 
     def test_sender_queue_no_timeout(self):
         statsd = DogStatsd(disable_background_sender=False, sender_queue_timeout=None)
+
+    def test_set_socket_timeout(self):
+        statsd = DogStatsd(disable_background_sender=False)
+        statsd.socket = FakeSocket()
+        statsd.set_socket_timeout(1)
+        self.assertEqual(statsd.socket.timeout, 1)
+        self.assertEqual(statsd.socket_timeout, 1)


### PR DESCRIPTION
### What does this PR do?

Make it possible to enable new features from #787 on the global `statsd` instance.

### Description of the Change

Add setter methods to modify socket timeout and start the background sender thread.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

