### PR TITLE
Improve forking support

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -96,7 +96,7 @@ TELEMETRY_FORMATTING_STR = "\n".join(
 
 Stop = object()
 
-SUPPORTS_FORKING = hasattr(os, "register_at_fork")
+SUPPORTS_FORKING = hasattr(os, "register_at_fork") and not os.environ.get("DD_DOGSTATSD_DISABLE_FORK_SUPPORT", None)
 
 _instances = weakref.WeakSet()
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -203,6 +203,13 @@ class DogStatsd(object):
         for origin detection.
         :type DD_ORIGIN_DETECTION_ENABLED: boolean
 
+        :envvar DD_DOGSTATSD_DISABLE_FORK_SUPPORT: Don't install global fork hooks with os.register_at_fork.
+        Global fork hooks then need to be called manually before and after calling os.fork.
+        :type DD_DOGSTATSD_DISABLE_FORK_SUPPORT: boolean
+
+        :envvar DD_DOGSTATSD_DISABLE_INSTANCE_TRACKING: Don't register instances of this class with global fork hooks.
+        :type DD_DOGSTATSD_DISABLE_INSTANCE_TRACKING: boolean
+
         :param host: the host of the DogStatsd server.
         :type host: string
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -99,7 +99,7 @@ Stop = object()
 SUPPORTS_FORKING = hasattr(os, "register_at_fork") and not os.environ.get("DD_DOGSTATSD_DISABLE_FORK_SUPPORT", None)
 TRACK_INSTANCES = not os.environ.get("DD_DOGSTATSD_DISABLE_INSTANCE_TRACKING", None)
 
-_instances = weakref.WeakSet()
+_instances = weakref.WeakSet() # type: weakref.WeakSet
 
 def pre_fork():
     """Prepare all client instances for a process fork.

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -114,7 +114,7 @@ def pre_fork():
 def post_fork():
     """Restore all client instances after a fork.
 
-    If SUPPORTS_FORKING is true, this will be called automatically before os.fork().
+    If SUPPORTS_FORKING is true, this will be called automatically after os.fork().
     """
     for c in _instances:
         c.post_fork()

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -476,9 +476,8 @@ class DogStatsd(object):
 
         Applications should call stop() before exiting to make sure all pending payloads are sent.
 
-        This method is not thread safe and should not be called concurrently with other methods on the current object.
-        Normally, this should be called shortly after process initialization (for example from a post-fork hook in a
-        forking server).
+        Compatible with os.fork() starting with Python 3.7. On earlier versions, compatible if applications
+        arrange to call pre_fork() and post_fork() module functions around calls to os.fork().
 
         :param sender_queue_size: Set the maximum number of packets to queue for the sender. Optional
         How may packets to queue before blocking or dropping the packet if the packet queue is already full.

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -479,17 +479,15 @@ class DogStatsd(object):
         Compatible with os.fork() starting with Python 3.7. On earlier versions, compatible if applications
         arrange to call pre_fork() and post_fork() module functions around calls to os.fork().
 
-        :param sender_queue_size: Set the maximum number of packets to queue for the sender. Optional
-        How may packets to queue before blocking or dropping the packet if the packet queue is already full.
-        Default: 0 (unlimited).
-        :type sender_queue_size: integer
-
-        :param sender_queue_timeout: Set timeout for packet queue operations, in seconds. Optional.
-        How long the application thread is willing to wait for the queue clear up before dropping the metric packet.
-        If set to None, wait forever.
-        If set to zero drop the packet immediately if the queue is full.
-        Default: 0 (no wait)
-        :type sender_queue_timeout: float
+        :param sender_queue_size: Set the maximum number of packets to queue for the sender.
+            How many packets to queue before blocking or dropping the packet if the packet queue is already full.
+            Default: 0 (unlimited).
+        :type sender_queue_size: integer, optional
+        :param sender_queue_timeout: Set timeout for packet queue operations, in seconds.
+            How long the application thread is willing to wait for the queue clear up before dropping the metric packet.
+            If set to None, wait forever. If set to zero drop the packet immediately if the queue is full.
+            Default: 0 (no wait).
+        :type sender_queue_timeout: float, optional
         """
 
         with self._config_lock:

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -299,7 +299,7 @@ class DogStatsd(object):
 
         :param disable_background_sender: Use a background thread to communicate with the dogstatsd server. Optional.
         When enabled, a background thread will be used to send metric payloads to the Agent.
-        Applications should call wait_for_pending() before exiting to make sure all pending payloads are sent.
+        Applications should call stop() before exiting to make sure all pending payloads are sent.
         Default: True.
         :type disable_background_sender: boolean
 
@@ -474,7 +474,7 @@ class DogStatsd(object):
         Use a background thread to communicate with the dogstatsd server.
         When enabled, a background thread will be used to send metric payloads to the Agent.
 
-        Applications should call wait_for_pending() before exiting to make sure all pending payloads are sent.
+        Applications should call stop() before exiting to make sure all pending payloads are sent.
 
         This method is not thread safe and should not be called concurrently with other methods on the current object.
         Normally, this should be called shortly after process initialization (for example from a post-fork hook in a

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -99,7 +99,8 @@ Stop = object()
 SUPPORTS_FORKING = hasattr(os, "register_at_fork") and not os.environ.get("DD_DOGSTATSD_DISABLE_FORK_SUPPORT", None)
 TRACK_INSTANCES = not os.environ.get("DD_DOGSTATSD_DISABLE_INSTANCE_TRACKING", None)
 
-_instances = weakref.WeakSet() # type: weakref.WeakSet
+_instances = weakref.WeakSet()  # type: weakref.WeakSet
+
 
 def pre_fork():
     """Prepare all client instances for a process fork.
@@ -109,6 +110,7 @@ def pre_fork():
     for c in _instances:
         c.pre_fork()
 
+
 def post_fork():
     """Restore all client instances after a fork.
 
@@ -117,14 +119,15 @@ def post_fork():
     for c in _instances:
         c.post_fork()
 
+
 if SUPPORTS_FORKING:
-    os.register_at_fork(before=pre_fork, after_in_child=post_fork, after_in_parent=post_fork) # type: ignore
+    os.register_at_fork(before=pre_fork, after_in_child=post_fork, after_in_parent=post_fork)  # type: ignore
+
 
 # pylint: disable=useless-object-inheritance,too-many-instance-attributes
 # pylint: disable=too-many-arguments,too-many-locals
 class DogStatsd(object):
     OK, WARNING, CRITICAL, UNKNOWN = (0, 1, 2, 3)
-
 
     def __init__(
         self,
@@ -312,7 +315,8 @@ class DogStatsd(object):
         Default: 0 (no wait)
         :type sender_queue_timeout: float
 
-        :param track_instance: Keep track of this instance and automatically handle cleanup when os.fork() is called, if supported.
+        :param track_instance: Keep track of this instance and automatically handle cleanup when os.fork() is called,
+        if supported.
         Default: True.
         :type track_instance: boolean
         """

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1362,5 +1362,18 @@ class DogStatsd(object):
         self._start_flush_thread(self._flush_interval)
         self._start_sender_thread()
 
+    def stop(self):
+        """Stop the client.
+
+        Disable buffering, background sender and flush any pending payloads to the server.
+
+        Client remains usable after this method, but sending metrics may block if socket_timeout is enabled.
+        """
+
+        self.disable_background_sender()
+        self.disable_buffering = True
+        self.flush()
+        self.close_socket()
+
 
 statsd = DogStatsd()

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -118,7 +118,7 @@ def post_fork():
         c.post_fork()
 
 if SUPPORTS_FORKING:
-    os.register_at_fork(before=pre_fork, after_in_child=post_fork, after_in_parent=post_fork)
+    os.register_at_fork(before=pre_fork, after_in_child=post_fork, after_in_parent=post_fork) # type: ignore
 
 # pylint: disable=useless-object-inheritance,too-many-instance-attributes
 # pylint: disable=too-many-arguments,too-many-locals

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -102,10 +102,18 @@ TRACK_INSTANCES = not os.environ.get("DD_DOGSTATSD_DISABLE_INSTANCE_TRACKING", N
 _instances = weakref.WeakSet()
 
 def pre_fork():
+    """Prepare all client instances for a process fork.
+
+    If SUPPORTS_FORKING is true, this will be called automatically before os.fork().
+    """
     for c in _instances:
         c.pre_fork()
 
 def post_fork():
+    """Restore all client instances after a fork.
+
+    If SUPPORTS_FORKING is true, this will be called automatically before os.fork().
+    """
     for c in _instances:
         c.post_fork()
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -547,7 +547,6 @@ class DogStatsd(object):
     # Note: Invocations of this method should be thread-safe
     def _stop_flush_thread(self):
         if not self._flush_thread:
-            log.warning("No statsd flush thread to stop")
             return
 
         try:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -188,6 +188,15 @@ Usage
     >>> initialize(statsd_host="localhost", statsd_port=8125)
     >>> statsd.increment("home.page.hits")
 
+.. data:: datadog.dogstatsd.base.SUPPORTS_FORKING
+
+    Indicates whether the Python runtime supports os.register_at_fork(). When
+    true, buffering and background sender can be safely used in applications
+    that use os.fork().
+
+.. autofunction:: datadog.dogstatsd.base.pre_fork
+.. autofunction:: datadog.dogstatsd.base.post_fork
+
 
 Get in Touch
 ============

--- a/tests/integration/dogstatsd/test_statsd_fork.py
+++ b/tests/integration/dogstatsd/test_statsd_fork.py
@@ -1,0 +1,43 @@
+import os
+import itertools
+import socket
+
+import pytest
+
+from datadog.dogstatsd.base import DogStatsd, SUPPORTS_FORKING
+
+
+@pytest.mark.parametrize(
+    "disable_background_sender, disable_buffering",
+    list(itertools.product([True, False], [True, False])),
+)
+def test_register_at_fork(disable_background_sender, disable_buffering):
+    if not SUPPORTS_FORKING:
+        pytest.skip("os.register_at_fork is required for this test")
+
+    statsd = DogStatsd(
+        telemetry_min_flush_interval=0,
+        disable_background_sender=disable_background_sender,
+        disable_buffering=disable_buffering,
+    )
+
+    tracker = {}
+
+    def track(method):
+        def inner(*args, **kwargs):
+            method(*args, **kwargs)
+            tracker[method] = True
+
+        return inner
+
+    statsd.pre_fork = track(statsd.pre_fork)
+    statsd.post_fork = track(statsd.post_fork)
+
+    pid = os.fork()
+    if pid == 0:
+        os._exit(0)
+
+    assert pid > 0
+    os.waitpid(pid, 0)
+
+    assert len(tracker) == 2

--- a/tests/integration/dogstatsd/test_statsd_sender.py
+++ b/tests/integration/dogstatsd/test_statsd_sender.py
@@ -7,10 +7,10 @@ import pytest
 from datadog.dogstatsd.base import DogStatsd
 
 @pytest.mark.parametrize(
-    "disable_background_sender, disable_buffering, wait_for_pending, socket_timeout",
-    list(itertools.product([True, False], [True, False], [True, False], [0, 1])),
+    "disable_background_sender, disable_buffering, wait_for_pending, socket_timeout, stop",
+    list(itertools.product([True, False], [True, False], [True, False], [0, 1], [True, False])),
 )
-def test_sender_mode(disable_background_sender, disable_buffering, wait_for_pending, socket_timeout):
+def test_sender_mode(disable_background_sender, disable_buffering, wait_for_pending, socket_timeout, stop):
     # Test basic sender operation with an assortment of options
     foo, bar = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM, 0)
     statsd = DogStatsd(
@@ -34,6 +34,9 @@ def test_sender_mode(disable_background_sender, disable_buffering, wait_for_pend
     statsd.increment("test.metric")
     if wait_for_pending:
         statsd.wait_for_pending()
+
+    if stop:
+        statsd.stop()
 
     t.join(timeout=10)
     assert not t.is_alive()


### PR DESCRIPTION
### What does this PR do?

Use `register_at_fork` added in Python 3.7+ to transparently handle process fork when the client is using background threads.

### Description of the Change

Forking support is introduced in several layers:
- Per-instance hooks that can be called before and after fork() to disable and re-enable background threads and also flushes pending metrics.
- A weakset is added that tracks all instances of DogStatsd (an opt-out is provided in case unforeseen complications arise).
- Package level hooks that invoke fork hooks on all tracked instances.
- On Python 3.7+, the package level hooks are automatically registered with the Python runtime via `os.register_at_fork`.

This approach is similar to one used in dd-trace-py for handling forks.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

