### PR TITLE
add aggregator 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - master
   pull_request:
     branches:
-    - master
+    - '*' # TODO: Revert when merged to master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -1,0 +1,86 @@
+import threading
+import time
+from enum import Enum
+
+from datadog.dogstatsd.metrics import MetricAggregator, CountMetric, GaugeMetric, SetMetric
+from datadog.dogstatsd import DogStatsd
+
+class MetricType(Enum):
+    COUNT = 'c'
+    GAUGE = 'g'
+    SET = 's'
+
+class Aggregator(object):
+    def __init__(self, client: DogStatsd):
+        self.client = client
+
+        self.metrics_map = {
+            MetricType.COUNT: {},
+            MetricType.GAUGE: {},
+            MetricType.SET: {}
+        }
+        self.locks = {
+            MetricType.COUNT: threading.RLock(),
+            MetricType.GAUGE: threading.RLock(),
+            MetricType.SET: threading.RLock()
+        }
+
+        self.closed = threading.Event()
+        self.exited = threading.Event()
+
+    def start(self, flush_interval):
+        self.flush_interval = flush_interval
+        self.ticker = threading.Timer(self.flush_interval, self.tick)
+        self.ticker.start()
+
+    def tick(self):
+        while not self.closed.is_set():
+            self.send_metrics()
+            time.sleep(self.flush_interval)
+        self.exited.set()
+
+    def send_metrics(self):
+        for metric in self.flush_metrics():
+            # TODO: change the _report function in base.py to handle new data
+            serialized_metric = self.client._serialize_metric(metric.name, metric.type, metric.value, metric.tags, metric)
+            self.client._report(serialized_metric)
+
+    def stop(self):
+        self.closed.set()
+        self.ticker.cancel()
+        self.exited.wait()
+        self.send_metrics()
+
+    def flush_metrics(self):
+        metrics = []
+
+        for metric_type in self.metrics_map.keys():
+            with self.locks[metric_type]:
+                current_metrics = self.metrics_map[metric_type]
+                self.metrics_map[metric_type] = {}
+
+            # TODO: the data type for unsafe_flush still needs to be decided.
+            for metric in current_metrics.values():
+                metrics.extend(metric if isinstance(metric, SetMetric) else [metric])
+
+        return metrics
+
+    def get_context(self, name, tags):
+        return "{}:{}".format(name, ",".join(tags))
+
+    def count(self, name, value, tags, rate, timestamp=0):
+        return self.add_metric(MetricType.COUNT, CountMetric, name, value, tags, rate, timestamp)
+
+    def gauge(self, name, value, tags, rate, timestamp=0):
+        return self.add_metric(MetricType.GAUGE, GaugeMetric, name, value, tags, rate, timestamp)
+
+    def set(self, name, value, tags, rate, timestamp=0):
+        return self.add_metric(MetricType.SET, SetMetric, name, value, tags, rate, timestamp)
+
+    def add_metric(self, metric_type: MetricType, metric_class: MetricAggregator, name, value, tags, rate, timestamp=0):
+        context = self.get_context(name, tags)
+        with self.locks[metric_type]:
+            if context in self.metrics_map[metric_type]:
+                self.metrics_map[metric_type][context].aggregate(value)
+            else:
+                self.metrics_map[metric_type][context] = metric_class(name, value, tags, rate, timestamp)

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -15,7 +15,7 @@ class Aggregator(object):
             MetricType.GAUGE: {},
             MetricType.SET: {},
         }
-        self.locks = {
+        self._locks = {
             MetricType.COUNT: threading.RLock(),
             MetricType.GAUGE: threading.RLock(),
             MetricType.SET: threading.RLock(),
@@ -37,7 +37,7 @@ class Aggregator(object):
     def flush_metrics(self):
         metrics = []
         for metric_type in self.metrics_map.keys():
-            with self.locks[metric_type]:
+            with self._locks[metric_type]:
                 current_metrics = self.metrics_map[metric_type]
                 self.metrics_map[metric_type] = {}
             for metric in current_metrics.values():
@@ -66,7 +66,7 @@ class Aggregator(object):
         self, metric_type, metric_class, name, value, tags, rate, timestamp=0
     ):
         context = self.get_context(name, tags)
-        with self.locks[metric_type]:
+        with self._locks[metric_type]:
             if context in self.metrics_map[metric_type]:
                 self.metrics_map[metric_type][context].aggregate(value)
             else:

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -1,5 +1,4 @@
 import threading
-import time
 from datadog.dogstatsd.metrics import (
     CountMetric,
     GaugeMetric,

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -70,7 +70,8 @@ class Aggregator(object):
 
     def add_metric(self, metric_type, metric_class, name, value, tags, rate, timestamp=0):
         context = self.get_context(name, tags)
-        if context in self.metrics_map[metric_type]:
-            self.metrics_map[metric_type][context].aggregate(value)
-        else:
-            self.metrics_map[metric_type][context] = metric_class(name, value, tags, rate, timestamp)
+        with self.locks[metric_type]:
+            if context in self.metrics_map[metric_type]:
+                self.metrics_map[metric_type][context].aggregate(value)
+            else:
+                self.metrics_map[metric_type][context] = metric_class(name, value, tags, rate, timestamp)

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -8,8 +8,7 @@ from datadog.dogstatsd.metric_types import MetricType
 
 
 class Aggregator(object):
-    def __init__(self, client):
-        self.client = client
+    def __init__(self):
         self.metrics_map = {
             MetricType.COUNT: {},
             MetricType.GAUGE: {},
@@ -20,19 +19,6 @@ class Aggregator(object):
             MetricType.GAUGE: threading.RLock(),
             MetricType.SET: threading.RLock(),
         }
-
-    def start(self, flush_interval):
-        self.flush_interval = flush_interval
-        self.client._start_flush_thread(flush_interval, self.send_metrics)
-
-    def stop(self):
-        self.client._stop_flush_thread(self.send_metrics)
-
-    def send_metrics(self):
-        for metric in self.flush_metrics():
-            self.client._report(
-                metric.name, metric.type, metric.value, metric.tags, metric.timestamp
-            )
 
     def flush_metrics(self):
         metrics = []

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -51,7 +51,7 @@ class Aggregator(object):
         self.send_metrics()
 
     def flush_metrics(self):
-        metrics: list[MetricAggregator] = []
+        metrics = []
 
         for metric_type in self.metrics_map.keys():
             with self.locks[metric_type]:

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -1,7 +1,6 @@
 import threading
 import time
 from datadog.dogstatsd.metrics import (
-    MetricAggregator,
     CountMetric,
     GaugeMetric,
     SetMetric,

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -34,8 +34,7 @@ class Aggregator(object):
 
     def send_metrics(self):
         for metric in self.flush_metrics():
-            self.client._report(metric.name, metric.type, metric.value, metric.tags, 
-                timestamp=metric.timestamp if metric.timestamp else 0)
+            self.client._report(metric.name, metric.type, metric.value, metric.tags, metric.timestamp)
 
     def stop(self):
         self.closed.set()
@@ -44,7 +43,7 @@ class Aggregator(object):
         self.send_metrics()
 
     def flush_metrics(self):
-        metrics = []
+        metrics: list[MetricAggregator] = []
 
         for metric_type in self.metrics_map.keys():
             with self.locks[metric_type]:
@@ -52,7 +51,7 @@ class Aggregator(object):
                 self.metrics_map[metric_type] = {}
 
             for metric in current_metrics.values():
-                metrics.extend(metric.unsafe_flush() if isinstance(metric, SetMetric) else [metric.unsafe_flush()])
+                metrics.extend(metric.get_data() if isinstance(metric, SetMetric) else [metric])
 
         return metrics
 

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -1,7 +1,13 @@
 import threading
 import time
-from datadog.dogstatsd.metrics import MetricAggregator, CountMetric, GaugeMetric, SetMetric
+from datadog.dogstatsd.metrics import (
+    MetricAggregator,
+    CountMetric,
+    GaugeMetric,
+    SetMetric,
+)
 from datadog.dogstatsd.metric_types import MetricType
+
 
 class Aggregator(object):
     def __init__(self, client):
@@ -10,12 +16,12 @@ class Aggregator(object):
         self.metrics_map = {
             MetricType.COUNT: {},
             MetricType.GAUGE: {},
-            MetricType.SET: {}
+            MetricType.SET: {},
         }
         self.locks = {
             MetricType.COUNT: threading.RLock(),
             MetricType.GAUGE: threading.RLock(),
-            MetricType.SET: threading.RLock()
+            MetricType.SET: threading.RLock(),
         }
 
         self.closed = threading.Event()
@@ -34,7 +40,9 @@ class Aggregator(object):
 
     def send_metrics(self):
         for metric in self.flush_metrics():
-            self.client._report(metric.name, metric.type, metric.value, metric.tags, metric.timestamp)
+            self.client._report(
+                metric.name, metric.type, metric.value, metric.tags, metric.timestamp
+            )
 
     def stop(self):
         self.closed.set()
@@ -51,7 +59,9 @@ class Aggregator(object):
                 self.metrics_map[metric_type] = {}
 
             for metric in current_metrics.values():
-                metrics.extend(metric.get_data() if isinstance(metric, SetMetric) else [metric])
+                metrics.extend(
+                    metric.get_data() if isinstance(metric, SetMetric) else [metric]
+                )
 
         return metrics
 
@@ -59,18 +69,28 @@ class Aggregator(object):
         return "{}:{}".format(name, ",".join(tags))
 
     def count(self, name, value, tags, rate, timestamp=0):
-        return self.add_metric(MetricType.COUNT, CountMetric, name, value, tags, rate, timestamp)
+        return self.add_metric(
+            MetricType.COUNT, CountMetric, name, value, tags, rate, timestamp
+        )
 
     def gauge(self, name, value, tags, rate, timestamp=0):
-        return self.add_metric(MetricType.GAUGE, GaugeMetric, name, value, tags, rate, timestamp)
+        return self.add_metric(
+            MetricType.GAUGE, GaugeMetric, name, value, tags, rate, timestamp
+        )
 
     def set(self, name, value, tags, rate, timestamp=0):
-        return self.add_metric(MetricType.SET, SetMetric, name, value, tags, rate, timestamp)
+        return self.add_metric(
+            MetricType.SET, SetMetric, name, value, tags, rate, timestamp
+        )
 
-    def add_metric(self, metric_type, metric_class, name, value, tags, rate, timestamp=0):
+    def add_metric(
+        self, metric_type, metric_class, name, value, tags, rate, timestamp=0
+    ):
         context = self.get_context(name, tags)
         with self.locks[metric_type]:
             if context in self.metrics_map[metric_type]:
                 self.metrics_map[metric_type][context].aggregate(value)
             else:
-                self.metrics_map[metric_type][context] = metric_class(name, value, tags, rate, timestamp)
+                self.metrics_map[metric_type][context] = metric_class(
+                    name, value, tags, rate, timestamp
+                )

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -6,6 +6,7 @@ from datadog.dogstatsd.metrics import (
 )
 from datadog.dogstatsd.metric_types import MetricType
 
+
 class Aggregator(object):
     def __init__(self, client):
         self.client = client
@@ -23,7 +24,7 @@ class Aggregator(object):
     def start(self, flush_interval):
         self.flush_interval = flush_interval
         self.client._start_flush_thread(flush_interval, self.send_metrics)
-    
+
     def stop(self):
         self.client._stop_flush_thread()
         self.send_metrics()

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -1,11 +1,10 @@
 import threading
 import time
 from datadog.dogstatsd.metrics import MetricAggregator, CountMetric, GaugeMetric, SetMetric
-from datadog.dogstatsd import DogStatsd
 from datadog.dogstatsd.metric_types import MetricType
 
 class Aggregator(object):
-    def __init__(self, client: DogStatsd):
+    def __init__(self, client):
         self.client = client
 
         self.metrics_map = {
@@ -69,7 +68,7 @@ class Aggregator(object):
     def set(self, name, value, tags, rate, timestamp=0):
         return self.add_metric(MetricType.SET, SetMetric, name, value, tags, rate, timestamp)
 
-    def add_metric(self, metric_type: MetricType, metric_class: MetricAggregator, name, value, tags, rate, timestamp=0):
+    def add_metric(self, metric_type, metric_class, name, value, tags, rate, timestamp=0):
         context = self.get_context(name, tags)
         with self.locks[metric_type]:
             if context in self.metrics_map[metric_type]:

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -26,8 +26,7 @@ class Aggregator(object):
         self.client._start_flush_thread(flush_interval, self.send_metrics)
 
     def stop(self):
-        self.client._stop_flush_thread()
-        self.send_metrics()
+        self.client._stop_flush_thread(self.send_metrics)
 
     def send_metrics(self):
         for metric in self.flush_metrics():

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -70,8 +70,7 @@ class Aggregator(object):
 
     def add_metric(self, metric_type, metric_class, name, value, tags, rate, timestamp=0):
         context = self.get_context(name, tags)
-        with self.locks[metric_type]:
-            if context in self.metrics_map[metric_type]:
-                self.metrics_map[metric_type][context].aggregate(value)
-            else:
-                self.metrics_map[metric_type][context] = metric_class(name, value, tags, rate, timestamp)
+        if context in self.metrics_map[metric_type]:
+            self.metrics_map[metric_type][context].aggregate(value)
+        else:
+            self.metrics_map[metric_type][context] = metric_class(name, value, tags, rate, timestamp)

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -35,10 +35,8 @@ class Aggregator(object):
 
     def send_metrics(self):
         for metric in self.flush_metrics():
-            # TODO: change the _report function in base.py to handle new data
-            serialized_metric = self.client._serialize_metric(metric.name, metric.type, metric.value, metric.tags, 
+            self.client._report(metric.name, metric.type, metric.value, metric.tags, 
                 timestamp=metric.timestamp if metric.timestamp else 0)
-            self.client._report(serialized_metric)
 
     def stop(self):
         self.closed.set()

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -544,12 +544,12 @@ class DogStatsd(object):
         )
 
     # Note: Invocations of this method should be thread-safe
-    def _stop_flush_thread(self):
+    def _stop_flush_thread(self, flush_function):
         if not self._flush_thread:
             return
 
         try:
-            self.flush()
+            flush_function()
         finally:
             pass
 
@@ -590,7 +590,7 @@ class DogStatsd(object):
             # otherwise start up the flushing thread and enable the buffering.
             if is_disabled:
                 self._send = self._send_to_server
-                self._stop_flush_thread()
+                self._stop_flush_thread(self.flush)
                 log.debug("Statsd buffering is disabled")
             else:
                 self._send = self._send_to_buffer
@@ -1408,7 +1408,7 @@ class DogStatsd(object):
         self._forking = True
 
         with self._config_lock:
-            self._stop_flush_thread()
+            self._stop_flush_thread(self.flush)
             self._stop_sender_thread()
         self.close_socket()
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1024,7 +1024,7 @@ class DogStatsd(object):
 
         if sample_rate != 1 and random() > sample_rate:
             return
-
+        # TODO: use metric_types enum
         # timestamps (protocol v1.3) only allowed on gauges and counts
         allows_timestamp = metric_type == "g" or metric_type == "c"
         if not allows_timestamp or timestamp < 0:

--- a/datadog/dogstatsd/metric_types.py
+++ b/datadog/dogstatsd/metric_types.py
@@ -4,3 +4,4 @@ class MetricType(Enum):
     COUNT = 'c'
     GAUGE = 'g'
     SET = 's'
+    

--- a/datadog/dogstatsd/metric_types.py
+++ b/datadog/dogstatsd/metric_types.py
@@ -1,5 +1,4 @@
-class MetricType():
-    COUNT = 'c'
-    GAUGE = 'g'
-    SET = 's'
-    
+class MetricType:
+    COUNT = "c"
+    GAUGE = "g"
+    SET = "s"

--- a/datadog/dogstatsd/metric_types.py
+++ b/datadog/dogstatsd/metric_types.py
@@ -1,7 +1,5 @@
-from enum import Enum
-
-
-class MetricType(Enum):
-    COUNT = "c"
-    GAUGE = "g"
-    SET = "s"
+class MetricType():
+    COUNT = 'c'
+    GAUGE = 'g'
+    SET = 's'
+    

--- a/datadog/dogstatsd/metric_types.py
+++ b/datadog/dogstatsd/metric_types.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class MetricType(Enum):
+    COUNT = 'c'
+    GAUGE = 'g'
+    SET = 's'

--- a/datadog/dogstatsd/metric_types.py
+++ b/datadog/dogstatsd/metric_types.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
+
 class MetricType(Enum):
-    COUNT = 'c'
-    GAUGE = 'g'
-    SET = 's'
-    
+    COUNT = "c"
+    GAUGE = "g"
+    SET = "s"

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -65,8 +65,6 @@ class SetMetric(MetricAggregator):
             self.data.add(v)
 
     def unsafe_flush(self):
-        if not self.data:
-            return []
         return [
             {
                 'metric_type': MetricType.SET,

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -1,7 +1,8 @@
 from datadog.dogstatsd.metric_types import MetricType
 
+
 class MetricAggregator(object):
-    def __init__(self, name, tags, rate, metric_type: MetricType, value=0, timestamp=0):
+    def __init__(self, name, tags, rate, metric_type, value=0, timestamp=0):
         self.name = name
         self.tags = tags
         self.rate = rate
@@ -12,24 +13,33 @@ class MetricAggregator(object):
     def aggregate(self, value):
         raise NotImplementedError("Subclasses should implement this method.")
 
+
 class CountMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate, timestamp=0):
-        super(CountMetric, self).__init__(name, tags, rate, MetricType.COUNT, value, timestamp)
+        super(CountMetric, self).__init__(
+            name, tags, rate, MetricType.COUNT, value, timestamp
+        )
 
     def aggregate(self, v):
         self.value += v
 
+
 class GaugeMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate, timestamp=0):
-        super(GaugeMetric, self).__init__(name, tags, rate, MetricType.GAUGE, value, timestamp)
+        super(GaugeMetric, self).__init__(
+            name, tags, rate, MetricType.GAUGE, value, timestamp
+        )
 
     def aggregate(self, v):
         self.value = v
 
+
 class SetMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate, timestamp=0):
         default_value = 0
-        super(SetMetric, self).__init__(name, tags, rate, MetricType.SET, default_value, default_value)
+        super(SetMetric, self).__init__(
+            name, tags, rate, MetricType.SET, default_value, default_value
+        )
         self.data = set()
         self.data.add(value)
 
@@ -38,12 +48,6 @@ class SetMetric(MetricAggregator):
 
     def get_data(self):
         return [
-            MetricAggregator(
-                self.name,
-                self.tags,
-                self.rate,
-                MetricType.SET,
-                value
-            )
+            MetricAggregator(self.name, self.tags, self.rate, MetricType.SET, value)
             for value in self.data
         ]

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -65,16 +65,15 @@ class SetMetric(MetricAggregator):
             self.data.add(v)
 
     def unsafe_flush(self):
-        with self.lock:
-            if not self.data:
-                return []
-            return [
-                {
-                    'metric_type': MetricType.SET,
-                    'name': self.name,
-                    'tags': self.tags,
-                    'rate': self.rate,
-                    'value': value,
-                }
-                for value in self.data
-            ]
+        if not self.data:
+            return []
+        return [
+            {
+                'metric_type': MetricType.SET,
+                'name': self.name,
+                'tags': self.tags,
+                'rate': self.rate,
+                'value': value,
+            }
+            for value in self.data
+        ]

--- a/tests/unit/dogstatsd/test_aggregator.py
+++ b/tests/unit/dogstatsd/test_aggregator.py
@@ -59,7 +59,7 @@ class TestAggregator(unittest.TestCase):
         self.assertEqual(len(self.aggregator.metrics_map[MetricType.SET]), 0)
 
         self.assertEqual(len(metrics), 7)
-        metrics.sort(key=lambda m: (m.metric_type.value, m.name, m.value))
+        metrics.sort(key=lambda m: (m.metric_type, m.name, m.value))
         expected_metrics = [
             {"metric_type": MetricType.COUNT, "name": "countTest1", "tags": tags, "rate": 1, "value": 31, "timestamp": 0},
             {"metric_type": MetricType.COUNT, "name": "countTest2", "tags": tags, "rate": 1, "value": 1, "timestamp": 0},

--- a/tests/unit/dogstatsd/test_aggregator.py
+++ b/tests/unit/dogstatsd/test_aggregator.py
@@ -2,7 +2,7 @@ import unittest
 from mock import Mock
 from datadog.dogstatsd import DogStatsd
 from datadog.dogstatsd.metric_types import MetricType
-from datadog.dogstatsd.aggregator import Aggregator  # Update with the correct module name
+from datadog.dogstatsd.aggregator import Aggregator
 
 
 class TestAggregator(unittest.TestCase):

--- a/tests/unit/dogstatsd/test_aggregator.py
+++ b/tests/unit/dogstatsd/test_aggregator.py
@@ -1,0 +1,84 @@
+import unittest
+from mock import Mock
+from datadog.dogstatsd import DogStatsd
+from datadog.dogstatsd.metric_types import MetricType
+from datadog.dogstatsd.aggregator import Aggregator  # Update with the correct module name
+
+
+class TestAggregator(unittest.TestCase):
+    def setUp(self):
+        self.client = Mock(spec=DogStatsd)
+        self.aggregator = Aggregator(self.client)
+
+    def test_aggregator_sample(self):
+        tags = ["tag1", "tag2"]
+
+        self.aggregator.gauge("gaugeTest", 21, tags, 1)
+        self.assertEqual(len(self.aggregator.metrics_map[MetricType.GAUGE]), 1)
+        self.assertIn("gaugeTest:tag1,tag2", self.aggregator.metrics_map[MetricType.GAUGE])
+
+        self.aggregator.count("countTest", 21, tags, 1)
+        self.assertEqual(len(self.aggregator.metrics_map[MetricType.COUNT]), 1)
+        self.assertIn("countTest:tag1,tag2", self.aggregator.metrics_map[MetricType.COUNT])
+
+        self.aggregator.set("setTest", "value1", tags, 1)
+        self.assertEqual(len(self.aggregator.metrics_map[MetricType.SET]), 1)
+        self.assertIn("setTest:tag1,tag2", self.aggregator.metrics_map[MetricType.SET])
+
+        self.aggregator.gauge("gaugeTest", 123, tags, 1)
+        self.assertEqual(len(self.aggregator.metrics_map[MetricType.GAUGE]), 1)
+        self.assertIn("gaugeTest:tag1,tag2", self.aggregator.metrics_map[MetricType.GAUGE])
+
+        self.aggregator.count("countTest", 10, tags, 1)
+        self.assertEqual(len(self.aggregator.metrics_map[MetricType.COUNT]), 1)
+        self.assertIn("countTest:tag1,tag2", self.aggregator.metrics_map[MetricType.COUNT])
+
+        self.aggregator.set("setTest", "value1", tags, 1)
+        self.assertEqual(len(self.aggregator.metrics_map[MetricType.SET]), 1)
+        self.assertIn("setTest:tag1,tag2", self.aggregator.metrics_map[MetricType.SET])
+
+    def test_aggregator_flush(self):
+        tags = ["tag1", "tag2"]
+
+        self.aggregator.gauge("gaugeTest1", 21, tags, 1)
+        self.aggregator.gauge("gaugeTest1", 10, tags, 1)
+        self.aggregator.gauge("gaugeTest2", 15, tags, 1)
+
+        self.aggregator.count("countTest1", 21, tags, 1)
+        self.aggregator.count("countTest1", 10, tags, 1)
+        self.aggregator.count("countTest2", 1, tags, 1)
+
+        self.aggregator.set("setTest1", "value1", tags, 1)
+        self.aggregator.set("setTest1", "value1", tags, 1)
+        self.aggregator.set("setTest1", "value2", tags, 1)
+        self.aggregator.set("setTest2", "value1", tags, 1)
+
+        metrics = self.aggregator.flush_metrics()
+        self.assertEqual(len(self.aggregator.metrics_map[MetricType.GAUGE]), 0)
+        self.assertEqual(len(self.aggregator.metrics_map[MetricType.COUNT]), 0)
+        self.assertEqual(len(self.aggregator.metrics_map[MetricType.SET]), 0)
+
+        self.assertEqual(len(metrics), 7)
+        for metric in metrics:
+            print("raymond", metric)
+            print("andrew", metric['metric_type'])
+        metrics.sort(key=lambda m: (m['metric_type'], m['name'], m['value']))
+        expected_metrics = [
+            {"metric_type": MetricType.COUNT, "name": "countTest1", "tags": tags, "rate": 1, "value": 31, "timestamp": 0},
+            {"metric_type": MetricType.COUNT, "name": "countTest2", "tags": tags, "rate": 1, "value": 1, "timestamp": 0},
+            {"metric_type": MetricType.GAUGE, "name": "gaugeTest1", "tags": tags, "rate": 1, "value": 10, "timestamp": 0},
+            {"metric_type": MetricType.GAUGE, "name": "gaugeTest2", "tags": tags, "rate": 1, "value": 15, "timestamp": 0},
+            {"metric_type": MetricType.SET, "name": "setTest1", "tags": tags, "rate": 1, "value": "value1", "timestamp": 0},
+            {"metric_type": MetricType.SET, "name": "setTest1", "tags": tags, "rate": 1, "value": "value2", "timestamp": 0},
+            {"metric_type": MetricType.SET, "name": "setTest2", "tags": tags, "rate": 1, "value": "value1", "timestamp": 0},
+        ]
+        
+        for metric, expected in zip(metrics, expected_metrics):
+            self.assertEqual(metric["name"], expected["name"])
+            self.assertEqual(metric["tags"], expected["tags"])
+            self.assertEqual(metric["rate"], expected["rate"])
+            self.assertEqual(metric["value"], expected["value"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/dogstatsd/test_aggregator.py
+++ b/tests/unit/dogstatsd/test_aggregator.py
@@ -59,7 +59,7 @@ class TestAggregator(unittest.TestCase):
         self.assertEqual(len(self.aggregator.metrics_map[MetricType.SET]), 0)
 
         self.assertEqual(len(metrics), 7)
-        metrics.sort(key=lambda m: (m['metric_type'], m['name'], m['value']))
+        metrics.sort(key=lambda m: (m.metric_type.value, m.name, m.value))
         expected_metrics = [
             {"metric_type": MetricType.COUNT, "name": "countTest1", "tags": tags, "rate": 1, "value": 31, "timestamp": 0},
             {"metric_type": MetricType.COUNT, "name": "countTest2", "tags": tags, "rate": 1, "value": 1, "timestamp": 0},
@@ -71,10 +71,10 @@ class TestAggregator(unittest.TestCase):
         ]
         
         for metric, expected in zip(metrics, expected_metrics):
-            self.assertEqual(metric["name"], expected["name"])
-            self.assertEqual(metric["tags"], expected["tags"])
-            self.assertEqual(metric["rate"], expected["rate"])
-            self.assertEqual(metric["value"], expected["value"])
+            self.assertEqual(metric.name, expected["name"])
+            self.assertEqual(metric.tags, expected["tags"])
+            self.assertEqual(metric.rate, expected["rate"])
+            self.assertEqual(metric.value, expected["value"])
 
 
 if __name__ == '__main__':

--- a/tests/unit/dogstatsd/test_aggregator.py
+++ b/tests/unit/dogstatsd/test_aggregator.py
@@ -1,14 +1,11 @@
 import unittest
-from mock import Mock
-from datadog.dogstatsd import DogStatsd
 from datadog.dogstatsd.metric_types import MetricType
 from datadog.dogstatsd.aggregator import Aggregator
 
 
 class TestAggregator(unittest.TestCase):
     def setUp(self):
-        self.client = Mock(spec=DogStatsd)
-        self.aggregator = Aggregator(self.client)
+        self.aggregator = Aggregator()
 
     def test_aggregator_sample(self):
         tags = ["tag1", "tag2"]

--- a/tests/unit/dogstatsd/test_aggregator.py
+++ b/tests/unit/dogstatsd/test_aggregator.py
@@ -59,9 +59,6 @@ class TestAggregator(unittest.TestCase):
         self.assertEqual(len(self.aggregator.metrics_map[MetricType.SET]), 0)
 
         self.assertEqual(len(metrics), 7)
-        for metric in metrics:
-            print("raymond", metric)
-            print("andrew", metric['metric_type'])
         metrics.sort(key=lambda m: (m['metric_type'], m['name'], m['value']))
         expected_metrics = [
             {"metric_type": MetricType.COUNT, "name": "countTest1", "tags": tags, "rate": 1, "value": 31, "timestamp": 0},

--- a/tests/unit/dogstatsd/test_metrics.py
+++ b/tests/unit/dogstatsd/test_metrics.py
@@ -58,7 +58,7 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(s.tags, ["tag1", "tag2"])
         self.assertEqual(s.rate, 1)
         self.assertEqual(s.timestamp, 1713804588)
-
+        print("huh?", s.timestamp)
         s_default_timestamp = SetMetric("test", "value1", ["tag1", "tag2"], 1)
         self.assertEqual(s_default_timestamp.data, {"value1"})
         self.assertEqual(s_default_timestamp.name, "test")

--- a/tests/unit/dogstatsd/test_metrics.py
+++ b/tests/unit/dogstatsd/test_metrics.py
@@ -52,29 +52,22 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(g.timestamp, 1713804588)
 
     def test_new_set_metric(self):
-        s = SetMetric("test", "value1", ["tag1", "tag2"], 1, 1713804588)
+        s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
         self.assertEqual(s.data, {"value1"})
         self.assertEqual(s.name, "test")
         self.assertEqual(s.tags, ["tag1", "tag2"])
         self.assertEqual(s.rate, 1)
-        self.assertEqual(s.timestamp, 1713804588)
-        print("huh?", s.timestamp)
-        s_default_timestamp = SetMetric("test", "value1", ["tag1", "tag2"], 1)
-        self.assertEqual(s_default_timestamp.data, {"value1"})
-        self.assertEqual(s_default_timestamp.name, "test")
-        self.assertEqual(s_default_timestamp.tags, ["tag1", "tag2"])
-        self.assertEqual(s_default_timestamp.rate, 1)
-        self.assertEqual(s_default_timestamp.timestamp, 0)
+        self.assertEqual(s.timestamp, 0)
 
     def test_set_metric_aggregate(self):
-        s = SetMetric("test", "value1", ["tag1", "tag2"], 1, 1713804588)
+        s = SetMetric("test", "value1", ["tag1", "tag2"], 1)
         s.aggregate("value2")
         s.aggregate("value2")
         self.assertEqual(s.data, {"value1", "value2"})
         self.assertEqual(s.name, "test")
         self.assertEqual(s.tags, ["tag1", "tag2"])
         self.assertEqual(s.rate, 1)
-        self.assertEqual(s.timestamp, 1713804588)
+        self.assertEqual(s.timestamp, 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

This PR adds the aggregator functionality for client side aggregation, it is pushing to a feature branch. This has already been implemented for the [GO client](https://github.com/DataDog/datadog-go/pull/139/files#diff-0d2ff0ba6d3144d1b0aea4da6445ea870b0ae794a5a5a8955dfa6c1b9150539a).

[Issue](https://datadoghq.atlassian.net/jira/software/c/projects/AMLII/boards/5315?selectedIssue=AMLII-1856)
### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Adds a class that periodically aggregates (this is not implemented yet as it will rely on functionality from the base.py class) metrics for a given `flush_interval` and then sends the aggregated metrics to intake. A metric will be aggregated if there was another [matching context](https://docs.google.com/document/d/1AoveWKoMQc65hYbvZ27uE7pQ_I5nsGfvv25EcNVPLvQ/edit#heading=h.no4x6fjugsh) sent within the same flush interval.



### Possible Drawbacks

A possible drawback is that the current code relies on object oriented programming (inheritance) for the `add_metric` and other functions, it requires that the `MetricAggregator` objects will have the same fields

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

Unit tests that verify the aggregator.py class matches the existing behavior in the client side aggregator for the [go client](https://github.com/DataDog/datadog-go/pull/139/files#diff-f554159d70c08124ea27e909de77e6b7162f782cbc12363a0cac8825834a2210).

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

No behavioral changes until the `base.py` class is changed

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

