### PR TITLE
Rename integrations-tools-and-libraries to api-clients in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,30 +4,30 @@
 # pattern is the one used.
 
 # Default owners of everything in the repo
-*                                @DataDog/integrations-tools-and-libraries
+*                                @DataDog/api-clients
 
 # API
-/datadog/api/                    @DataDog/integrations-tools-and-libraries
-/tests/integration/api/          @DataDog/integrations-tools-and-libraries
-/tests/unit/api/                 @DataDog/integrations-tools-and-libraries
+/datadog/api/                    @DataDog/api-clients
+/tests/integration/api/          @DataDog/api-clients
+/tests/unit/api/                 @DataDog/api-clients
 
 # Dogshell
-/datadog/dogshell/               @DataDog/integrations-tools-and-libraries
-/tests/integration/dogshell/     @DataDog/integrations-tools-and-libraries
+/datadog/dogshell/               @DataDog/api-clients
+/tests/integration/dogshell/     @DataDog/api-clients
 
 # Dogstatd
-/datadog/dogstatsd/              @DataDog/integrations-tools-and-libraries @DataDog/agent-metrics-logs
-/datadog/util/                   @DataDog/integrations-tools-and-libraries @DataDog/agent-metrics-logs
-/tests/integration/dogstatsd/    @DataDog/integrations-tools-and-libraries @DataDog/agent-metrics-logs
-/tests/unit/dogstatsd/           @DataDog/integrations-tools-and-libraries @DataDog/agent-metrics-logs
-/tests/unit/util/                @DataDog/integrations-tools-and-libraries @DataDog/agent-metrics-logs
-/tests/util/                     @DataDog/integrations-tools-and-libraries @DataDog/agent-metrics-logs
-/tests/performance/test_statsd_* @DataDog/integrations-tools-and-libraries @DataDog/agent-metrics-logs
+/datadog/dogstatsd/              @DataDog/api-clients @DataDog/agent-metrics-logs
+/datadog/util/                   @DataDog/api-clients @DataDog/agent-metrics-logs
+/tests/integration/dogstatsd/    @DataDog/api-clients @DataDog/agent-metrics-logs
+/tests/unit/dogstatsd/           @DataDog/api-clients @DataDog/agent-metrics-logs
+/tests/unit/util/                @DataDog/api-clients @DataDog/agent-metrics-logs
+/tests/util/                     @DataDog/api-clients @DataDog/agent-metrics-logs
+/tests/performance/test_statsd_* @DataDog/api-clients @DataDog/agent-metrics-logs
 
 # Threadstats
-/datadog/threadstats/            @DataDog/integrations-tools-and-libraries @DataDog/agent-metrics-logs
-/tests/unit/threadstats/         @DataDog/integrations-tools-and-libraries @DataDog/agent-metrics-logs
+/datadog/threadstats/            @DataDog/api-clients @DataDog/agent-metrics-logs
+/tests/unit/threadstats/         @DataDog/api-clients @DataDog/agent-metrics-logs
 
 # Documentation
-*.md                             @DataDog/documentation @DataDog/integrations-tools-and-libraries
-LICENSE                          @DataDog/documentation @DataDog/integrations-tools-and-libraries
+*.md                             @DataDog/documentation @DataDog/api-clients
+LICENSE                          @DataDog/documentation @DataDog/api-clients


### PR DESCRIPTION
Cleanup from a team rename that already went into effect in Workday. The new team has the same members as the old one, plus managers:

https://github.com/orgs/DataDog/teams/integrations-tools-and-libraries
https://github.com/orgs/DataDog/teams/api-clients

[APITL-857](https://datadoghq.atlassian.net/browse/APITL-857)

[APITL-857]: https://datadoghq.atlassian.net/browse/APITL-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ