### PR TITLE
Fix stale client_transport tag

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -325,14 +325,12 @@ class DogStatsd(object):
             self.socket_path = socket_path  # type: Optional[text]
             self.host = None
             self.port = None
-            transport = "uds"
             if not self._max_payload_size:
                 self._max_payload_size = UDS_OPTIMAL_PAYLOAD_LENGTH
         else:
             self.socket_path = None
             self.host = self.resolve_host(host, use_default_route)
             self.port = int(port)
-            transport = "udp"
             if not self._max_payload_size:
                 self._max_payload_size = UDP_OPTIMAL_PAYLOAD_LENGTH
 
@@ -381,7 +379,6 @@ class DogStatsd(object):
         self._client_tags = [
             "client:py",
             "client_version:{}".format(__version__),
-            "client_transport:{}".format(transport),
         ]
         self._reset_telemetry()
         self._telemetry_flush_interval = telemetry_min_flush_interval
@@ -416,6 +413,15 @@ class DogStatsd(object):
         self._queue = None
         if not disable_background_sender:
             self.enable_background_sender(sender_queue_size, sender_queue_timeout)
+
+    @property
+    def socket_path(self):
+        return self._socket_path
+
+    @socket_path.setter
+    def socket_path(self, path):
+        self._socket_path = path
+        self._transport = "udp" if path is None else "uds"
 
     def enable_background_sender(self, sender_queue_size=0, sender_queue_timeout=0):
         """
@@ -935,7 +941,10 @@ class DogStatsd(object):
         self._last_flush_time = time.time()
 
     def _flush_telemetry(self):
-        telemetry_tags = ",".join(self._add_constant_tags(self._client_tags))
+        tags = self._client_tags[:]
+        tags.append("client_transport:{}".format(self._transport))
+        tags.extend(self.constant_tags)
+        telemetry_tags = ",".join(tags)
 
         return TELEMETRY_FORMATTING_STR % (
             self.metrics_count,


### PR DESCRIPTION

### What does this PR do?


This patch makes the `client_transport` tag dynamic and updates it every time the `socket_path` property is updated.


<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

`datadog.initialize` reassigns `socket_path` property on the global statsd instance, but the `client_transport` tag was computed in the constructor and never updated, causing client to misreport transport as udp when a unix socket was actually used.


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

