### PR TITLE
Add ipv6 support for dogstatsd

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -635,8 +635,8 @@ class DogStatsd(object):
         log.debug("Connecting to %s:%s", host, port)
         addrinfo = socket.getaddrinfo(host, port, type=socket.SOCK_DGRAM)
         # Override gai.conf order for backwrads compatibility: prefer
-        # v4, so that v4-only service on hosts with both addresses
-        # still work.
+        # v4, so that a v4-only service on hosts with both addresses
+        # still works.
         addrinfo.sort(key=lambda v: v[0] == socket.AF_INET, reverse=True)
         lastaddr = len(addrinfo) - 1
         for i, (af, ty, proto, _, addr) in enumerate(addrinfo):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -625,13 +625,6 @@ class DogStatsd(object):
 
     @classmethod
     def _get_udp_socket(cls, host, port, timeout):
-        sock = cls._create_udp_conn(host, port)
-        sock.settimeout(timeout)
-        cls._ensure_min_send_buffer_size(sock)
-        return sock
-
-    @classmethod
-    def _create_udp_conn(cls, host, port):
         log.debug("Connecting to %s:%s", host, port)
         addrinfo = socket.getaddrinfo(host, port, 0, socket.SOCK_DGRAM)
         # Override gai.conf order for backwrads compatibility: prefer
@@ -643,6 +636,8 @@ class DogStatsd(object):
             sock = None
             try:
                 sock = socket.socket(af, ty, proto)
+                sock.settimeout(timeout)
+                cls._ensure_min_send_buffer_size(sock)
                 sock.connect(addr)
                 log.debug("Connected to: %s", addr)
                 return sock

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -633,7 +633,7 @@ class DogStatsd(object):
     @classmethod
     def _create_udp_conn(cls, host, port):
         log.debug("Connecting to %s:%s", host, port)
-        addrinfo = socket.getaddrinfo(host, port, type=socket.SOCK_DGRAM)
+        addrinfo = socket.getaddrinfo(host, port, 0, socket.SOCK_DGRAM)
         # Override gai.conf order for backwrads compatibility: prefer
         # v4, so that a v4-only service on hosts with both addresses
         # still works.

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -625,12 +625,36 @@ class DogStatsd(object):
 
     @classmethod
     def _get_udp_socket(cls, host, port, timeout):
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock = cls._create_udp_conn(host, port)
         sock.settimeout(timeout)
         cls._ensure_min_send_buffer_size(sock)
-        sock.connect((host, port))
-
         return sock
+
+    @classmethod
+    def _create_udp_conn(cls, host, port):
+        log.debug("Connecting to %s:%s", host, port)
+        addrinfo = socket.getaddrinfo(host, port, type=socket.SOCK_DGRAM)
+        # Override gai.conf order for backwrads compatibility: prefer
+        # v4, so that v4-only service on hosts with both addresses
+        # still work.
+        addrinfo.sort(key=lambda v: v[0] == socket.AF_INET, reverse=True)
+        lastaddr = len(addrinfo) - 1
+        for i, (af, ty, proto, _, addr) in enumerate(addrinfo):
+            sock = None
+            try:
+                sock = socket.socket(af, ty, proto)
+                sock.connect(addr)
+                log.debug("Connected to: %s", addr)
+                return sock
+            except Exception as e:
+                if sock is not None:
+                    sock.close()
+                log.debug("Failed to connect to %s: %s", addr, e)
+                if i < lastaddr:
+                    continue
+                raise e
+        else:
+            raise ValueError("getaddrinfo returned no addresses to connect to")
 
     def open_buffer(self, max_buffer_size=None):
         """


### PR DESCRIPTION
### What does this PR do?

Add IPv6 support for hostnames and literal addresses.

### Description of the Change

Call `getaddrinfo` to parse and resolve an internet address before creating the socket. Try in a loop until one address succeeds.

For backwards compatibility, prefer ipv4 addresses: ipv4-only agent should still work even if hostname (e.g. `localhost`) resolves to both ipv4 and ipv6 address and ipv6 is preferred by the OS. This also matches behavior of Golang.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

Address order specified in `gai.conf` is ignored, which may lead to inconsistencies with other applications.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

