### PR TITLE
Support passing Unix timestamps to dogstatsd

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -775,13 +775,32 @@ class DogStatsd(object):
         """
         return self._report(metric, "g", value, tags, sample_rate, timestamp)
 
+    # Minimum Datadog Agent version: 7.40.0
+    def gauge_with_timestamp(
+        self,
+        metric,  # type: Text
+        value,  # type: float
+        timestamp,  # type: int
+        tags=None,  # type: Optional[List[str]]
+        sample_rate=None,  # type: Optional[float]
+    ):  # type(...) -> None
+        """u
+        Record the value of a gauge with a Unix timestamp (in seconds),
+        optionally setting a list of tags and a sample rate.
+
+        Minimum Datadog Agent version: 7.40.0
+
+        >>> statsd.gauge("users.online", 123, 1713804588)
+        >>> statsd.gauge("active.connections", 1001, 1713804588, tags=["protocol:http"])
+        """
+        return self._report(metric, "g", value, tags, sample_rate, timestamp)
+
     def increment(
         self,
         metric,  # type: Text
         value=1,  # type: float
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
-        timestamp=0,  # type:int
     ):  # type: (...) -> None
         """
         Increment a counter, optionally setting a value, tags and a sample
@@ -789,6 +808,26 @@ class DogStatsd(object):
 
         >>> statsd.increment("page.views")
         >>> statsd.increment("files.transferred", 124)
+        """
+        self._report(metric, "c", value, tags, sample_rate)
+
+    # Minimum Datadog Agent version: 7.40.0
+    def increment_with_timestamp(
+        self,
+        metric,  # type: Text
+        value=1,  # type: float
+        timestamp=0,  # type: int
+        tags=None,  # type: Optional[List[str]]
+        sample_rate=None,  # type: Optional[float]
+    ):  # type: (...) -> None
+        """
+        Increment a counter, optionally setting a value, a Unix timestamp
+        in seconds, tags and a sample rate.
+
+        Minimum Datadog Agent version: 7.40.0
+
+        >>> statsd.increment("page.views", timestamp=1713804588)
+        >>> statsd.increment("files.transferred", 124, timestamp=1713804588)
         """
         self._report(metric, "c", value, tags, sample_rate, timestamp)
 
@@ -798,11 +837,31 @@ class DogStatsd(object):
         value=1,  # type: float
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
-        timestamp=0,  # type:int
     ):  # type(...) -> None
         """
         Decrement a counter, optionally setting a value, tags and a sample
         rate.
+
+        >>> statsd.decrement("files.remaining")
+        >>> statsd.decrement("active.connections", 2)
+        """
+        metric_value = -value if value else value
+        self._report(metric, "c", metric_value, tags, sample_rate)
+
+    # Minimum Datadog Agent version: 7.40.0
+    def decrement_with_timestamp(
+        self,
+        metric,  # type: Text
+        value=1,  # type: float
+        timestamp=0,  # type:int
+        tags=None,  # type: Optional[List[str]]
+        sample_rate=None,  # type: Optional[float]
+    ):  # type(...) -> None
+        """
+        Decrement a counter, optionally setting a value, a Unix timestamp
+        in seconds, tags and a sample rate.
+
+        Minimum Datadog Agent version: 7.40.0
 
         >>> statsd.decrement("files.remaining")
         >>> statsd.decrement("active.connections", 2)

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -764,7 +764,6 @@ class DogStatsd(object):
         value,  # type: float
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
-        timestamp=0,  # type:int
     ):  # type(...) -> None
         """
         Record the value of a gauge, optionally setting a list of tags and a
@@ -773,7 +772,7 @@ class DogStatsd(object):
         >>> statsd.gauge("users.online", 123)
         >>> statsd.gauge("active.connections", 1001, tags=["protocol:http"])
         """
-        return self._report(metric, "g", value, tags, sample_rate, timestamp)
+        return self._report(metric, "g", value, tags, sample_rate)
 
     # Minimum Datadog Agent version: 7.40.0
     def gauge_with_timestamp(
@@ -795,13 +794,47 @@ class DogStatsd(object):
         """
         return self._report(metric, "g", value, tags, sample_rate, timestamp)
 
+    def count(
+        self,
+        metric,  # type: Text
+        value,  # type: float
+        tags=None,  # type: Optional[List[str]]
+        sample_rate=None,  # type: Optional[float]
+    ):  # type(...) -> None
+        """
+        Count tracks how many times something happened per second, tags and a sample
+        rate.
+
+        >>> statsd.count("page.views", 123)
+        """
+        self._report(metric, "c", value, tags, sample_rate)
+
+    # Minimum Datadog Agent version: 7.40.0
+    def count_with_timestamp(
+        self,
+        metric,  # type: Text
+        value,  # type: float
+        timestamp=0,  # type: int
+        tags=None,  # type: Optional[List[str]]
+        sample_rate=None,  # type: Optional[float]
+    ):  # type(...) -> None
+        """
+        Count how many times something happened at a given Unix timestamp in seconds,
+        tags and a sample rate.
+
+        Minimum Datadog Agent version: 7.40.0
+
+        >>> statsd.count("files.transferred", 124, timestamp=1713804588)
+        """
+        self._report(metric, "c", value, tags, sample_rate, timestamp)
+
     def increment(
         self,
         metric,  # type: Text
         value=1,  # type: float
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
-    ):  # type: (...) -> None
+    ):  # type(...) -> None
         """
         Increment a counter, optionally setting a value, tags and a sample
         rate.
@@ -810,26 +843,6 @@ class DogStatsd(object):
         >>> statsd.increment("files.transferred", 124)
         """
         self._report(metric, "c", value, tags, sample_rate)
-
-    # Minimum Datadog Agent version: 7.40.0
-    def increment_with_timestamp(
-        self,
-        metric,  # type: Text
-        value=1,  # type: float
-        timestamp=0,  # type: int
-        tags=None,  # type: Optional[List[str]]
-        sample_rate=None,  # type: Optional[float]
-    ):  # type: (...) -> None
-        """
-        Increment a counter, optionally setting a value, a Unix timestamp
-        in seconds, tags and a sample rate.
-
-        Minimum Datadog Agent version: 7.40.0
-
-        >>> statsd.increment("page.views", timestamp=1713804588)
-        >>> statsd.increment("files.transferred", 124, timestamp=1713804588)
-        """
-        self._report(metric, "c", value, tags, sample_rate, timestamp)
 
     def decrement(
         self,
@@ -847,27 +860,6 @@ class DogStatsd(object):
         """
         metric_value = -value if value else value
         self._report(metric, "c", metric_value, tags, sample_rate)
-
-    # Minimum Datadog Agent version: 7.40.0
-    def decrement_with_timestamp(
-        self,
-        metric,  # type: Text
-        value=1,  # type: float
-        timestamp=0,  # type:int
-        tags=None,  # type: Optional[List[str]]
-        sample_rate=None,  # type: Optional[float]
-    ):  # type(...) -> None
-        """
-        Decrement a counter, optionally setting a value, a Unix timestamp
-        in seconds, tags and a sample rate.
-
-        Minimum Datadog Agent version: 7.40.0
-
-        >>> statsd.decrement("files.remaining")
-        >>> statsd.decrement("active.connections", 2)
-        """
-        metric_value = -value if value else value
-        self._report(metric, "c", metric_value, tags, sample_rate, timestamp)
 
     def histogram(
         self,

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -336,18 +336,23 @@ class TestDogStatsd(unittest.TestCase):
         self.statsd.flush()
         self.assert_equal_telemetry('page.views:-12|c\n', self.recv(2))
 
-    def test_counter_with_ts(self):
-        self.statsd.increment_with_timestamp("page.views", timestamp=1066)
+    def test_count(self):
+        self.statsd.count('page.views', 11)
+        self.statsd.flush()
+        self.assert_equal_telemetry('page.views:11|c\n', self.recv(2))
+
+    def test_count_with_ts(self):
+        self.statsd.count_with_timestamp("page.views", 1, timestamp=1066)
         self.statsd.flush()
         self.assert_equal_telemetry("page.views:1|c|T1066\n", self.recv(2))
 
         self.statsd._reset_telemetry()
-        self.statsd.increment_with_timestamp("page.views", 11, timestamp=2121)
+        self.statsd.count_with_timestamp("page.views", 11, timestamp=2121)
         self.statsd.flush()
         self.assert_equal_telemetry("page.views:11|c|T2121\n", self.recv(2))
 
-    def test_counter_with_invalid_ts_should_be_ignored(self):
-        self.statsd.increment_with_timestamp("page.views", timestamp=-1066)
+    def test_count_with_invalid_ts_should_be_ignored(self):
+        self.statsd.count_with_timestamp("page.views", 1, timestamp=-1066)
         self.statsd.flush()
         self.assert_equal_telemetry("page.views:1|c\n", self.recv(2))
 

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -309,11 +309,11 @@ class TestDogStatsd(unittest.TestCase):
         self.assert_equal_telemetry('gauge:123.4|g\n', self.recv(2))
 
     def test_gauge_with_ts(self):
-        self.statsd.gauge("gauge", 123.4, timestamp=1066)
+        self.statsd.gauge_with_timestamp("gauge", 123.4, timestamp=1066)
         self.assert_equal_telemetry("gauge:123.4|g|T1066\n", self.recv(2))
 
     def test_gauge_with_invalid_ts_should_be_ignored(self):
-        self.statsd.gauge("gauge", 123.4, timestamp=-500)
+        self.statsd.gauge_with_timestamp("gauge", 123.4, timestamp=-500)
         self.assert_equal_telemetry("gauge:123.4|g\n", self.recv(2))
 
     def test_counter(self):
@@ -337,17 +337,17 @@ class TestDogStatsd(unittest.TestCase):
         self.assert_equal_telemetry('page.views:-12|c\n', self.recv(2))
 
     def test_counter_with_ts(self):
-        self.statsd.increment("page.views", timestamp=1066)
+        self.statsd.increment_with_timestamp("page.views", timestamp=1066)
         self.statsd.flush()
         self.assert_equal_telemetry("page.views:1|c|T1066\n", self.recv(2))
 
         self.statsd._reset_telemetry()
-        self.statsd.increment("page.views", 11, timestamp=2121)
+        self.statsd.increment_with_timestamp("page.views", 11, timestamp=2121)
         self.statsd.flush()
         self.assert_equal_telemetry("page.views:11|c|T2121\n", self.recv(2))
 
     def test_counter_with_invalid_ts_should_be_ignored(self):
-        self.statsd.increment("page.views", timestamp=-1066)
+        self.statsd.increment_with_timestamp("page.views", timestamp=-1066)
         self.statsd.flush()
         self.assert_equal_telemetry("page.views:1|c\n", self.recv(2))
 

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -304,6 +304,19 @@ class TestDogStatsd(unittest.TestCase):
         self.statsd.set('set', 123)
         self.assert_equal_telemetry('set:123|s\n', self.recv(2))
 
+    def test_report(self):
+        self.statsd._report('report', 'g', 123.4, tags=None, sample_rate=None)
+        self.assert_equal_telemetry('report:123.4|g\n', self.recv(2))
+
+    def test_report_metric_with_unsupported_ts(self):
+        self.statsd._reset_telemetry()
+        self.statsd._report('report', 'h', 123.5, tags=None, sample_rate=None, timestamp=100)
+        self.assert_equal_telemetry('report:123.5|h\n', self.recv(2))
+
+        self.statsd._reset_telemetry()
+        self.statsd._report('set', 's', 123, tags=None, sample_rate=None, timestamp=100)
+        self.assert_equal_telemetry('set:123|s\n', self.recv(2))
+
     def test_gauge(self):
         self.statsd.gauge('gauge', 123.4)
         self.assert_equal_telemetry('gauge:123.4|g\n', self.recv(2))


### PR DESCRIPTION
### What does this PR do?

Following [v1.3 protocol](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v13), allow passing timestamps along with the metric, which can mitigate the load on the agent when emitting a lot of metrics in a short time span.

### Description of the Change

Adds `gauge_with_timestamp` and `count_with_timestamp` to allow for passing metrics with timestamps. Also added `count` method which other clients have so that our clients all have similar methods.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

