### PR TITLE
Close socket during initialization

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -122,6 +122,7 @@ def initialize(
             statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)
         if statsd_port:
             statsd.port = int(statsd_port)
+    statsd.close_socket()
     if statsd_namespace:
         statsd.namespace = text(statsd_namespace)
     if statsd_constant_tags:

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -285,6 +285,12 @@ class TestDogStatsd(unittest.TestCase):
         self.assertEqual(dogstatsd.host, "myenvvarhost")
         self.assertEqual(dogstatsd.port, 4321)
 
+    def test_initialization_closes_socket(self):
+        statsd.socket = FakeSocket()
+        self.assertIsNotNone(statsd.socket)
+        initialize()
+        self.assertIsNone(statsd.socket)
+
     def test_default_route(self):
         """
         Dogstatsd host can be dynamically set to the default route.


### PR DESCRIPTION
### What does this PR do?

Make sure statsd uses socket settings configured in `initialize`.

### Description of the Change

If the global statsd instance is used before initialize() is called (for example, statsd used to send metrics from a top-level of a loaded module), statsd instance will already have a socket open when we set connection parameters. To make sure they take effect, call close_socket().

### Alternate Designs


### Possible Drawbacks

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

