### PR TITLE
add metric object type

### DIFF
--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -1,4 +1,5 @@
-from threading import Lock
+# TODO: potentially add locks
+# from threading import Lock
 
 
 class MetricAggregator(object):
@@ -10,8 +11,9 @@ class MetricAggregator(object):
     def aggregate(self, value):
         raise NotImplementedError("Subclasses should implement this method.")
 
-    def flush_unsafe(self):
-        raise NotImplementedError("Subclasses should implement this method.")
+    # TODO: potentially add this function
+    # def flush_unsafe(self):
+    #     raise NotImplementedError("Subclasses should implement this method.")
 
 
 class CountMetric(MetricAggregator):
@@ -22,14 +24,15 @@ class CountMetric(MetricAggregator):
     def aggregate(self, v):
         self.value += v
 
-    def flush_unsafe(self):
-        return {
-            "metric_type": "count",
-            "name": self.name,
-            "tags": self.tags,
-            "rate": self.rate,
-            "ivalue": self.value,
-        }
+    # TODO: potentially add this function
+    # def flush_unsafe(self):
+    #     return {
+    #         "metric_type": "count",
+    #         "name": self.name,
+    #         "tags": self.tags,
+    #         "rate": self.rate,
+    #         "ivalue": self.value,
+    #     }
 
 
 class GaugeMetric(MetricAggregator):
@@ -40,14 +43,15 @@ class GaugeMetric(MetricAggregator):
     def aggregate(self, v):
         self.value = v
 
-    def flush_unsafe(self):
-        return {
-            "metric_type": "gauge",
-            "name": self.name,
-            "tags": self.tags,
-            "rate": self.rate,
-            "fvalue": self.value,
-        }
+    # TODO: potentially add this function
+    # def flush_unsafe(self):
+    #     return {
+    #         "metric_type": "gauge",
+    #         "name": self.name,
+    #         "tags": self.tags,
+    #         "rate": self.rate,
+    #         "fvalue": self.value,
+    #     }
 
 
 class SetMetric(MetricAggregator):
@@ -55,23 +59,25 @@ class SetMetric(MetricAggregator):
         super(SetMetric, self).__init__(name, tags, rate)
         self.data = set()
         self.data.add(value)
-        self.lock = Lock()
+        # TODO: potentially locks
+        # self.lock = Lock()
 
     def aggregate(self, v):
-        with self.lock:
-            self.data.add(v)
+        # with self.lock:
+        #     self.data.add(v)
+        self.data.add(v)
 
-    def flush_unsafe(self):
-        with self.lock:
-            if not self.data:
-                return []
-            return [
-                {
-                    "metric_type": "set",
-                    "name": self.name,
-                    "tags": self.tags,
-                    "rate": self.rate,
-                    "svalue": value,
-                }
-                for value in self.data
-            ]
+    # def flush_unsafe(self):
+    #     with self.lock:
+    #         if not self.data:
+    #             return []
+    #         return [
+    #             {
+    #                 "metric_type": "set",
+    #                 "name": self.name,
+    #                 "tags": self.tags,
+    #                 "rate": self.rate,
+    #                 "svalue": value,
+    #             }
+    #             for value in self.data
+    #         ]

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -1,11 +1,11 @@
 from threading import Lock
 
-class MetricAggregator:
+class MetricAggregator(object):
     def __init__(self, name, tags, rate):
         self.name = name
         self.tags = tags
         self.rate = rate
-
+ 
     def aggregate(self, value):
         raise NotImplementedError("Subclasses should implement this method.")
 
@@ -14,7 +14,7 @@ class MetricAggregator:
 
 class CountMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate):
-        super().__init__(name, tags, rate)
+        super(CountMetric, self).__init__(name, tags, rate)
         self.value = value
 
     def aggregate(self, v):
@@ -31,7 +31,7 @@ class CountMetric(MetricAggregator):
 
 class GaugeMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate):
-        super().__init__(name, tags, rate)
+        super(GaugeMetric, self).__init__(name, tags, rate)
         self.value = value
 
     def aggregate(self, v):
@@ -48,7 +48,7 @@ class GaugeMetric(MetricAggregator):
 
 class SetMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate):
-        super().__init__(name, tags, rate)
+        super(SetMetric, self).__init__(name, tags, rate)
         self.data = set()
         self.data.add(value)
         self.lock = Lock()

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -1,8 +1,9 @@
 class MetricAggregator(object):
-    def __init__(self, name, tags, rate):
+    def __init__(self, name, tags, rate, timestamp=0):
         self.name = name
         self.tags = tags
         self.rate = rate
+        self.timestamp = timestamp
 
     def aggregate(self, value):
         raise NotImplementedError("Subclasses should implement this method.")
@@ -13,8 +14,8 @@ class MetricAggregator(object):
 
 
 class CountMetric(MetricAggregator):
-    def __init__(self, name, value, tags, rate):
-        super(CountMetric, self).__init__(name, tags, rate)
+    def __init__(self, name, value, tags, rate, timestamp=0):
+        super(CountMetric, self).__init__(name, tags, rate, timestamp)
         self.value = value
 
     def aggregate(self, v):
@@ -26,8 +27,8 @@ class CountMetric(MetricAggregator):
 
 
 class GaugeMetric(MetricAggregator):
-    def __init__(self, name, value, tags, rate):
-        super(GaugeMetric, self).__init__(name, tags, rate)
+    def __init__(self, name, value, tags, rate, timestamp=0):
+        super(GaugeMetric, self).__init__(name, tags, rate, timestamp)
         self.value = value
 
     def aggregate(self, v):
@@ -39,8 +40,8 @@ class GaugeMetric(MetricAggregator):
 
 
 class SetMetric(MetricAggregator):
-    def __init__(self, name, value, tags, rate):
-        super(SetMetric, self).__init__(name, tags, rate)
+    def __init__(self, name, value, tags, rate, timestamp=0):
+        super(SetMetric, self).__init__(name, tags, rate, timestamp)
         self.data = set()
         self.data.add(value)
 

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -8,7 +8,7 @@ class MetricAggregator(object):
         raise NotImplementedError("Subclasses should implement this method.")
 
     # TODO: This may be implemented once flushing aggregated metrics is supported
-    def unsafe_flush():
+    def unsafe_flush(self):
         pass
 
 
@@ -21,7 +21,7 @@ class CountMetric(MetricAggregator):
         self.value += v
 
     # TODO: This may be implemented once flushing aggregated metrics is supported
-    def unsafe_flush():
+    def unsafe_flush(self):
         pass
 
 
@@ -34,7 +34,7 @@ class GaugeMetric(MetricAggregator):
         self.value = v
 
     # TODO: This may be implemented once flushing aggregated metrics is supported
-    def unsafe_flush():
+    def unsafe_flush(self):
         pass
 
 
@@ -48,5 +48,5 @@ class SetMetric(MetricAggregator):
         self.data.add(v)
 
     # TODO: This may be implemented once flushing aggregated metrics is supported
-    def unsafe_flush():
+    def unsafe_flush(self):
         pass

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -1,7 +1,3 @@
-# TODO: potentially add locks
-# from threading import Lock
-
-
 class MetricAggregator(object):
     def __init__(self, name, tags, rate):
         self.name = name
@@ -11,9 +7,9 @@ class MetricAggregator(object):
     def aggregate(self, value):
         raise NotImplementedError("Subclasses should implement this method.")
 
-    # TODO: potentially add this function
-    # def flush_unsafe(self):
-    #     raise NotImplementedError("Subclasses should implement this method.")
+    # TODO: This may be implemented once flushing aggregated metrics is supported
+    def unsafe_flush():
+        pass
 
 
 class CountMetric(MetricAggregator):
@@ -24,15 +20,9 @@ class CountMetric(MetricAggregator):
     def aggregate(self, v):
         self.value += v
 
-    # TODO: potentially add this function
-    # def flush_unsafe(self):
-    #     return {
-    #         "metric_type": "count",
-    #         "name": self.name,
-    #         "tags": self.tags,
-    #         "rate": self.rate,
-    #         "ivalue": self.value,
-    #     }
+    # TODO: This may be implemented once flushing aggregated metrics is supported
+    def unsafe_flush():
+        pass
 
 
 class GaugeMetric(MetricAggregator):
@@ -43,15 +33,9 @@ class GaugeMetric(MetricAggregator):
     def aggregate(self, v):
         self.value = v
 
-    # TODO: potentially add this function
-    # def flush_unsafe(self):
-    #     return {
-    #         "metric_type": "gauge",
-    #         "name": self.name,
-    #         "tags": self.tags,
-    #         "rate": self.rate,
-    #         "fvalue": self.value,
-    #     }
+    # TODO: This may be implemented once flushing aggregated metrics is supported
+    def unsafe_flush():
+        pass
 
 
 class SetMetric(MetricAggregator):
@@ -59,25 +43,10 @@ class SetMetric(MetricAggregator):
         super(SetMetric, self).__init__(name, tags, rate)
         self.data = set()
         self.data.add(value)
-        # TODO: potentially locks
-        # self.lock = Lock()
 
     def aggregate(self, v):
-        # with self.lock:
-        #     self.data.add(v)
         self.data.add(v)
 
-    # def flush_unsafe(self):
-    #     with self.lock:
-    #         if not self.data:
-    #             return []
-    #         return [
-    #             {
-    #                 "metric_type": "set",
-    #                 "name": self.name,
-    #                 "tags": self.tags,
-    #                 "rate": self.rate,
-    #                 "svalue": value,
-    #             }
-    #             for value in self.data
-    #         ]
+    # TODO: This may be implemented once flushing aggregated metrics is supported
+    def unsafe_flush():
+        pass

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -1,16 +1,18 @@
 from threading import Lock
 
+
 class MetricAggregator(object):
     def __init__(self, name, tags, rate):
         self.name = name
         self.tags = tags
         self.rate = rate
- 
+
     def aggregate(self, value):
         raise NotImplementedError("Subclasses should implement this method.")
 
     def flush_unsafe(self):
         raise NotImplementedError("Subclasses should implement this method.")
+
 
 class CountMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate):
@@ -22,12 +24,13 @@ class CountMetric(MetricAggregator):
 
     def flush_unsafe(self):
         return {
-            'metric_type': 'count',
-            'name': self.name,
-            'tags': self.tags,
-            'rate': self.rate,
-            'ivalue': self.value,
+            "metric_type": "count",
+            "name": self.name,
+            "tags": self.tags,
+            "rate": self.rate,
+            "ivalue": self.value,
         }
+
 
 class GaugeMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate):
@@ -39,12 +42,13 @@ class GaugeMetric(MetricAggregator):
 
     def flush_unsafe(self):
         return {
-            'metric_type': 'gauge',
-            'name': self.name,
-            'tags': self.tags,
-            'rate': self.rate,
-            'fvalue': self.value,
+            "metric_type": "gauge",
+            "name": self.name,
+            "tags": self.tags,
+            "rate": self.rate,
+            "fvalue": self.value,
         }
+
 
 class SetMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate):
@@ -63,11 +67,11 @@ class SetMetric(MetricAggregator):
                 return []
             return [
                 {
-                    'metric_type': 'set',
-                    'name': self.name,
-                    'tags': self.tags,
-                    'rate': self.rate,
-                    'svalue': value,
+                    "metric_type": "set",
+                    "name": self.name,
+                    "tags": self.tags,
+                    "rate": self.rate,
+                    "svalue": value,
                 }
                 for value in self.data
             ]

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -1,0 +1,73 @@
+from threading import Lock
+
+class MetricAggregator:
+    def __init__(self, name, tags, rate):
+        self.name = name
+        self.tags = tags
+        self.rate = rate
+
+    def aggregate(self, value):
+        raise NotImplementedError("Subclasses should implement this method.")
+
+    def flush_unsafe(self):
+        raise NotImplementedError("Subclasses should implement this method.")
+
+class CountMetric(MetricAggregator):
+    def __init__(self, name, value, tags, rate):
+        super().__init__(name, tags, rate)
+        self.value = value
+
+    def aggregate(self, v):
+        self.value += v
+
+    def flush_unsafe(self):
+        return {
+            'metric_type': 'count',
+            'name': self.name,
+            'tags': self.tags,
+            'rate': self.rate,
+            'ivalue': self.value,
+        }
+
+class GaugeMetric(MetricAggregator):
+    def __init__(self, name, value, tags, rate):
+        super().__init__(name, tags, rate)
+        self.value = value
+
+    def aggregate(self, v):
+        self.value = v
+
+    def flush_unsafe(self):
+        return {
+            'metric_type': 'gauge',
+            'name': self.name,
+            'tags': self.tags,
+            'rate': self.rate,
+            'fvalue': self.value,
+        }
+
+class SetMetric(MetricAggregator):
+    def __init__(self, name, value, tags, rate):
+        super().__init__(name, tags, rate)
+        self.data = set()
+        self.data.add(value)
+        self.lock = Lock()
+
+    def aggregate(self, v):
+        with self.lock:
+            self.data.add(v)
+
+    def flush_unsafe(self):
+        with self.lock:
+            if not self.data:
+                return []
+            return [
+                {
+                    'metric_type': 'set',
+                    'name': self.name,
+                    'tags': self.tags,
+                    'rate': self.rate,
+                    'svalue': value,
+                }
+                for value in self.data
+            ]

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -7,7 +7,7 @@ class MetricAggregator(object):
     def aggregate(self, value):
         raise NotImplementedError("Subclasses should implement this method.")
 
-    # TODO: This may be implemented once flushing aggregated metrics is supported
+    # TODO: This may be implemented if flushing aggregated metrics is supported
     def unsafe_flush(self):
         pass
 
@@ -20,7 +20,7 @@ class CountMetric(MetricAggregator):
     def aggregate(self, v):
         self.value += v
 
-    # TODO: This may be implemented once flushing aggregated metrics is supported
+    # TODO: This may be implemented if flushing aggregated metrics is supported
     def unsafe_flush(self):
         pass
 

--- a/tests/unit/dogstatsd/test_metrics.py
+++ b/tests/unit/dogstatsd/test_metrics.py
@@ -10,7 +10,7 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(c.tags, ["tag1", "tag2"])
         self.assertEqual(c.rate, 1.0)
         self.assertEqual(c.timestamp, 1713804588)
-
+        # Testing for default timestamp may be unecessary
         c_default_timestamp = CountMetric("test", 21, ["tag1", "tag2"], 1)
         self.assertEqual(c_default_timestamp.value, 21)
         self.assertEqual(c_default_timestamp.name, "test")

--- a/tests/unit/dogstatsd/test_metrics.py
+++ b/tests/unit/dogstatsd/test_metrics.py
@@ -4,50 +4,77 @@ from datadog.dogstatsd.metrics import CountMetric, GaugeMetric, SetMetric
 
 class TestMetrics(unittest.TestCase):
     def test_new_count_metric(self):
-        c = CountMetric("test", 21, ["tag1", "tag2"], 1)
+        c = CountMetric("test", 21, ["tag1", "tag2"], 1, 1713804588)
         self.assertEqual(c.value, 21)
         self.assertEqual(c.name, "test")
         self.assertEqual(c.tags, ["tag1", "tag2"])
         self.assertEqual(c.rate, 1.0)
+        self.assertEqual(c.timestamp, 1713804588)
+
+        c_default_timestamp = CountMetric("test", 21, ["tag1", "tag2"], 1)
+        self.assertEqual(c_default_timestamp.value, 21)
+        self.assertEqual(c_default_timestamp.name, "test")
+        self.assertEqual(c_default_timestamp.tags, ["tag1", "tag2"])
+        self.assertEqual(c_default_timestamp.rate, 1.0)
+        self.assertEqual(c_default_timestamp.timestamp, 0)
 
     def test_count_metric_aggregate(self):
-        c = CountMetric("test", 10, ["tag1", "tag2"], 1)
+        c = CountMetric("test", 10, ["tag1", "tag2"], 1, 1713804588)
         c.aggregate(20)
         self.assertEqual(c.value, 30)
         self.assertEqual(c.name, "test")
         self.assertEqual(c.tags, ["tag1", "tag2"])
-        self.assertEqual(c.rate, 1.0)    
+        self.assertEqual(c.rate, 1.0)
+        self.assertEqual(c.timestamp, 1713804588)
 
     def test_new_gauge_metric(self):
-        g = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
+        g = GaugeMetric("test", 10, ["tag1", "tag2"], 1, 1713804588)
         self.assertEqual(g.value, 10)
         self.assertEqual(g.name, "test")
         self.assertEqual(g.tags, ["tag1", "tag2"])
         self.assertEqual(g.rate, 1)
+        self.assertEqual(g.timestamp, 1713804588)
+
+        g_default_timestamp = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
+        self.assertEqual(g_default_timestamp.value, 10)
+        self.assertEqual(g_default_timestamp.name, "test")
+        self.assertEqual(g_default_timestamp.tags, ["tag1", "tag2"])
+        self.assertEqual(g_default_timestamp.rate, 1)
+        self.assertEqual(g_default_timestamp.timestamp, 0)
 
     def test_gauge_metric_aggregate(self):
-        g = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
+        g = GaugeMetric("test", 10, ["tag1", "tag2"], 1, 1713804588)
         g.aggregate(20)
         self.assertEqual(g.value, 20)
         self.assertEqual(g.name, "test")
         self.assertEqual(g.tags, ["tag1", "tag2"])
         self.assertEqual(g.rate, 1.0)
+        self.assertEqual(g.timestamp, 1713804588)
 
     def test_new_set_metric(self):
-        s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
+        s = SetMetric("test", "value1", ["tag1", "tag2"], 1, 1713804588)
         self.assertEqual(s.data, {"value1"})
         self.assertEqual(s.name, "test")
         self.assertEqual(s.tags, ["tag1", "tag2"])
         self.assertEqual(s.rate, 1)
+        self.assertEqual(s.timestamp, 1713804588)
+
+        s_default_timestamp = SetMetric("test", "value1", ["tag1", "tag2"], 1)
+        self.assertEqual(s_default_timestamp.data, {"value1"})
+        self.assertEqual(s_default_timestamp.name, "test")
+        self.assertEqual(s_default_timestamp.tags, ["tag1", "tag2"])
+        self.assertEqual(s_default_timestamp.rate, 1)
+        self.assertEqual(s_default_timestamp.timestamp, 0)
 
     def test_set_metric_aggregate(self):
-        s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
+        s = SetMetric("test", "value1", ["tag1", "tag2"], 1, 1713804588)
         s.aggregate("value2")
         s.aggregate("value2")
         self.assertEqual(s.data, {"value1", "value2"})
         self.assertEqual(s.name, "test")
         self.assertEqual(s.tags, ["tag1", "tag2"])
         self.assertEqual(s.rate, 1)
+        self.assertEqual(s.timestamp, 1713804588)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/dogstatsd/test_metrics.py
+++ b/tests/unit/dogstatsd/test_metrics.py
@@ -1,0 +1,117 @@
+import unittest
+
+from datadog.dogstatsd.metrics import CountMetric, GaugeMetric, SetMetric
+
+class TestMetrics(unittest.TestCase):
+
+    def test_new_count_metric(self):
+        c = CountMetric("test", 21, ["tag1", "tag2"], 1)
+        self.assertEqual(c.value, 21)
+        self.assertEqual(c.name, "test")
+        self.assertEqual(c.tags, ["tag1", "tag2"])
+        self.assertEqual(c.rate, 1.0)
+
+    def test_count_metric_aggregate(self):
+        c = CountMetric("test", 10, ["tag1", "tag2"], 1)
+        c.aggregate(20)
+        self.assertEqual(c.value, 30)
+        self.assertEqual(c.name, "test")
+        self.assertEqual(c.tags, ["tag1", "tag2"])
+        self.assertEqual(c.rate, 1.0)
+
+    def test_flush_unsafe_count_metric(self):
+        c = CountMetric("test", 10, ["tag1", "tag2"], 1)
+        m = c.flush_unsafe()
+        self.assertEqual(m['metric_type'], 'count')
+        self.assertEqual(m['ivalue'], 10)
+        self.assertEqual(m['name'], "test")
+        self.assertEqual(m['tags'], ["tag1", "tag2"])
+        self.assertEqual(m['rate'], 1)
+
+        c.aggregate(20)
+        m = c.flush_unsafe()
+        self.assertEqual(m['metric_type'], 'count')
+        self.assertEqual(m['ivalue'], 30)
+        self.assertEqual(m['name'], "test")
+        self.assertEqual(m['tags'], ["tag1", "tag2"])
+        self.assertEqual(m['rate'], 1.0)
+
+    def test_new_gauge_metric(self):
+        g = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
+        self.assertEqual(g.value, 10)
+        self.assertEqual(g.name, "test")
+        self.assertEqual(g.tags, ["tag1", "tag2"])
+        self.assertEqual(g.rate, 1)
+
+    def test_gauge_metric_aggregate(self):
+        g = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
+        g.aggregate(20)
+        self.assertEqual(g.value, 20)
+        self.assertEqual(g.name, "test")
+        self.assertEqual(g.tags, ["tag1", "tag2"])
+        self.assertEqual(g.rate, 1.0)
+
+    def test_flush_unsafe_gauge_metric(self):
+        g = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
+        m = g.flush_unsafe()
+        self.assertEqual(m['metric_type'], 'gauge')
+        self.assertEqual(m['fvalue'], 10)
+        self.assertEqual(m['name'], "test")
+        self.assertEqual(m['tags'], ["tag1", "tag2"])
+        self.assertEqual(m['rate'], 1)
+
+        g.aggregate(20)
+        m = g.flush_unsafe()
+        self.assertEqual(m['metric_type'], 'gauge')
+        self.assertEqual(m['fvalue'], 20)
+        self.assertEqual(m['name'], "test")
+        self.assertEqual(m['tags'], ["tag1", "tag2"])
+        self.assertEqual(m['rate'], 1)
+
+    def test_new_set_metric(self):
+        s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
+        self.assertEqual(s.data, {"value1"})
+        self.assertEqual(s.name, "test")
+        self.assertEqual(s.tags, ["tag1", "tag2"])
+        self.assertEqual(s.rate, 1)
+
+    def test_set_metric_aggregate(self):
+        s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
+        s.aggregate("value2")
+        s.aggregate("value2")
+        self.assertEqual(s.data, {"value1", "value2"})
+        self.assertEqual(s.name, "test")
+        self.assertEqual(s.tags, ["tag1", "tag2"])
+        self.assertEqual(s.rate, 1)
+
+    def test_flush_unsafe_set_metric(self):
+        s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
+        m = s.flush_unsafe()
+
+        self.assertEqual(len(m), 1)
+        self.assertEqual(m[0]['metric_type'], 'set')
+        self.assertEqual(m[0]['svalue'], "value1")
+        self.assertEqual(m[0]['name'], "test")
+        self.assertEqual(m[0]['tags'], ["tag1", "tag2"])
+        self.assertEqual(m[0]['rate'], 1)
+
+        s.aggregate("value1")
+        s.aggregate("value2")
+        m = s.flush_unsafe()
+
+        m = sorted(m, key=lambda x: x['svalue'])
+
+        self.assertEqual(len(m), 2)
+        self.assertEqual(m[0]['metric_type'], 'set')
+        self.assertEqual(m[0]['svalue'], "value1")
+        self.assertEqual(m[0]['name'], "test")
+        self.assertEqual(m[0]['tags'], ["tag1", "tag2"])
+        self.assertEqual(m[0]['rate'], 1)
+        self.assertEqual(m[1]['metric_type'], 'set')
+        self.assertEqual(m[1]['svalue'], "value2")
+        self.assertEqual(m[1]['name'], "test")
+        self.assertEqual(m[1]['tags'], ["tag1", "tag2"])
+        self.assertEqual(m[1]['rate'], 1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/dogstatsd/test_metrics.py
+++ b/tests/unit/dogstatsd/test_metrics.py
@@ -3,7 +3,7 @@ import unittest
 from datadog.dogstatsd.metrics import CountMetric, GaugeMetric, SetMetric
 
 class TestMetrics(unittest.TestCase):
-
+    # TODO: potentially test flush_unsafe and locks
     def test_new_count_metric(self):
         c = CountMetric("test", 21, ["tag1", "tag2"], 1)
         self.assertEqual(c.value, 21)
@@ -19,22 +19,22 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(c.tags, ["tag1", "tag2"])
         self.assertEqual(c.rate, 1.0)
 
-    def test_flush_unsafe_count_metric(self):
-        c = CountMetric("test", 10, ["tag1", "tag2"], 1)
-        m = c.flush_unsafe()
-        self.assertEqual(m['metric_type'], 'count')
-        self.assertEqual(m['ivalue'], 10)
-        self.assertEqual(m['name'], "test")
-        self.assertEqual(m['tags'], ["tag1", "tag2"])
-        self.assertEqual(m['rate'], 1)
+    # def test_flush_unsafe_count_metric(self):
+    #     c = CountMetric("test", 10, ["tag1", "tag2"], 1)
+    #     m = c.flush_unsafe()
+    #     self.assertEqual(m['metric_type'], 'count')
+    #     self.assertEqual(m['ivalue'], 10)
+    #     self.assertEqual(m['name'], "test")
+    #     self.assertEqual(m['tags'], ["tag1", "tag2"])
+    #     self.assertEqual(m['rate'], 1)
 
-        c.aggregate(20)
-        m = c.flush_unsafe()
-        self.assertEqual(m['metric_type'], 'count')
-        self.assertEqual(m['ivalue'], 30)
-        self.assertEqual(m['name'], "test")
-        self.assertEqual(m['tags'], ["tag1", "tag2"])
-        self.assertEqual(m['rate'], 1.0)
+    #     c.aggregate(20)
+    #     m = c.flush_unsafe()
+    #     self.assertEqual(m['metric_type'], 'count')
+    #     self.assertEqual(m['ivalue'], 30)
+    #     self.assertEqual(m['name'], "test")
+    #     self.assertEqual(m['tags'], ["tag1", "tag2"])
+    #     self.assertEqual(m['rate'], 1.0)
 
     def test_new_gauge_metric(self):
         g = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
@@ -51,22 +51,22 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(g.tags, ["tag1", "tag2"])
         self.assertEqual(g.rate, 1.0)
 
-    def test_flush_unsafe_gauge_metric(self):
-        g = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
-        m = g.flush_unsafe()
-        self.assertEqual(m['metric_type'], 'gauge')
-        self.assertEqual(m['fvalue'], 10)
-        self.assertEqual(m['name'], "test")
-        self.assertEqual(m['tags'], ["tag1", "tag2"])
-        self.assertEqual(m['rate'], 1)
+    # def test_flush_unsafe_gauge_metric(self):
+    #     g = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
+    #     m = g.flush_unsafe()
+    #     self.assertEqual(m['metric_type'], 'gauge')
+    #     self.assertEqual(m['fvalue'], 10)
+    #     self.assertEqual(m['name'], "test")
+    #     self.assertEqual(m['tags'], ["tag1", "tag2"])
+    #     self.assertEqual(m['rate'], 1)
 
-        g.aggregate(20)
-        m = g.flush_unsafe()
-        self.assertEqual(m['metric_type'], 'gauge')
-        self.assertEqual(m['fvalue'], 20)
-        self.assertEqual(m['name'], "test")
-        self.assertEqual(m['tags'], ["tag1", "tag2"])
-        self.assertEqual(m['rate'], 1)
+    #     g.aggregate(20)
+    #     m = g.flush_unsafe()
+    #     self.assertEqual(m['metric_type'], 'gauge')
+    #     self.assertEqual(m['fvalue'], 20)
+    #     self.assertEqual(m['name'], "test")
+    #     self.assertEqual(m['tags'], ["tag1", "tag2"])
+    #     self.assertEqual(m['rate'], 1)
 
     def test_new_set_metric(self):
         s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
@@ -84,34 +84,34 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(s.tags, ["tag1", "tag2"])
         self.assertEqual(s.rate, 1)
 
-    def test_flush_unsafe_set_metric(self):
-        s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
-        m = s.flush_unsafe()
+    # def test_flush_unsafe_set_metric(self):
+    #     s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
+    #     m = s.flush_unsafe()
 
-        self.assertEqual(len(m), 1)
-        self.assertEqual(m[0]['metric_type'], 'set')
-        self.assertEqual(m[0]['svalue'], "value1")
-        self.assertEqual(m[0]['name'], "test")
-        self.assertEqual(m[0]['tags'], ["tag1", "tag2"])
-        self.assertEqual(m[0]['rate'], 1)
+    #     self.assertEqual(len(m), 1)
+    #     self.assertEqual(m[0]['metric_type'], 'set')
+    #     self.assertEqual(m[0]['svalue'], "value1")
+    #     self.assertEqual(m[0]['name'], "test")
+    #     self.assertEqual(m[0]['tags'], ["tag1", "tag2"])
+    #     self.assertEqual(m[0]['rate'], 1)
 
-        s.aggregate("value1")
-        s.aggregate("value2")
-        m = s.flush_unsafe()
+    #     s.aggregate("value1")
+    #     s.aggregate("value2")
+    #     m = s.flush_unsafe()
 
-        m = sorted(m, key=lambda x: x['svalue'])
+    #     m = sorted(m, key=lambda x: x['svalue'])
 
-        self.assertEqual(len(m), 2)
-        self.assertEqual(m[0]['metric_type'], 'set')
-        self.assertEqual(m[0]['svalue'], "value1")
-        self.assertEqual(m[0]['name'], "test")
-        self.assertEqual(m[0]['tags'], ["tag1", "tag2"])
-        self.assertEqual(m[0]['rate'], 1)
-        self.assertEqual(m[1]['metric_type'], 'set')
-        self.assertEqual(m[1]['svalue'], "value2")
-        self.assertEqual(m[1]['name'], "test")
-        self.assertEqual(m[1]['tags'], ["tag1", "tag2"])
-        self.assertEqual(m[1]['rate'], 1)
+    #     self.assertEqual(len(m), 2)
+    #     self.assertEqual(m[0]['metric_type'], 'set')
+    #     self.assertEqual(m[0]['svalue'], "value1")
+    #     self.assertEqual(m[0]['name'], "test")
+    #     self.assertEqual(m[0]['tags'], ["tag1", "tag2"])
+    #     self.assertEqual(m[0]['rate'], 1)
+    #     self.assertEqual(m[1]['metric_type'], 'set')
+    #     self.assertEqual(m[1]['svalue'], "value2")
+    #     self.assertEqual(m[1]['name'], "test")
+    #     self.assertEqual(m[1]['tags'], ["tag1", "tag2"])
+    #     self.assertEqual(m[1]['rate'], 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/dogstatsd/test_metrics.py
+++ b/tests/unit/dogstatsd/test_metrics.py
@@ -3,7 +3,6 @@ import unittest
 from datadog.dogstatsd.metrics import CountMetric, GaugeMetric, SetMetric
 
 class TestMetrics(unittest.TestCase):
-    # TODO: potentially test flush_unsafe and locks
     def test_new_count_metric(self):
         c = CountMetric("test", 21, ["tag1", "tag2"], 1)
         self.assertEqual(c.value, 21)
@@ -17,24 +16,7 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(c.value, 30)
         self.assertEqual(c.name, "test")
         self.assertEqual(c.tags, ["tag1", "tag2"])
-        self.assertEqual(c.rate, 1.0)
-
-    # def test_flush_unsafe_count_metric(self):
-    #     c = CountMetric("test", 10, ["tag1", "tag2"], 1)
-    #     m = c.flush_unsafe()
-    #     self.assertEqual(m['metric_type'], 'count')
-    #     self.assertEqual(m['ivalue'], 10)
-    #     self.assertEqual(m['name'], "test")
-    #     self.assertEqual(m['tags'], ["tag1", "tag2"])
-    #     self.assertEqual(m['rate'], 1)
-
-    #     c.aggregate(20)
-    #     m = c.flush_unsafe()
-    #     self.assertEqual(m['metric_type'], 'count')
-    #     self.assertEqual(m['ivalue'], 30)
-    #     self.assertEqual(m['name'], "test")
-    #     self.assertEqual(m['tags'], ["tag1", "tag2"])
-    #     self.assertEqual(m['rate'], 1.0)
+        self.assertEqual(c.rate, 1.0)    
 
     def test_new_gauge_metric(self):
         g = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
@@ -51,23 +33,6 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(g.tags, ["tag1", "tag2"])
         self.assertEqual(g.rate, 1.0)
 
-    # def test_flush_unsafe_gauge_metric(self):
-    #     g = GaugeMetric("test", 10, ["tag1", "tag2"], 1)
-    #     m = g.flush_unsafe()
-    #     self.assertEqual(m['metric_type'], 'gauge')
-    #     self.assertEqual(m['fvalue'], 10)
-    #     self.assertEqual(m['name'], "test")
-    #     self.assertEqual(m['tags'], ["tag1", "tag2"])
-    #     self.assertEqual(m['rate'], 1)
-
-    #     g.aggregate(20)
-    #     m = g.flush_unsafe()
-    #     self.assertEqual(m['metric_type'], 'gauge')
-    #     self.assertEqual(m['fvalue'], 20)
-    #     self.assertEqual(m['name'], "test")
-    #     self.assertEqual(m['tags'], ["tag1", "tag2"])
-    #     self.assertEqual(m['rate'], 1)
-
     def test_new_set_metric(self):
         s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
         self.assertEqual(s.data, {"value1"})
@@ -83,35 +48,6 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(s.name, "test")
         self.assertEqual(s.tags, ["tag1", "tag2"])
         self.assertEqual(s.rate, 1)
-
-    # def test_flush_unsafe_set_metric(self):
-    #     s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
-    #     m = s.flush_unsafe()
-
-    #     self.assertEqual(len(m), 1)
-    #     self.assertEqual(m[0]['metric_type'], 'set')
-    #     self.assertEqual(m[0]['svalue'], "value1")
-    #     self.assertEqual(m[0]['name'], "test")
-    #     self.assertEqual(m[0]['tags'], ["tag1", "tag2"])
-    #     self.assertEqual(m[0]['rate'], 1)
-
-    #     s.aggregate("value1")
-    #     s.aggregate("value2")
-    #     m = s.flush_unsafe()
-
-    #     m = sorted(m, key=lambda x: x['svalue'])
-
-    #     self.assertEqual(len(m), 2)
-    #     self.assertEqual(m[0]['metric_type'], 'set')
-    #     self.assertEqual(m[0]['svalue'], "value1")
-    #     self.assertEqual(m[0]['name'], "test")
-    #     self.assertEqual(m[0]['tags'], ["tag1", "tag2"])
-    #     self.assertEqual(m[0]['rate'], 1)
-    #     self.assertEqual(m[1]['metric_type'], 'set')
-    #     self.assertEqual(m[1]['svalue'], "value2")
-    #     self.assertEqual(m[1]['name'], "test")
-    #     self.assertEqual(m[1]['tags'], ["tag1", "tag2"])
-    #     self.assertEqual(m[1]['rate'], 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What does this PR do?

<!-- 

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

This PR is for adding metric objects that will make aggregation easier by allowing us to have one Metric object instantiation for each [unique metric context](https://docs.google.com/document/d/1AoveWKoMQc65hYbvZ27uE7pQ_I5nsGfvv25EcNVPLvQ/edit#heading=h.no4x6fjugsh) that we can add samples to which will make aggregation easier. Existing behavior already exists in the [client side aggregation for GO ](https://github.com/DataDog/datadog-go/pull/139/files#diff-768b1bb89feaa2e5fedd4162f84c59c801610960af421ebd18e744d3f0adaa94)



### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Create metric object type (`MetricAgggregator`) that other metric objects (`CountMetric`, `GaugeMetric`, etc.) implement that will enforce the objects to implement functions `aggregate` and **potentially** `flush_unsafe`. This should also allow us to group the different metric types together in one list to be sent when we [flush the metrics](https://github.com/DataDog/datadog-go/blob/0b67271aa15f5531a429d7d4598c705afefb4a55/statsd/aggregator.go#L70).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Some future metrics may not have the necessary fields to be of type `MetricAggregator`

<img width="343" alt="image" src="https://github.com/DataDog/datadogpy/assets/171708865/6972ccca-abbb-4d03-8f7b-2b0e89277742">

The existing code for flushing metrics does NOT use object oriented programming, as a result they have duplicate code for each metric type. 
<img width="438" alt="image" src="https://github.com/DataDog/datadogpy/assets/171708865/2ff6fa05-62f3-4655-8c1a-325648ea76ea">

Maybe i'm missing the potential drawbacks to using object oriented programming (specifically inheritance)? 

**Update:** 
<img width="1135" alt="image" src="https://github.com/DataDog/datadogpy/assets/171708865/a9415af9-8b00-427b-ad6e-bcaf575acb90">


### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.
The unit tests can be run using 
-->

Unit tests that verify the new metric objects match the existing behavior in the [client side aggregator for Go](url).


### Additional Notes

<!-- Anything else we should know when reviewing? -->
The[ python dogstatsd API](https://github.com/DataDog/datadogpy/blob/master/datadog/dogstatsd/base.py) will need to be refactored in the future to use these metric objects.

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->
N/A, no new behavior until the aggregator class is implemented

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

