### PR TITLE
Support inode resolution mechanism for Origin Detection

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -32,7 +32,7 @@ from datadog.dogstatsd.context import (
     DistributedContextManagerDecorator,
 )
 from datadog.dogstatsd.route import get_default_route
-from datadog.dogstatsd.container import ContainerID
+from datadog.dogstatsd.container import Cgroup
 from datadog.util.compat import is_p3k, text
 from datadog.util.format import normalize_tags
 from datadog.version import __version__
@@ -1288,7 +1288,7 @@ class DogStatsd(object):
             return
         if origin_detection_enabled:
             try:
-                reader = ContainerID()
+                reader = Cgroup()
                 self._container_id = reader.container_id
             except Exception as e:
                 log.debug("Couldn't get container ID: %s", str(e))

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -94,12 +94,13 @@ class Cgroup(object):
             self.CGROUPV1_BASE_CONTROLLER,
             self.CGROUPV2_BASE_CONTROLLER,
         ]:
-            if controller, cpath in cgroup_controllers_paths.values():
+            if controller in cgroup_controllers_paths:
                 inode_path = os.path.join(
-                    self.DEFAULT_CGROUP_MOUNT_PATH,
+                    self.CGROUP_MOUNT_PATH,
                     controller,
-                    cpath if cpath != "/" else "",
+                    cgroup_controllers_paths[controller] if cgroup_controllers_paths[controller] != "/" else "",
                 )
-                return "in-{0}".format(os.stat(inode_path).st_ino)
+                inode = os.stat(inode_path).st_ino
+                return "in-{0}".format(inode) if int(inode) > 2 else None
 
         return None

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -86,7 +86,7 @@ class Cgroup(object):
                 tokens = line.strip().split(":")
                 if len(tokens) != 3:
                     continue
-                if tokens[1] == self.CGROUPV1_BASE_CONTROLLER or tokens[1] == "":
+                if tokens[1] == self.CGROUPV1_BASE_CONTROLLER or tokens[1] == self.CGROUPV2_BASE_CONTROLLER:
                     cgroup_controllers_paths[tokens[1]] = tokens[2]
 
         # Retrieve the cgroup inode from "/sys/fs/cgroup + controller + cgroupNodePath"

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -42,12 +42,12 @@ class Cgroup(object):
     CONTAINER_RE = re.compile(r"(?:.+)?({0}|{1}|{2})(?:\.scope)?$".format(UUID_SOURCE, CONTAINER_SOURCE, TASK_SOURCE))
 
     def __init__(self):
-        if self._is_cgroup_namespace():
+        if self._is_host_cgroup_namespace():
             self.container_id = self._read_cgroup_path()
             return
         self.container_id = self._get_cgroup_from_inode()
 
-    def _is_cgroup_namespace(self):
+    def _is_host_cgroup_namespace(self):
         """Check if the current process is in a host cgroup namespace."""
         return (
             os.stat(self.CGROUP_NS_PATH).st_ino == self.HOST_CGROUP_NAMESPACE_INODE
@@ -101,6 +101,7 @@ class Cgroup(object):
                     cgroup_controllers_paths[controller] if cgroup_controllers_paths[controller] != "/" else "",
                 )
                 inode = os.stat(inode_path).st_ino
+                # 0 is not a valid inode. 1 is a bad block inode and 2 is the root of a filesystem.
                 return "in-{0}".format(inode) if int(inode) > 2 else None
 
         return None

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -49,11 +49,14 @@ class Cgroup(object):
 
     def _is_host_cgroup_namespace(self):
         """Check if the current process is in a host cgroup namespace."""
-        return (
-            os.stat(self.CGROUP_NS_PATH).st_ino == self.HOST_CGROUP_NAMESPACE_INODE
-            if os.path.exists(self.CGROUP_NS_PATH)
-            else False
-        )
+        try:
+            return (
+                os.stat(self.CGROUP_NS_PATH).st_ino == self.HOST_CGROUP_NAMESPACE_INODE
+                if os.path.exists(self.CGROUP_NS_PATH)
+                else False
+            )
+        except Exception:
+            return False
 
     def _read_cgroup_path(self):
         """Read the container ID from the cgroup file."""

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -4,6 +4,7 @@
 # Copyright 2015-Present Datadog, Inc
 
 import errno
+import os
 import re
 
 
@@ -13,12 +14,14 @@ class UnresolvableContainerID(Exception):
     """
 
 
-class ContainerID(object):
+class Cgroup(object):
     """
-    A reader class that retrieves the current container ID parsed from a the cgroup file.
+    A reader class that retrieves either:
+    - The current container ID parsed from the cgroup file
+    - The cgroup controller inode.
 
     Returns:
-    object: ContainerID
+    object: Cgroup
 
     Raises:
         `NotImplementedError`: No proc filesystem is found (non-Linux systems)
@@ -26,6 +29,12 @@ class ContainerID(object):
     """
 
     CGROUP_PATH = "/proc/self/cgroup"
+    DEFAULT_CGROUP_MOUNT_PATH = "/sys/fs/cgroup"  # default cgroup mount path.
+    CGROUP_NS_PATH = "/proc/self/ns/cgroup"  # path to the cgroup namespace file.
+    CGROUPV1_BASE_CONTROLLER = "memory"  # controller used to identify the container-id in cgroup v1 (memory).
+    CGROUPV2_BASE_CONTROLLER = ""  # controller used to identify the container-id in cgroup v2.
+    HOST_CGROUP_NAMESPACE_INODE = "0xEFFFFFFBL"  # inode of the host cgroup namespace.
+
     UUID_SOURCE = r"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}"
     CONTAINER_SOURCE = r"[0-9a-f]{64}"
     TASK_SOURCE = r"[0-9a-f]{32}-\d+"
@@ -33,11 +42,23 @@ class ContainerID(object):
     CONTAINER_RE = re.compile(r"(?:.+)?({0}|{1}|{2})(?:\.scope)?$".format(UUID_SOURCE, CONTAINER_SOURCE, TASK_SOURCE))
 
     def __init__(self):
-        self.container_id = self._read_container_id(self.CGROUP_PATH)
+        if self._is_cgroup_namespace():
+            self.container_id = self._read_cgroup_path()
+            return
+        self.container_id = self._get_cgroup_from_inode()
 
-    def _read_container_id(self, fpath):
+    def _is_cgroup_namespace(self):
+        """Check if the current process is in a host cgroup namespace."""
+        return (
+            os.stat(self.CGROUP_NS_PATH).st_ino == self.HOST_CGROUP_NAMESPACE_INODE
+            if os.path.exists(self.CGROUP_NS_PATH)
+            else False
+        )
+
+    def _read_cgroup_path(self):
+        """Read the container ID from the cgroup file."""
         try:
-            with open(fpath, mode="r") as fp:
+            with open(self.CGROUP_PATH, mode="r") as fp:
                 for line in fp:
                     line = line.strip()
                     match = self.LINE_RE.match(line)
@@ -54,4 +75,31 @@ class ContainerID(object):
                 raise NotImplementedError("Unable to open {}.".format(self.CGROUP_PATH))
         except Exception as e:
             raise UnresolvableContainerID("Unable to read the container ID: " + str(e))
+        return None
+
+    def _get_cgroup_from_inode(self):
+        """Read the container ID from the cgroup inode."""
+        # Parse /proc/self/cgroup and get a map of controller to its associated cgroup node path.
+        cgroup_controllers_paths = {}
+        with open(self.CGROUP_PATH, mode="r") as fp:
+            for line in fp:
+                tokens = line.strip().split(":")
+                if len(tokens) != 3:
+                    continue
+                if tokens[1] == self.CGROUPV1_BASE_CONTROLLER or tokens[1] == "":
+                    cgroup_controllers_paths[tokens[1]] = tokens[2]
+
+        # Retrieve the cgroup inode from "/sys/fs/cgroup + controller + cgroupNodePath"
+        for controller in [
+            self.CGROUPV1_BASE_CONTROLLER,
+            self.CGROUPV2_BASE_CONTROLLER,
+        ]:
+            if controller in cgroup_controllers_paths:
+                inode_path = os.path.join(
+                    self.DEFAULT_CGROUP_MOUNT_PATH,
+                    controller,
+                    cgroup_controllers_paths[controller] if cgroup_controllers_paths[controller] != "/" else "",
+                )
+                return "in-{0}".format(os.stat(inode_path).st_ino)
+
         return None

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -98,7 +98,7 @@ class Cgroup(object):
                 inode_path = os.path.join(
                     self.DEFAULT_CGROUP_MOUNT_PATH,
                     controller,
-                    cgroup_controllers_paths[controller] if cgroup_controllers_paths[controller] != "/" else "",
+                    cpath if cpath != "/" else "",
                 )
                 return "in-{0}".format(os.stat(inode_path).st_ino)
 

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -29,7 +29,7 @@ class Cgroup(object):
     """
 
     CGROUP_PATH = "/proc/self/cgroup"
-    DEFAULT_CGROUP_MOUNT_PATH = "/sys/fs/cgroup"  # default cgroup mount path.
+    CGROUP_MOUNT_PATH = "/sys/fs/cgroup"  # cgroup mount path.
     CGROUP_NS_PATH = "/proc/self/ns/cgroup"  # path to the cgroup namespace file.
     CGROUPV1_BASE_CONTROLLER = "memory"  # controller used to identify the container-id in cgroup v1 (memory).
     CGROUPV2_BASE_CONTROLLER = ""  # controller used to identify the container-id in cgroup v2.

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -94,7 +94,7 @@ class Cgroup(object):
             self.CGROUPV1_BASE_CONTROLLER,
             self.CGROUPV2_BASE_CONTROLLER,
         ]:
-            if controller in cgroup_controllers_paths:
+            if controller, cpath in cgroup_controllers_paths.values():
                 inode_path = os.path.join(
                     self.DEFAULT_CGROUP_MOUNT_PATH,
                     controller,

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -33,7 +33,7 @@ class Cgroup(object):
     CGROUP_NS_PATH = "/proc/self/ns/cgroup"  # path to the cgroup namespace file.
     CGROUPV1_BASE_CONTROLLER = "memory"  # controller used to identify the container-id in cgroup v1 (memory).
     CGROUPV2_BASE_CONTROLLER = ""  # controller used to identify the container-id in cgroup v2.
-    HOST_CGROUP_NAMESPACE_INODE = "0xEFFFFFFBL"  # inode of the host cgroup namespace.
+    HOST_CGROUP_NAMESPACE_INODE = 0xEFFFFFFB  # inode of the host cgroup namespace.
 
     UUID_SOURCE = r"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}"
     CONTAINER_SOURCE = r"[0-9a-f]{64}"
@@ -105,6 +105,7 @@ class Cgroup(object):
                 )
                 inode = os.stat(inode_path).st_ino
                 # 0 is not a valid inode. 1 is a bad block inode and 2 is the root of a filesystem.
-                return "in-{0}".format(inode) if int(inode) > 2 else None
+                if inode > 2:
+                    return "in-{0}".format(inode)
 
         return None

--- a/tests/unit/dogstatsd/test_container.py
+++ b/tests/unit/dogstatsd/test_container.py
@@ -130,7 +130,7 @@ def test_container_id_from_cgroup(file_contents, expected_container_id):
         if file_contents is None:
             mock_open.side_effect = IOError
 
-        with mock.patch("os.stat", mock.MagicMock(return_value=mock.Mock(st_ino="0xEFFFFFFBL"))):
+        with mock.patch("os.stat", mock.MagicMock(return_value=mock.Mock(st_ino=0xEFFFFFFB))):
             reader = Cgroup()
         assert expected_container_id == reader.container_id
 
@@ -140,7 +140,44 @@ def test_container_id_from_cgroup(file_contents, expected_container_id):
 def test_container_id_inode():
     """Test that the inode is returned when the container ID cannot be found."""
     with mock.patch("datadog.dogstatsd.container.open", mock.mock_open(read_data="0::/")) as mock_open:
-        with mock.patch("os.stat", mock.MagicMock(return_value=mock.Mock(st_ino="1234"))):
+        with mock.patch("os.stat", mock.MagicMock(return_value=mock.Mock(st_ino=1234))):
             reader = Cgroup()
         assert reader.container_id == "in-1234"
+        mock_open.assert_called_once_with("/proc/self/cgroup", mode="r")
+
+    cgroupv1_priority = """
+12:cpu,cpuacct:/
+11:hugetlb:/
+10:devices:/
+9:rdma:/
+8:net_cls,net_prio:/
+7:memory:/
+6:cpuset:/
+5:pids:/
+4:freezer:/
+3:perf_event:/
+2:blkio:/
+1:name=systemd:/
+0::/
+"""
+
+    paths_checked = []
+
+    def inode_stat_mock(path):
+        paths_checked.append(path)
+
+        # The cgroupv1 controller is mounted on inode 0. This will cause a fallback to the cgroupv2 controller.
+        if path == "/sys/fs/cgroup/memory/":
+            return mock.Mock(st_ino=0)
+        elif path == "/sys/fs/cgroup/":
+            return mock.Mock(st_ino=1234)
+
+    with mock.patch("datadog.dogstatsd.container.open", mock.mock_open(read_data=cgroupv1_priority)) as mock_open:
+        with mock.patch("os.stat", mock.MagicMock(side_effect=inode_stat_mock)):
+            reader = Cgroup()
+        assert reader.container_id == "in-1234"
+        assert paths_checked[-2:] == [
+            "/sys/fs/cgroup/memory/",
+            "/sys/fs/cgroup/"
+        ]
         mock_open.assert_called_once_with("/proc/self/cgroup", mode="r")


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Implements the support of Origin Detection when the container ID is unavailable from inside the container by using the inode resolution mechanic. The original Go implementation is here: [https://github.com/DataDog/datadog-go/pull/291](https://github.com/DataDog/datadog-go/pull/291)

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

If we are not able to find the container ID from inside the container, we will send instead the cgroup inode to be able to resolve the container ID on the Agent side.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

Use the following deployment on a k8s cluster running `cgroupv2`:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-dsd-python-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-dsd-python-app
  template:
    metadata:
      labels:
        app: dummy-dsd-python-app
        admission.datadoghq.com/enabled: "false"
    spec:
      containers:
      - name: dummy-dsd-python-app
        image: wdhifdatadog/dummy-dsd-python-app
        imagePullPolicy: Always
        env:
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
```

You should then be able to find a `dummy.dsd.python.metric` with a `container_id` tag.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [x] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

