### PR TITLE
Add client side aggregation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
     - master
   pull_request:
     branches:
-    - '*' # TODO: Revert when merged to master
+    - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -83,7 +83,7 @@ def initialize(
     :type statsd_disable_aggregating: boolean
 
     :param statsd_aggregation_flush_interval: Sets the flush interval for aggregation
-                                     (default: 3 seconds)
+                                     (default: 2 seconds)
     :type statsd_aggregation_flush_interval: float
 
     :param statsd_use_default_route: Dynamically set the statsd host to the default route

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -39,7 +39,7 @@ def initialize(
     statsd_port=None,  # type: Optional[int]
     statsd_disable_aggregating=False,  # type: bool
     statsd_disable_buffering=True,  # type: bool
-    statsd_aggregation_flush_interval=3,  # type: float
+    statsd_aggregation_flush_interval=2,  # type: float
     statsd_use_default_route=False,  # type: bool
     statsd_socket_path=None,  # type: Optional[str]
     statsd_namespace=None,  # type: Optional[str]

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -37,7 +37,7 @@ def initialize(
     api_host=None,  # type: Optional[str]
     statsd_host=None,  # type: Optional[str]
     statsd_port=None,  # type: Optional[int]
-    statsd_disable_aggregating=True,  # type: bool
+    statsd_disable_aggregator=True,  # type: bool
     statsd_disable_buffering=True,  # type: bool
     statsd_aggregation_flush_interval=2,  # type: float
     statsd_use_default_route=False,  # type: bool
@@ -78,9 +78,9 @@ def initialize(
                                      (default: True).
     :type statsd_disable_buffering: boolean
 
-    :param statsd_disable_aggregating: Enable/disable statsd client aggregation support
+    :param statsd_disable_aggregator: Enable/disable statsd client aggregation support
                                      (default: True).
-    :type statsd_disable_aggregating: boolean
+    :type statsd_disable_aggregator: boolean
 
     :param statsd_aggregation_flush_interval: Sets the flush interval for aggregation
                                      (default: 2 seconds)
@@ -138,7 +138,7 @@ def initialize(
     if statsd_constant_tags:
         statsd.constant_tags += statsd_constant_tags
 
-    if statsd_disable_aggregating:
+    if statsd_disable_aggregator:
         statsd.disable_aggregation()
     else:
         statsd.enable_aggregation(statsd_aggregation_flush_interval)

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -139,8 +139,8 @@ def initialize(
         statsd.constant_tags += statsd_constant_tags
 
     statsd._aggregation_flush_interval = statsd_aggregation_flush_interval
-    statsd.disable_buffering = statsd_disable_buffering
     statsd.disable_aggregating = statsd_disable_aggregating
+    statsd.disable_buffering = statsd_disable_buffering
     api._return_raw_response = return_raw_response
 
     # HTTP client and API options

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -38,7 +38,7 @@ def initialize(
     statsd_host=None,  # type: Optional[str]
     statsd_port=None,  # type: Optional[int]
     statsd_disable_buffering=True,  # type: bool
-    statsd_disable_aggregating=True,  # type: bool
+    statsd_disable_aggregating=False,  # type: bool
     statsd_aggregation_flush_interval=3,  # type: float
     statsd_use_default_route=False,  # type: bool
     statsd_socket_path=None,  # type: Optional[str]

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -39,7 +39,7 @@ def initialize(
     statsd_port=None,  # type: Optional[int]
     statsd_disable_buffering=True,  # type: bool
     statsd_disable_aggregating=True,  # type: bool
-    statsd_aggregation_flush_interval=3, # type: float
+    statsd_aggregation_flush_interval=3,  # type: float
     statsd_use_default_route=False,  # type: bool
     statsd_socket_path=None,  # type: Optional[str]
     statsd_namespace=None,  # type: Optional[str]

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -37,8 +37,8 @@ def initialize(
     api_host=None,  # type: Optional[str]
     statsd_host=None,  # type: Optional[str]
     statsd_port=None,  # type: Optional[int]
-    statsd_disable_buffering=True,  # type: bool
     statsd_disable_aggregating=False,  # type: bool
+    statsd_disable_buffering=True,  # type: bool
     statsd_aggregation_flush_interval=3,  # type: float
     statsd_use_default_route=False,  # type: bool
     statsd_socket_path=None,  # type: Optional[str]

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -39,6 +39,7 @@ def initialize(
     statsd_port=None,  # type: Optional[int]
     statsd_disable_buffering=True,  # type: bool
     statsd_disable_aggregating=True,  # type: bool
+    statsd_aggregation_flush_interval=3, # type: float
     statsd_use_default_route=False,  # type: bool
     statsd_socket_path=None,  # type: Optional[str]
     statsd_namespace=None,  # type: Optional[str]
@@ -80,6 +81,10 @@ def initialize(
     :param statsd_disable_aggregating: Enable/disable statsd client aggregation support
                                      (default: True).
     :type statsd_disable_aggregating: boolean
+
+    :param statsd_aggregation_flush_interval: Sets the flush interval for aggregation
+                                     (default: 3 seconds)
+    :type statsd_aggregation_flush_interval: float
 
     :param statsd_use_default_route: Dynamically set the statsd host to the default route
                                      (Useful when running the client in a container)
@@ -133,14 +138,12 @@ def initialize(
     if statsd_constant_tags:
         statsd.constant_tags += statsd_constant_tags
 
+    statsd._aggregation_flush_interval = statsd_aggregation_flush_interval
     statsd.disable_buffering = statsd_disable_buffering
     statsd.disable_aggregating = statsd_disable_aggregating
-    print("wacktest buffering", statsd_disable_buffering)
-    print("wacktest aggregation", statsd_disable_aggregating)
     api._return_raw_response = return_raw_response
 
     # HTTP client and API options
     for key, value in iteritems(kwargs):
         attribute = "_{}".format(key)
-        print(attribute, "is attribute")
         setattr(api, attribute, value)

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -38,6 +38,7 @@ def initialize(
     statsd_host=None,  # type: Optional[str]
     statsd_port=None,  # type: Optional[int]
     statsd_disable_buffering=True,  # type: bool
+    statsd_disable_aggregating=True,  # type: bool
     statsd_use_default_route=False,  # type: bool
     statsd_socket_path=None,  # type: Optional[str]
     statsd_namespace=None,  # type: Optional[str]
@@ -75,6 +76,10 @@ def initialize(
     :param statsd_disable_buffering: Enable/disable statsd client buffering support
                                      (default: True).
     :type statsd_disable_buffering: boolean
+
+    :param statsd_disable_aggregating: Enable/disable statsd client aggregation support
+                                     (default: True).
+    :type statsd_disable_aggregating: boolean
 
     :param statsd_use_default_route: Dynamically set the statsd host to the default route
                                      (Useful when running the client in a container)
@@ -129,10 +134,13 @@ def initialize(
         statsd.constant_tags += statsd_constant_tags
 
     statsd.disable_buffering = statsd_disable_buffering
-
+    statsd.disable_aggregating = statsd_disable_aggregating
+    print("wacktest buffering", statsd_disable_buffering)
+    print("wacktest aggregation", statsd_disable_aggregating)
     api._return_raw_response = return_raw_response
 
     # HTTP client and API options
     for key, value in iteritems(kwargs):
         attribute = "_{}".format(key)
+        print(attribute, "is attribute")
         setattr(api, attribute, value)

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -37,7 +37,7 @@ def initialize(
     api_host=None,  # type: Optional[str]
     statsd_host=None,  # type: Optional[str]
     statsd_port=None,  # type: Optional[int]
-    statsd_disable_aggregating=False,  # type: bool
+    statsd_disable_aggregating=True,  # type: bool
     statsd_disable_buffering=True,  # type: bool
     statsd_aggregation_flush_interval=2,  # type: float
     statsd_use_default_route=False,  # type: bool

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -138,8 +138,10 @@ def initialize(
     if statsd_constant_tags:
         statsd.constant_tags += statsd_constant_tags
 
-    statsd._aggregation_flush_interval = statsd_aggregation_flush_interval
-    statsd.disable_aggregating = statsd_disable_aggregating
+    if statsd_disable_aggregating:
+        statsd.disable_aggregation()
+    else:
+        statsd.enable_aggregation(statsd_aggregation_flush_interval)
     statsd.disable_buffering = statsd_disable_buffering
     api._return_raw_response = return_raw_response
 

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -139,8 +139,8 @@ def initialize(
         statsd.constant_tags += statsd_constant_tags
 
     statsd._aggregation_flush_interval = statsd_aggregation_flush_interval
-    statsd.disable_aggregating = statsd_disable_aggregating
     statsd.disable_buffering = statsd_disable_buffering
+    statsd.disable_aggregating = statsd_disable_aggregating
     api._return_raw_response = return_raw_response
 
     # HTTP client and API options

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -20,7 +20,7 @@ class Aggregator(object):
             MetricType.SET: threading.RLock(),
         }
 
-    def flush_metrics(self):
+    def flush_aggregated_metrics(self):
         metrics = []
         for metric_type in self.metrics_map.keys():
             with self._locks[metric_type]:

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -31,7 +31,8 @@ class Aggregator(object):
         return metrics
 
     def get_context(self, name, tags):
-        return "{}:{}".format(name, ",".join(tags))
+        tags_str = ",".join(tags) if tags is not None else ""
+        return "{}:{}".format(name, tags_str)
 
     def count(self, name, value, tags, rate, timestamp=0):
         return self.add_metric(

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1515,7 +1515,7 @@ class DogStatsd(object):
         self._forking = True
 
         with self._config_lock:
-            self._stop_buffering_flush_thread()
+            self._stop_flush_thread()
             self._stop_sender_thread()
         self.close_socket()
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -712,9 +712,9 @@ class DogStatsd(object):
             log.debug("Statsd aggregation is disabled")
 
     def enable_aggregation(self, aggregation_flush_interval=DEFAULT_AGGREGATION_FLUSH_INTERVAL):
-        # print("andrewqian")
-        # log.info("andrewqian")
-        # log.debug("andrewqian")
+        print("andrewqian")
+        log.info("andrewqian")
+        log.debug("andrewqian")
         with self._config_lock:
             if not self._disable_aggregating:
                 return

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1205,7 +1205,6 @@ class DogStatsd(object):
         )
 
         # Send it
-        print("payload sent", payload)
         self._send(payload)
 
     def _reset_telemetry(self):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -634,8 +634,8 @@ class DogStatsd(object):
             pass
 
         self._buffering_flush_thread_stop.set()
-
-        self._buffering_flush_thread[0].join()
+        if self._buffering_flush_thread[0]:
+            self._buffering_flush_thread[0].join()
         self._buffering_flush_thread = [None]
 
         self._buffering_flush_thread_stop.clear()
@@ -650,8 +650,8 @@ class DogStatsd(object):
             pass
 
         self._aggregation_flush_thread_stop.set()
-
-        self._aggregation_flush_thread[0].join()
+        if self._aggregation_flush_thread[0]:
+            self._aggregation_flush_thread[0].join()
         self._aggregation_flush_thread = [None]
 
         self._aggregation_flush_thread_stop.clear()

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -438,7 +438,8 @@ class DogStatsd(object):
 
         self._reset_buffer()
 
-        # This lock is used for all cases where client configuration is being changed: buffering, aggregation sender mode.
+        # This lock is used for all cases where client configuration is being changed: buffering,
+        # aggregation, sender mode.
         self._config_lock = RLock()
 
         self._disable_buffering = disable_buffering
@@ -457,7 +458,8 @@ class DogStatsd(object):
             self._buffer_flush_interval = buffer_flush_interval
             self._batching_flush_thread_stop = threading.Event()
             self._send = self._send_to_buffer
-            # We make the _batching_flush_thread and _aggregation_flush_thread a list so that it is a mutable object, which allows us to mutate it in the
+            # We make the _batching_flush_thread and _aggregation_flush_thread a list so that it is a mutable object,
+            # which allows us to mutate it in the
             # _start_flush_thread function
             self._batching_flush_thread = [None]
             self._start_flush_thread(

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -710,7 +710,7 @@ class DogStatsd(object):
             self._send = self._send_to_server
             self._stop_aggregation_flush_thread()
             log.debug("Statsd aggregation is disabled")
-            
+
             self._start_flush_thread(
                 self._aggregation_flush_interval,
                 MIN_AGGREGATION_FLUSH_INTERVAL,
@@ -718,7 +718,7 @@ class DogStatsd(object):
                 self._aggregation_flush_thread,
                 self._aggregation_flush_thread_stop,
             )
-    
+
     def enable_aggregation(self, aggregation_flush_interval=DEFAULT_AGGREGATION_FLUSH_INTERVAL):
         with self._config_lock:
             if not self._disable_aggregating:

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -432,8 +432,6 @@ class DogStatsd(object):
         # This lock is used for all cases where client configuration is being changed: buffering, aggregation sender mode.
         self._config_lock = RLock()
 
-        # If buffering is disabled, we bypass the buffer function.
-        self._send = self._send_to_buffer
         self._disable_buffering = disable_buffering
         self._disable_aggregating = disable_aggregating
 
@@ -449,12 +447,14 @@ class DogStatsd(object):
             # as a value for disabling the automatic flush timer as well.
             self._buffer_flush_interval = buffer_flush_interval
             self._batching_flush_thread_stop = threading.Event()
+            self._send = self._send_to_buffer
             # We make the _batching_flush_thread and _aggregation_flush_thread a list so that it is a mutable object, which allows us to mutate it in the 
             # _start_flush_thread function
             self._batching_flush_thread = [None]
             self._start_flush_thread(self._buffer_flush_interval, MIN_BUFFERING_FLUSH_INTERVAL, self.flush_buffered_metrics, self._batching_flush_thread,
                 self._batching_flush_thread_stop)
         else:
+            self._send = self._send_to_server
             self._forking = False
             self._disable_buffering = True
             self.aggregator = Aggregator()
@@ -1515,7 +1515,7 @@ class DogStatsd(object):
     def stop(self):
         """Stop the client.
 
-        Disable buffering, background sender and flush any pending payloads to the server.
+        Disable buffering, aggregation, background sender and flush any pending payloads to the server.
 
         Client remains usable after this method, but sending metrics may block if socket_timeout is enabled.
         """

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -50,11 +50,10 @@ DEFAULT_PORT = 8125
 
 # Buffering-related values (in seconds)
 DEFAULT_BUFFERING_FLUSH_INTERVAL = 0.3
-MIN_BUFFERING_FLUSH_INTERVAL = 0.0001
+MIN__FLUSH_INTERVAL = 0.0001
 
 # Aggregation-related values (in seconds)
 DEFAULT_AGGREGATION_FLUSH_INTERVAL = 2
-MIN_AGGREGATION_FLUSH_INTERVAL = 0.01
 # Env var to enable/disable sending the container ID field
 ORIGIN_DETECTION_ENABLED = "DD_ORIGIN_DETECTION_ENABLED"
 
@@ -82,24 +81,21 @@ DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL = 10
 # Telemetry pre-computed formatting string. Pre-computation
 # increases throughput of composing the result by 2-15% from basic
 # '%'-based formatting with a `join`.
-TELEMETRY_FORMATTING_STR = (
-    "\n".join(
-        [
-            "datadog.dogstatsd.client.metrics:%s|c|#%s",
-            "datadog.dogstatsd.client.events:%s|c|#%s",
-            "datadog.dogstatsd.client.service_checks:%s|c|#%s",
-            "datadog.dogstatsd.client.bytes_sent:%s|c|#%s",
-            "datadog.dogstatsd.client.bytes_dropped:%s|c|#%s",
-            "datadog.dogstatsd.client.bytes_dropped_queue:%s|c|#%s",
-            "datadog.dogstatsd.client.bytes_dropped_writer:%s|c|#%s",
-            "datadog.dogstatsd.client.packets_sent:%s|c|#%s",
-            "datadog.dogstatsd.client.packets_dropped:%s|c|#%s",
-            "datadog.dogstatsd.client.packets_dropped_queue:%s|c|#%s",
-            "datadog.dogstatsd.client.packets_dropped_writer:%s|c|#%s",
-        ]
-    )
-    + "\n"
-)
+TELEMETRY_FORMATTING_STR = "\n".join(
+    [
+        "datadog.dogstatsd.client.metrics:%s|c|#%s",
+        "datadog.dogstatsd.client.events:%s|c|#%s",
+        "datadog.dogstatsd.client.service_checks:%s|c|#%s",
+        "datadog.dogstatsd.client.bytes_sent:%s|c|#%s",
+        "datadog.dogstatsd.client.bytes_dropped:%s|c|#%s",
+        "datadog.dogstatsd.client.bytes_dropped_queue:%s|c|#%s",
+        "datadog.dogstatsd.client.bytes_dropped_writer:%s|c|#%s",
+        "datadog.dogstatsd.client.packets_sent:%s|c|#%s",
+        "datadog.dogstatsd.client.packets_dropped:%s|c|#%s",
+        "datadog.dogstatsd.client.packets_dropped_queue:%s|c|#%s",
+        "datadog.dogstatsd.client.packets_dropped_writer:%s|c|#%s",
+    ]
+) + "\n"
 
 Stop = object()
 
@@ -138,34 +134,32 @@ class DogStatsd(object):
 
     def __init__(
         self,
-        host=DEFAULT_HOST,  # type: Text
-        port=DEFAULT_PORT,  # type: int
-        max_buffer_size=None,  # type: None
+        host=DEFAULT_HOST,                      # type: Text
+        port=DEFAULT_PORT,                      # type: int
+        max_buffer_size=None,                   # type: None
         flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL,  # type: float
-        disable_aggregating=True,  # type: bool
-        disable_buffering=True,  # type: bool
-        namespace=None,  # type: Optional[Text]
-        constant_tags=None,  # type: Optional[List[str]]
-        use_ms=False,  # type: bool
-        use_default_route=False,  # type: bool
-        socket_path=None,  # type: Optional[Text]
-        default_sample_rate=1,  # type: float
-        disable_telemetry=False,  # type: bool
-        telemetry_min_flush_interval=(
-            DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL
-        ),  # type: int
-        telemetry_host=None,  # type: Text
-        telemetry_port=None,  # type: Union[str, int]
-        telemetry_socket_path=None,  # type: Text
-        max_buffer_len=0,  # type: int
-        container_id=None,  # type: Optional[Text]
-        origin_detection_enabled=True,  # type: bool
-        socket_timeout=0,  # type: Optional[float]
-        telemetry_socket_timeout=0,  # type: Optional[float]
-        disable_background_sender=True,  # type: bool
-        sender_queue_size=0,  # type: int
-        sender_queue_timeout=0,  # type: Optional[float]
-        track_instance=True,  # type: bool
+        disable_aggregating=True,               # type: bool
+        disable_buffering=True,                 # type: bool
+        namespace=None,                         # type: Optional[Text]
+        constant_tags=None,                     # type: Optional[List[str]]
+        use_ms=False,                           # type: bool
+        use_default_route=False,                # type: bool
+        socket_path=None,                       # type: Optional[Text]
+        default_sample_rate=1,                  # type: float
+        disable_telemetry=False,                # type: bool
+        telemetry_min_flush_interval=(DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL),  # type: int
+        telemetry_host=None,                    # type: Text
+        telemetry_port=None,                    # type: Union[str, int]
+        telemetry_socket_path=None,             # type: Text
+        max_buffer_len=0,                       # type: int
+        container_id=None,                      # type: Optional[Text]
+        origin_detection_enabled=True,          # type: bool
+        socket_timeout=0,                       # type: Optional[float]
+        telemetry_socket_timeout=0,             # type: Optional[float]
+        disable_background_sender=True,         # type: bool
+        sender_queue_size=0,                    # type: int
+        sender_queue_timeout=0,                 # type: Optional[float]
+        track_instance=True,                    # type: bool
         aggregation_flush_interval=DEFAULT_AGGREGATION_FLUSH_INTERVAL,  # type: float
     ):  # type: (...) -> None
         """
@@ -345,9 +339,7 @@ class DogStatsd(object):
 
         # Check for deprecated option
         if max_buffer_size is not None:
-            log.warning(
-                "The parameter max_buffer_size is now deprecated and is not used anymore"
-            )
+            log.warning("The parameter max_buffer_size is now deprecated and is not used anymore")
         # Check host and port env vars
         agent_host = os.environ.get("DD_AGENT_HOST")
         if agent_host and host == DEFAULT_HOST:
@@ -471,7 +463,7 @@ class DogStatsd(object):
             self._send = self._send_to_buffer
             self._start_flush_thread(
                 self._flush_interval,
-                MIN_BUFFERING_FLUSH_INTERVAL,
+                MIN__FLUSH_INTERVAL,
                 self.flush_buffered_metrics,
                 self._buffering_flush_thread,
                 self._buffering_flush_thread_stop,
@@ -481,7 +473,7 @@ class DogStatsd(object):
             self._disable_buffering = True
             self._start_flush_thread(
                 self._aggregation_flush_interval,
-                MIN_AGGREGATION_FLUSH_INTERVAL,
+                MIN__FLUSH_INTERVAL,
                 self.flush_aggregated_metrics,
                 self._aggregation_flush_thread,
                 self._aggregation_flush_thread_stop,
@@ -691,7 +683,7 @@ class DogStatsd(object):
                 self._send = self._send_to_buffer
                 self._start_flush_thread(
                     self._flush_interval,
-                    MIN_BUFFERING_FLUSH_INTERVAL,
+                    MIN__FLUSH_INTERVAL,
                     self.flush_buffered_metrics,
                     self._buffering_flush_thread,
                     self._buffering_flush_thread_stop,
@@ -720,7 +712,7 @@ class DogStatsd(object):
             self._send = self._send_to_server
             self._start_flush_thread(
                 self._aggregation_flush_interval,
-                MIN_AGGREGATION_FLUSH_INTERVAL,
+                MIN__FLUSH_INTERVAL,
                 self.flush_aggregated_metrics,
                 self._aggregation_flush_thread,
                 self._aggregation_flush_thread_stop,
@@ -1604,7 +1596,7 @@ class DogStatsd(object):
         with self._config_lock:
             self._start_flush_thread(
                 self._flush_interval,
-                MIN_BUFFERING_FLUSH_INTERVAL,
+                MIN__FLUSH_INTERVAL,
                 self.flush_buffered_metrics,
                 self._buffering_flush_thread,
                 self._buffering_flush_thread_stop,

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -24,8 +24,6 @@ except ImportError:
     # pypy has the same module, but capitalized.
     import Queue as queue  # type: ignore[no-redef]
 
-from typing import Optional, List, Text, Union
-
 # Datadog libraries
 from datadog.dogstatsd.aggregator import Aggregator
 from datadog.dogstatsd.metric_types import MetricType
@@ -77,25 +75,30 @@ DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL = 10
 # Telemetry pre-computed formatting string. Pre-computation
 # increases throughput of composing the result by 2-15% from basic
 # '%'-based formatting with a `join`.
-TELEMETRY_FORMATTING_STR = "\n".join(
-    [
-        "datadog.dogstatsd.client.metrics:%s|c|#%s",
-        "datadog.dogstatsd.client.events:%s|c|#%s",
-        "datadog.dogstatsd.client.service_checks:%s|c|#%s",
-        "datadog.dogstatsd.client.bytes_sent:%s|c|#%s",
-        "datadog.dogstatsd.client.bytes_dropped:%s|c|#%s",
-        "datadog.dogstatsd.client.bytes_dropped_queue:%s|c|#%s",
-        "datadog.dogstatsd.client.bytes_dropped_writer:%s|c|#%s",
-        "datadog.dogstatsd.client.packets_sent:%s|c|#%s",
-        "datadog.dogstatsd.client.packets_dropped:%s|c|#%s",
-        "datadog.dogstatsd.client.packets_dropped_queue:%s|c|#%s",
-        "datadog.dogstatsd.client.packets_dropped_writer:%s|c|#%s",
-    ]
-) + "\n"
+TELEMETRY_FORMATTING_STR = (
+    "\n".join(
+        [
+            "datadog.dogstatsd.client.metrics:%s|c|#%s",
+            "datadog.dogstatsd.client.events:%s|c|#%s",
+            "datadog.dogstatsd.client.service_checks:%s|c|#%s",
+            "datadog.dogstatsd.client.bytes_sent:%s|c|#%s",
+            "datadog.dogstatsd.client.bytes_dropped:%s|c|#%s",
+            "datadog.dogstatsd.client.bytes_dropped_queue:%s|c|#%s",
+            "datadog.dogstatsd.client.bytes_dropped_writer:%s|c|#%s",
+            "datadog.dogstatsd.client.packets_sent:%s|c|#%s",
+            "datadog.dogstatsd.client.packets_dropped:%s|c|#%s",
+            "datadog.dogstatsd.client.packets_dropped_queue:%s|c|#%s",
+            "datadog.dogstatsd.client.packets_dropped_writer:%s|c|#%s",
+        ]
+    )
+    + "\n"
+)
 
 Stop = object()
 
-SUPPORTS_FORKING = hasattr(os, "register_at_fork") and not os.environ.get("DD_DOGSTATSD_DISABLE_FORK_SUPPORT", None)
+SUPPORTS_FORKING = hasattr(os, "register_at_fork") and not os.environ.get(
+    "DD_DOGSTATSD_DISABLE_FORK_SUPPORT", None
+)
 TRACK_INSTANCES = not os.environ.get("DD_DOGSTATSD_DISABLE_INSTANCE_TRACKING", None)
 
 _instances = weakref.WeakSet()  # type: weakref.WeakSet
@@ -120,7 +123,9 @@ def post_fork():
 
 
 if SUPPORTS_FORKING:
-    os.register_at_fork(before=pre_fork, after_in_child=post_fork, after_in_parent=post_fork)  # type: ignore
+    os.register_at_fork(
+        before=pre_fork, after_in_child=post_fork, after_in_parent=post_fork
+    )  # type: ignore
 
 
 # pylint: disable=useless-object-inheritance,too-many-instance-attributes
@@ -130,32 +135,34 @@ class DogStatsd(object):
 
     def __init__(
         self,
-        host=DEFAULT_HOST,                      # type: Text
-        port=DEFAULT_PORT,                      # type: int
-        max_buffer_size=None,                   # type: None
+        host=DEFAULT_HOST,  # type: Text
+        port=DEFAULT_PORT,  # type: int
+        max_buffer_size=None,  # type: None
         buffer_flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL,  # type: float
-        disable_aggregating=True,                 # type: bool
-        disable_buffering=True,                 # type: bool
-        namespace=None,                         # type: Optional[Text]
-        constant_tags=None,                     # type: Optional[List[str]]
-        use_ms=False,                           # type: bool
-        use_default_route=False,                # type: bool
-        socket_path=None,                       # type: Optional[Text]
-        default_sample_rate=1,                  # type: float
-        disable_telemetry=False,                # type: bool
-        telemetry_min_flush_interval=(DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL),  # type: int
-        telemetry_host=None,                    # type: Text
-        telemetry_port=None,                    # type: Union[str, int]
-        telemetry_socket_path=None,             # type: Text
-        max_buffer_len=0,                       # type: int
-        container_id=None,                      # type: Optional[Text]
-        origin_detection_enabled=True,          # type: bool
-        socket_timeout=0,                       # type: Optional[float]
-        telemetry_socket_timeout=0,             # type: Optional[float]
-        disable_background_sender=True,         # type: bool
-        sender_queue_size=0,                    # type: int
-        sender_queue_timeout=0,                 # type: Optional[float]
-        track_instance=True,                    # type: bool
+        disable_aggregating=True,  # type: bool
+        disable_buffering=True,  # type: bool
+        namespace=None,  # type: Optional[Text]
+        constant_tags=None,  # type: Optional[List[str]]
+        use_ms=False,  # type: bool
+        use_default_route=False,  # type: bool
+        socket_path=None,  # type: Optional[Text]
+        default_sample_rate=1,  # type: float
+        disable_telemetry=False,  # type: bool
+        telemetry_min_flush_interval=(
+            DEFAULT_TELEMETRY_MIN_FLUSH_INTERVAL
+        ),  # type: int
+        telemetry_host=None,  # type: Text
+        telemetry_port=None,  # type: Union[str, int]
+        telemetry_socket_path=None,  # type: Text
+        max_buffer_len=0,  # type: int
+        container_id=None,  # type: Optional[Text]
+        origin_detection_enabled=True,  # type: bool
+        socket_timeout=0,  # type: Optional[float]
+        telemetry_socket_timeout=0,  # type: Optional[float]
+        disable_background_sender=True,  # type: bool
+        sender_queue_size=0,  # type: int
+        sender_queue_timeout=0,  # type: Optional[float]
+        track_instance=True,  # type: bool
         aggregation_flush_interval=DEFAULT_AGGREGATION_FLUSH_INTERVAL,  # type: float
     ):  # type: (...) -> None
         """
@@ -335,7 +342,9 @@ class DogStatsd(object):
 
         # Check for deprecated option
         if max_buffer_size is not None:
-            log.warning("The parameter max_buffer_size is now deprecated and is not used anymore")
+            log.warning(
+                "The parameter max_buffer_size is now deprecated and is not used anymore"
+            )
 
         # Check host and port env vars
         agent_host = os.environ.get("DD_AGENT_HOST")
@@ -442,17 +451,22 @@ class DogStatsd(object):
         elif self._disable_aggregating:
             # Indicates if the process is about to fork, so we shouldn't start any new threads yet.
             self._forking = False
-             # Start the flush thread if buffering is enabled and the interval is above
+            # Start the flush thread if buffering is enabled and the interval is above
             # a reasonable range. This both prevents thrashing and allow us to use "0.0"
             # as a value for disabling the automatic flush timer as well.
             self._buffer_flush_interval = buffer_flush_interval
             self._batching_flush_thread_stop = threading.Event()
             self._send = self._send_to_buffer
-            # We make the _batching_flush_thread and _aggregation_flush_thread a list so that it is a mutable object, which allows us to mutate it in the 
+            # We make the _batching_flush_thread and _aggregation_flush_thread a list so that it is a mutable object, which allows us to mutate it in the
             # _start_flush_thread function
             self._batching_flush_thread = [None]
-            self._start_flush_thread(self._buffer_flush_interval, MIN_BUFFERING_FLUSH_INTERVAL, self.flush_buffered_metrics, self._batching_flush_thread,
-                self._batching_flush_thread_stop)
+            self._start_flush_thread(
+                self._buffer_flush_interval,
+                MIN_BUFFERING_FLUSH_INTERVAL,
+                self.flush_buffered_metrics,
+                self._batching_flush_thread,
+                self._batching_flush_thread_stop,
+            )
         else:
             self._send = self._send_to_server
             self._forking = False
@@ -461,8 +475,13 @@ class DogStatsd(object):
             self._aggregation_flush_interval = aggregation_flush_interval
             self._aggregation_flush_thread_stop = threading.Event()
             self._aggregation_flush_thread = [None]
-            self._start_flush_thread(self._aggregation_flush_interval, MIN_AGGREGATION_FLUSH_INTERVAL, self.flush_aggregated_metrics, 
-                self._aggregation_flush_thread, self._aggregation_flush_thread_stop)
+            self._start_flush_thread(
+                self._aggregation_flush_interval,
+                MIN_AGGREGATION_FLUSH_INTERVAL,
+                self.flush_aggregated_metrics,
+                self._aggregation_flush_thread,
+                self._aggregation_flush_thread_stop,
+            )
 
         self._queue = None
         self._sender_thread = None
@@ -484,10 +503,14 @@ class DogStatsd(object):
             self._socket_path = path
             if path is None:
                 self._transport = "udp"
-                self._max_payload_size = self._max_buffer_len or UDP_OPTIMAL_PAYLOAD_LENGTH
+                self._max_payload_size = (
+                    self._max_buffer_len or UDP_OPTIMAL_PAYLOAD_LENGTH
+                )
             else:
                 self._transport = "uds"
-                self._max_payload_size = self._max_buffer_len or UDS_OPTIMAL_PAYLOAD_LENGTH
+                self._max_payload_size = (
+                    self._max_buffer_len or UDS_OPTIMAL_PAYLOAD_LENGTH
+                )
 
     def enable_background_sender(self, sender_queue_size=0, sender_queue_timeout=0):
         """
@@ -538,22 +561,34 @@ class DogStatsd(object):
         self._telemetry = True
 
     # Note: Invocations of this method should be thread-safe
-    def _start_flush_thread(self, flush_interval, min_flush_interval, flush_function, flush_thread_container, flush_thread_stop):
+    def _start_flush_thread(
+        self,
+        flush_interval,
+        min_flush_interval,
+        flush_function,
+        flush_thread_container,
+        flush_thread_stop,
+    ):
         if self._disable_buffering and flush_function == self.flush_buffered_metrics:
             log.debug("Statsd periodic buffer flush is disabled")
             return
-        if self._disable_aggregating and flush_function == self.flush_aggregated_metrics:
+        if (
+            self._disable_aggregating
+            and flush_function == self.flush_aggregated_metrics
+        ):
             log.debug("Statsd periodic aggregating flush is disabled")
             return
-        
-        flush_type = ''
+
+        flush_type = ""
         if self._disable_buffering:
-            flush_type = 'aggregation'
+            flush_type = "aggregation"
         else:
-            flush_type = 'buffering'
+            flush_type = "buffering"
 
         if flush_interval <= min_flush_interval:
-            log.debug("the set flush interval for %s is less then the minimum", flush_type)
+            log.debug(
+                "the set flush interval for %s is less then the minimum", flush_type
+            )
             return
 
         if self._forking:
@@ -570,7 +605,10 @@ class DogStatsd(object):
         new_thread = threading.Thread(
             name="{}_flush_thread".format(self.__class__.__name__),
             target=_flush_thread_loop,
-            args=(self, flush_interval,),
+            args=(
+                self,
+                flush_interval,
+            ),
         )
         new_thread.daemon = True
         new_thread.start()
@@ -647,9 +685,14 @@ class DogStatsd(object):
                 log.debug("Statsd buffering is disabled")
             else:
                 self._send = self._send_to_buffer
-                self._start_flush_thread(self._buffer_flush_interval, MIN_BUFFERING_FLUSH_INTERVAL, self.flush_buffered_metrics, self._batching_flush_thread,
-                    self._batching_flush_thread_stop)
-    
+                self._start_flush_thread(
+                    self._buffer_flush_interval,
+                    MIN_BUFFERING_FLUSH_INTERVAL,
+                    self.flush_buffered_metrics,
+                    self._batching_flush_thread,
+                    self._batching_flush_thread_stop,
+                )
+
     @property
     def disable_aggregation(self):
         with self._config_lock:
@@ -671,8 +714,13 @@ class DogStatsd(object):
                 self._stop_aggregation_flush_thread()
                 log.debug("Statsd aggregation is disabled")
             else:
-                self._start_flush_thread(self._aggregation_flush_interval, MIN_AGGREGATION_FLUSH_INTERVAL, self.flush_aggregated_metrics, self._aggregation_flush_thread,
-                    self._aggregation_flush_thread_stop)
+                self._start_flush_thread(
+                    self._aggregation_flush_interval,
+                    MIN_AGGREGATION_FLUSH_INTERVAL,
+                    self.flush_aggregated_metrics,
+                    self._aggregation_flush_thread,
+                    self._aggregation_flush_thread_stop,
+                )
 
     @staticmethod
     def resolve_host(host, use_default_route):
@@ -715,7 +763,9 @@ class DogStatsd(object):
 
             if not self.socket:
                 if self.socket_path is not None:
-                    self.socket = self._get_uds_socket(self.socket_path, self.socket_timeout)
+                    self.socket = self._get_uds_socket(
+                        self.socket_path, self.socket_timeout
+                    )
                 else:
                     self.socket = self._get_udp_socket(
                         self.host,
@@ -741,7 +791,7 @@ class DogStatsd(object):
     def _ensure_min_send_buffer_size(cls, sock, min_size=MIN_SEND_BUFFER_SIZE):
         # Increase the receiving buffer size where needed (e.g. MacOS has 4k RX
         # buffers which is half of the max packet size that the client will send.
-        if os.name == 'posix':
+        if os.name == "posix":
             try:
                 recv_buff_size = sock.getsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF)
                 if recv_buff_size <= min_size:
@@ -804,7 +854,9 @@ class DogStatsd(object):
         self._send = self._send_to_buffer
 
         if max_buffer_size is not None:
-            log.warning("The parameter max_buffer_size is now deprecated and is not used anymore")
+            log.warning(
+                "The parameter max_buffer_size is now deprecated and is not used anymore"
+            )
 
     def close_buffer(self):
         """
@@ -835,7 +887,7 @@ class DogStatsd(object):
             if self._buffer:
                 self._send_to_server("\n".join(self._buffer))
                 self._reset_buffer()
-    
+
     def flush_aggregated_metrics(self):
         """
         Flush the aggregated metrics
@@ -1045,7 +1097,9 @@ class DogStatsd(object):
             finally:
                 statsd.distribution("user.query.time", time.time() - start)
         """
-        return DistributedContextManagerDecorator(self, metric, tags, sample_rate, use_ms)
+        return DistributedContextManagerDecorator(
+            self, metric, tags, sample_rate, use_ms
+        )
 
     def set(self, metric, value, tags=None, sample_rate=None):
         """
@@ -1112,7 +1166,9 @@ class DogStatsd(object):
             return
         # TODO: use metric_types enum
         # timestamps (protocol v1.3) only allowed on gauges and counts
-        allows_timestamp = metric_type == MetricType.GAUGE or metric_type == MetricType.COUNT
+        allows_timestamp = (
+            metric_type == MetricType.GAUGE or metric_type == MetricType.COUNT
+        )
         if not allows_timestamp or timestamp < 0:
             timestamp = 0
 
@@ -1178,8 +1234,10 @@ class DogStatsd(object):
         )
 
     def _is_telemetry_flush_time(self):
-        return self._telemetry and \
-            self._last_flush_time + self._telemetry_flush_interval < time.time()
+        return (
+            self._telemetry
+            and self._last_flush_time + self._telemetry_flush_interval < time.time()
+        )
 
     def _send_to_server(self, packet):
         # Skip the lock if the queue is None. There is no race with enable_background_sender.
@@ -1188,13 +1246,15 @@ class DogStatsd(object):
             with self._buffer_lock:
                 if self._queue is not None:
                     try:
-                        self._queue.put(packet + '\n', self._queue_blocking, self._queue_timeout)
+                        self._queue.put(
+                            packet + "\n", self._queue_blocking, self._queue_timeout
+                        )
                     except queue.Full:
                         self.packets_dropped_queue += 1
                         self.bytes_dropped_queue += 1
                     return
 
-        self._xmit_packet_with_telemetry(packet + '\n')
+        self._xmit_packet_with_telemetry(packet + "\n")
 
     def _xmit_packet_with_telemetry(self, packet):
         self._xmit_packet(packet, False)
@@ -1237,14 +1297,17 @@ class DogStatsd(object):
             self.close_socket()
         except socket.error as socket_err:
             if socket_err.errno == errno.EAGAIN:
-                log.debug("Socket send would block: %s, dropping the packet", socket_err)
+                log.debug(
+                    "Socket send would block: %s, dropping the packet", socket_err
+                )
             elif socket_err.errno == errno.ENOBUFS:
                 log.debug("Socket buffer full: %s, dropping the packet", socket_err)
             elif socket_err.errno == errno.EMSGSIZE:
                 log.debug(
                     "Packet size too big (size: %d): %s, dropping the packet",
                     len(packet.encode(self.encoding)),
-                    socket_err)
+                    socket_err,
+                )
             else:
                 log.warning(
                     "Error submitting packet: %s, dropping the packet and closing the socket",
@@ -1272,7 +1335,10 @@ class DogStatsd(object):
             self._current_buffer_total_size += len(packet) + 1
 
     def _should_flush(self, length_to_be_added):
-        if self._current_buffer_total_size + length_to_be_added + 1 > self._max_payload_size:
+        if (
+            self._current_buffer_total_size + length_to_be_added + 1
+            > self._max_payload_size
+        ):
             return True
         return False
 
@@ -1308,17 +1374,21 @@ class DogStatsd(object):
 
         # pylint: disable=undefined-variable
         if not is_p3k():
-            if not isinstance(title, unicode):                                       # noqa: F821
-                title = unicode(DogStatsd._escape_event_content(title), 'utf8')      # noqa: F821
-            if not isinstance(message, unicode):                                     # noqa: F821
-                message = unicode(DogStatsd._escape_event_content(message), 'utf8')  # noqa: F821
+            if not isinstance(title, unicode):  # noqa: F821
+                title = unicode(
+                    DogStatsd._escape_event_content(title), "utf8"
+                )  # noqa: F821
+            if not isinstance(message, unicode):  # noqa: F821
+                message = unicode(
+                    DogStatsd._escape_event_content(message), "utf8"
+                )  # noqa: F821
 
         # Append all client level tags to every event
         tags = self._add_constant_tags(tags)
 
-        string = u"_e{{{},{}}}:{}|{}".format(
-            len(title.encode('utf8', 'replace')),
-            len(message.encode('utf8', 'replace')),
+        string = "_e{{{},{}}}:{}|{}".format(
+            len(title.encode("utf8", "replace")),
+            len(message.encode("utf8", "replace")),
             title,
             message,
         )
@@ -1342,9 +1412,7 @@ class DogStatsd(object):
 
         if len(string) > 8 * 1024:
             raise ValueError(
-                u'Event "{0}" payload is too big (>=8KB). Event discarded'.format(
-                    title
-                )
+                'Event "{0}" payload is too big (>=8KB). Event discarded'.format(title)
             )
 
         if self._telemetry:
@@ -1366,23 +1434,27 @@ class DogStatsd(object):
 
         >>> statsd.service_check("my_service.check_name", DogStatsd.WARNING)
         """
-        message = DogStatsd._escape_service_check_message(message) if message is not None else ""
+        message = (
+            DogStatsd._escape_service_check_message(message)
+            if message is not None
+            else ""
+        )
 
-        string = u"_sc|{0}|{1}".format(check_name, status)
+        string = "_sc|{0}|{1}".format(check_name, status)
 
         # Append all client level tags to every status check
         tags = self._add_constant_tags(tags)
 
         if timestamp:
-            string = u"{0}|d:{1}".format(string, timestamp)
+            string = "{0}|d:{1}".format(string, timestamp)
         if hostname:
-            string = u"{0}|h:{1}".format(string, hostname)
+            string = "{0}|h:{1}".format(string, hostname)
         if tags:
-            string = u"{0}|#{1}".format(string, ",".join(tags))
+            string = "{0}|#{1}".format(string, ",".join(tags))
         if message:
-            string = u"{0}|m:{1}".format(string, message)
+            string = "{0}|m:{1}".format(string, message)
         if self._container_id:
-            string = u"{0}|c:{1}".format(string, self._container_id)
+            string = "{0}|c:{1}".format(string, self._container_id)
 
         if self._telemetry:
             self.service_checks_count += 1
@@ -1440,7 +1512,7 @@ class DogStatsd(object):
         self._sender_thread = threading.Thread(
             name="{}_sender_thread".format(self.__class__.__name__),
             target=self._sender_main_loop,
-            args=(self._queue,)
+            args=(self._queue,),
         )
         self._sender_thread.daemon = True
         self._sender_thread.start()
@@ -1508,8 +1580,13 @@ class DogStatsd(object):
         self._forking = False
 
         with self._config_lock:
-            self._start_flush_thread(self._buffer_flush_interval, MIN_BUFFERING_FLUSH_INTERVAL, self.flush_buffered_metrics, self._batching_flush_thread,
-                self._batching_flush_thread_stop)
+            self._start_flush_thread(
+                self._buffer_flush_interval,
+                MIN_BUFFERING_FLUSH_INTERVAL,
+                self.flush_buffered_metrics,
+                self._batching_flush_thread,
+                self._batching_flush_thread_stop,
+            )
             self._start_sender_thread()
 
     def stop(self):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -711,14 +711,6 @@ class DogStatsd(object):
             self._stop_aggregation_flush_thread()
             log.debug("Statsd aggregation is disabled")
 
-            self._start_flush_thread(
-                self._aggregation_flush_interval,
-                MIN_AGGREGATION_FLUSH_INTERVAL,
-                self.flush_aggregated_metrics,
-                self._aggregation_flush_thread,
-                self._aggregation_flush_thread_stop,
-            )
-
     def enable_aggregation(self, aggregation_flush_interval=DEFAULT_AGGREGATION_FLUSH_INTERVAL):
         with self._config_lock:
             if not self._disable_aggregating:

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -573,7 +573,7 @@ class DogStatsd(object):
         flush_thread_container,
         flush_thread_stop,
     ):
-        if self._disable_buffering and flush_function == self.flush_buffered_metrics:
+        if (self._disable_buffering or not self._disable_aggregating) and flush_function == self.flush_buffered_metrics:
             log.debug("Statsd periodic buffer flush is disabled")
             return
         if (

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -465,7 +465,6 @@ class DogStatsd(object):
             self._send = self._send_to_server
             log.debug("Statsd buffering and aggregation is disabled")
         elif self._disable_aggregating:
-            
             # Start the flush thread if buffering is enabled and the interval is above
             # a reasonable range. This both prevents thrashing and allow us to use "0.0"
             # as a value for disabling the automatic flush timer as well.
@@ -1398,14 +1397,10 @@ class DogStatsd(object):
 
         # pylint: disable=undefined-variable
         if not is_p3k():
-            if not isinstance(title, unicode):  # noqa: F821
-                title = unicode(
-                    DogStatsd._escape_event_content(title), "utf8"
-                )  # noqa: F821
-            if not isinstance(message, unicode):  # noqa: F821
-                message = unicode(
-                    DogStatsd._escape_event_content(message), "utf8"
-                )  # noqa: F821
+            if not isinstance(title, unicode):                                       # noqa: F821
+                title = unicode(DogStatsd._escape_event_content(title), 'utf8')      # noqa: F821
+            if not isinstance(message, unicode):                                     # noqa: F821
+                message = unicode(DogStatsd._escape_event_content(message), 'utf8')  # noqa: F821
 
         # Append all client level tags to every event
         tags = self._add_constant_tags(tags)

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -962,6 +962,7 @@ class DogStatsd(object):
             self._report(metric, "c", value, tags, sample_rate)
         else:
             print("AGGREGATION ENABLED")
+            print("FLUSH THREAD IS ", self._aggregation_flush_thread[0])
             self.aggregator.count(metric, value, tags, sample_rate)
 
     # Minimum Datadog Agent version: 7.40.0

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -53,7 +53,7 @@ DEFAULT_BUFFERING_FLUSH_INTERVAL = 0.3
 MIN_BUFFERING_FLUSH_INTERVAL = 0.0001
 
 # Aggregation-related values (in seconds)
-DEFAULT_AGGREGATION_FLUSH_INTERVAL = 3
+DEFAULT_AGGREGATION_FLUSH_INTERVAL = 2
 MIN_AGGREGATION_FLUSH_INTERVAL = 0.01
 # Env var to enable/disable sending the container ID field
 ORIGIN_DETECTION_ENABLED = "DD_ORIGIN_DETECTION_ENABLED"
@@ -235,7 +235,7 @@ class DogStatsd(object):
         it overrides the default value.
         :type flush_interval: float
 
-        :disable_aggregating: If true, metrics (Count, Guage, Set) are no longered aggregated by the client
+        :disable_aggregating: If true, metrics (Count, Gauge, Set) are no longered aggregated by the client
         :type disable_aggregating: bool
 
         :disable_buffering: If set, metrics are no longered buffered by the client and
@@ -1205,6 +1205,7 @@ class DogStatsd(object):
         )
 
         # Send it
+        print("payload sent", payload)
         self._send(payload)
 
     def _reset_telemetry(self):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -712,9 +712,6 @@ class DogStatsd(object):
             log.debug("Statsd aggregation is disabled")
 
     def enable_aggregation(self, aggregation_flush_interval=DEFAULT_AGGREGATION_FLUSH_INTERVAL):
-        print("andrewqian")
-        log.info("andrewqian")
-        log.debug("andrewqian")
         with self._config_lock:
             if not self._disable_aggregating:
                 return

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1533,7 +1533,16 @@ class DogStatsd(object):
 
     def post_fork_parent(self):
         """Restore the client state after a fork in the parent process."""
-        self._start_flush_thread(self._flush_interval)
+        if self._disable_aggregating:
+            self._start_flush_thread(
+                self._flush_interval,
+                self.flush_buffered_metrics,
+            )
+        else:
+            self._start_flush_thread(
+                self._flush_interval,
+                self.flush_aggregated_metrics,
+            )
         self._start_sender_thread()
         self._config_lock.release()
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -486,10 +486,10 @@ class DogStatsd(object):
             self._socket_path = path
             if path is None:
                 self._transport = "udp"
-                self._max_payload_size = (self._max_buffer_len or UDP_OPTIMAL_PAYLOAD_LENGTH)
+                self._max_payload_size = self._max_buffer_len or UDP_OPTIMAL_PAYLOAD_LENGTH
             else:
                 self._transport = "uds"
-                self._max_payload_size = (self._max_buffer_len or UDS_OPTIMAL_PAYLOAD_LENGTH)
+                self._max_payload_size = self._max_buffer_len or UDS_OPTIMAL_PAYLOAD_LENGTH
 
     def enable_background_sender(self, sender_queue_size=0, sender_queue_timeout=0):
         """
@@ -1130,7 +1130,6 @@ class DogStatsd(object):
 
         if sample_rate != 1 and random() > sample_rate:
             return
-        # TODO: use metric_types enum
         # timestamps (protocol v1.3) only allowed on gauges and counts
         allows_timestamp = metric_type == MetricType.GAUGE or metric_type == MetricType.COUNT
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -24,6 +24,10 @@ except ImportError:
     # pypy has the same module, but capitalized.
     import Queue as queue  # type: ignore[no-redef]
 
+# pylint: disable=unused-import
+from typing import Optional, List, Text, Union
+# pylint: enable=unused-import
+
 # Datadog libraries
 from datadog.dogstatsd.aggregator import Aggregator
 from datadog.dogstatsd.metric_types import MetricType

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -592,7 +592,7 @@ class DogStatsd(object):
         if not self._flush_thread:
             return
         try:
-            if self.disable_aggregation:
+            if self._disable_aggregating:
                 self.flush_buffered_metrics()
             else:
                 self.flush_aggregated_metrics()
@@ -1524,9 +1524,15 @@ class DogStatsd(object):
         self._forking = False
 
         with self._config_lock:
-            self._start_flush_thread(
+            if self._disable_aggregating:
+                self._start_flush_thread(
+                    self._flush_interval,
+                    self.flush_buffered_metrics,
+                )
+            else:
+                self._start_flush_thread(
                 self._flush_interval,
-                self.flush_buffered_metrics,
+                self.flush_aggregated_metrics,
             )
             self._start_sender_thread()
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -103,9 +103,7 @@ TELEMETRY_FORMATTING_STR = (
 
 Stop = object()
 
-SUPPORTS_FORKING = hasattr(os, "register_at_fork") and not os.environ.get(
-    "DD_DOGSTATSD_DISABLE_FORK_SUPPORT", None
-)
+SUPPORTS_FORKING = hasattr(os, "register_at_fork") and not os.environ.get("DD_DOGSTATSD_DISABLE_FORK_SUPPORT", None)
 TRACK_INSTANCES = not os.environ.get("DD_DOGSTATSD_DISABLE_INSTANCE_TRACKING", None)
 
 _instances = weakref.WeakSet()  # type: weakref.WeakSet
@@ -130,9 +128,7 @@ def post_fork():
 
 
 if SUPPORTS_FORKING:
-    os.register_at_fork(
-        before=pre_fork, after_in_child=post_fork, after_in_parent=post_fork
-    )  # type: ignore
+    os.register_at_fork(before=pre_fork, after_in_child=post_fork, after_in_parent=post_fork)  # type: ignore
 
 
 # pylint: disable=useless-object-inheritance,too-many-instance-attributes

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1536,9 +1536,9 @@ class DogStatsd(object):
                 )
             else:
                 self._start_flush_thread(
-                self._flush_interval,
-                self.flush_aggregated_metrics,
-            )
+                    self._flush_interval,
+                    self.flush_aggregated_metrics,
+                )
             self._start_sender_thread()
 
     def stop(self):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1414,7 +1414,7 @@ class DogStatsd(object):
         # Append all client level tags to every event
         tags = self._add_constant_tags(tags)
 
-        string = "_e{{{},{}}}:{}|{}".format(
+        string = u"_e{{{},{}}}:{}|{}".format(
             len(title.encode("utf8", "replace")),
             len(message.encode("utf8", "replace")),
             title,
@@ -1468,21 +1468,21 @@ class DogStatsd(object):
             else ""
         )
 
-        string = "_sc|{0}|{1}".format(check_name, status)
+        string = u"_sc|{0}|{1}".format(check_name, status)
 
         # Append all client level tags to every status check
         tags = self._add_constant_tags(tags)
 
         if timestamp:
-            string = "{0}|d:{1}".format(string, timestamp)
+            string = u"{0}|d:{1}".format(string, timestamp)
         if hostname:
-            string = "{0}|h:{1}".format(string, hostname)
+            string = u"{0}|h:{1}".format(string, hostname)
         if tags:
-            string = "{0}|#{1}".format(string, ",".join(tags))
+            string = u"{0}|#{1}".format(string, ",".join(tags))
         if message:
-            string = "{0}|m:{1}".format(string, message)
+            string = u"{0}|m:{1}".format(string, message)
         if self._container_id:
-            string = "{0}|c:{1}".format(string, self._container_id)
+            string = u"{0}|c:{1}".format(string, self._container_id)
 
         if self._telemetry:
             self.service_checks_count += 1

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -53,7 +53,7 @@ DEFAULT_BUFFERING_FLUSH_INTERVAL = 0.3
 MIN_BUFFERING_FLUSH_INTERVAL = 0.0001
 
 # Aggregation-related values (in seconds)
-DEFAULT_AGGREGATION_FLUSH_INTERVAL = 3
+DEFAULT_AGGREGATION_FLUSH_INTERVAL = 60
 MIN_AGGREGATION_FLUSH_INTERVAL = 0.01
 # Env var to enable/disable sending the container ID field
 ORIGIN_DETECTION_ENABLED = "DD_ORIGIN_DETECTION_ENABLED"
@@ -348,7 +348,8 @@ class DogStatsd(object):
             log.warning(
                 "The parameter max_buffer_size is now deprecated and is not used anymore"
             )
-
+        print("BASE.PY buffering is ????", disable_buffering)
+        print("BASE.PY disable_aggregating is ????", disable_aggregating)
         # Check host and port env vars
         agent_host = os.environ.get("DD_AGENT_HOST")
         if agent_host and host == DEFAULT_HOST:
@@ -448,6 +449,7 @@ class DogStatsd(object):
 
         self._disable_buffering = disable_buffering
         self._disable_aggregating = disable_aggregating
+        
         self._buffer_flush_interval = buffer_flush_interval
         self._aggregation_flush_interval = aggregation_flush_interval
         # We make the _buffering_flush_thread and _aggregation_flush_thread a list so that it is a mutable object,
@@ -956,8 +958,10 @@ class DogStatsd(object):
         >>> statsd.count("page.views", 123)
         """
         if self._disable_aggregating:
+            print("AGGREGATION DISABLED")
             self._report(metric, "c", value, tags, sample_rate)
         else:
+            print("AGGREGATION ENABLED")
             self.aggregator.count(metric, value, tags, sample_rate)
 
     # Minimum Datadog Agent version: 7.40.0
@@ -997,8 +1001,10 @@ class DogStatsd(object):
         >>> statsd.increment("files.transferred", 124)
         """
         if self._disable_aggregating:
+            print("NO aggregation")
             self._report(metric, "c", value, tags, sample_rate)
         else:
+            print("YES we are aggregating")
             self.aggregator.count(metric, value, tags, sample_rate)
 
     def decrement(

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -712,6 +712,9 @@ class DogStatsd(object):
             log.debug("Statsd aggregation is disabled")
 
     def enable_aggregation(self, aggregation_flush_interval=DEFAULT_AGGREGATION_FLUSH_INTERVAL):
+        print("andrewqian")
+        log.info("andrewqian")
+        log.debug("andrewqian")
         with self._config_lock:
             if not self._disable_aggregating:
                 return

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -447,7 +447,7 @@ class DogStatsd(object):
 
         self._disable_buffering = disable_buffering
         self._disable_aggregating = disable_aggregating
-        
+
         self._flush_interval = flush_interval
         self._aggregation_flush_interval = aggregation_flush_interval
         # We make the _buffering_flush_thread and _aggregation_flush_thread a list so that it is a mutable object,

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -24,10 +24,6 @@ except ImportError:
     # pypy has the same module, but capitalized.
     import Queue as queue  # type: ignore[no-redef]
 
-# pylint: disable=unused-import
-from typing import Optional, List, Text, Union
-# pylint: enable=unused-import
-
 # Datadog libraries
 from datadog.dogstatsd.aggregator import Aggregator
 from datadog.dogstatsd.metric_types import MetricType

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -24,6 +24,11 @@ except ImportError:
     # pypy has the same module, but capitalized.
     import Queue as queue  # type: ignore[no-redef]
 
+
+# pylint: disable=unused-import
+from typing import Optional, List, Text, Union
+# pylint: enable=unused-import
+
 # Datadog libraries
 from datadog.dogstatsd.aggregator import Aggregator
 from datadog.dogstatsd.metric_types import MetricType

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -719,7 +719,7 @@ class DogStatsd(object):
                 self._aggregation_flush_thread_stop,
             )
     
-    def enable_aggregation(self, aggregation_flush_interval):
+    def enable_aggregation(self, aggregation_flush_interval=DEFAULT_AGGREGATION_FLUSH_INTERVAL):
         with self._config_lock:
             if not self._disable_aggregating:
                     return

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -996,7 +996,10 @@ class DogStatsd(object):
         >>> statsd.increment("page.views")
         >>> statsd.increment("files.transferred", 124)
         """
-        self._report(metric, "c", value, tags, sample_rate)
+        if self._disable_aggregating:
+            self._report(metric, "c", value, tags, sample_rate)
+        else:
+            self.aggregator.count(metric, value, tags, sample_rate)
 
     def decrement(
         self,

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -712,9 +712,9 @@ class DogStatsd(object):
             log.debug("Statsd aggregation is disabled")
 
     def enable_aggregation(self, aggregation_flush_interval=DEFAULT_AGGREGATION_FLUSH_INTERVAL):
-        print("andrewqian")
-        log.info("andrewqian")
-        log.debug("andrewqian")
+        # print("andrewqian")
+        # log.info("andrewqian")
+        # log.debug("andrewqian")
         with self._config_lock:
             if not self._disable_aggregating:
                 return

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -714,7 +714,7 @@ class DogStatsd(object):
     def enable_aggregation(self, aggregation_flush_interval=DEFAULT_AGGREGATION_FLUSH_INTERVAL):
         with self._config_lock:
             if not self._disable_aggregating:
-                    return
+                return
             self._disable_aggregating = False
             self._aggregation_flush_interval = aggregation_flush_interval
             self._send = self._send_to_server

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -461,7 +461,7 @@ class DogStatsd(object):
             self._aggregation_flush_interval = aggregation_flush_interval
             self._aggregation_flush_thread_stop = threading.Event()
             self._aggregation_flush_thread = [None]
-            self._start_flush_thread(self._aggregation_flush_interval, MIN_AGGREGATION_FLUSH_INTERVAL, self.aggregator.flush_aggregated_metrics, 
+            self._start_flush_thread(self._aggregation_flush_interval, MIN_AGGREGATION_FLUSH_INTERVAL, self.flush_aggregated_metrics, 
                 self._aggregation_flush_thread, self._aggregation_flush_thread_stop)
 
         self._queue = None
@@ -591,7 +591,7 @@ class DogStatsd(object):
         if not self._aggregation_flush_thread:
             return
         try:
-            self.aggregator.flush_aggregated_metrics()
+            self.flush_aggregated_metrics()
         finally:
             pass
 
@@ -800,6 +800,14 @@ class DogStatsd(object):
             if self._buffer:
                 self._send_to_server("\n".join(self._buffer))
                 self._reset_buffer()
+    
+    def flush_aggregated_metrics(self):
+        """
+        Flush the aggregated metrics
+        """
+        metrics = self.aggregator.flush_aggregated_metrics()
+        for m in metrics:
+            self._report(m.name, m.metric_type, m.value, m.tags, m.rate, m.timestamp)
 
     def gauge(
         self,
@@ -1481,7 +1489,7 @@ class DogStatsd(object):
         self.disable_buffering = True
         self.disable_aggregating = True
         self.flush_buffered_metrics()
-        self.aggregator.flush_aggregated_metrics()
+        self.flush_aggregated_metrics()
         self.close_socket()
 
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -141,7 +141,7 @@ class DogStatsd(object):
         host=DEFAULT_HOST,  # type: Text
         port=DEFAULT_PORT,  # type: int
         max_buffer_size=None,  # type: None
-        buffer_flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL,  # type: float
+        flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL,  # type: float
         disable_aggregating=True,  # type: bool
         disable_buffering=True,  # type: bool
         namespace=None,  # type: Optional[Text]
@@ -230,10 +230,10 @@ class DogStatsd(object):
         :max_buffer_size: Deprecated option, do not use it anymore.
         :type max_buffer_type: None
 
-        :buffer_flush_interval: Amount of time in seconds that the flush thread will
+        :flush_interval: Amount of time in seconds that the flush thread will
         wait before trying to flush the buffered metrics to the server. If set,
         it overrides the default value.
-        :type buffer_flush_interval: float
+        :type flush_interval: float
 
         :disable_aggregating: If true, metrics (Count, Guage, Set) are no longered aggregated by the client
         :type disable_aggregating: bool
@@ -450,7 +450,7 @@ class DogStatsd(object):
         self._disable_buffering = disable_buffering
         self._disable_aggregating = disable_aggregating
         
-        self._buffer_flush_interval = buffer_flush_interval
+        self._flush_interval = flush_interval
         self._aggregation_flush_interval = aggregation_flush_interval
         # We make the _buffering_flush_thread and _aggregation_flush_thread a list so that it is a mutable object,
         # which allows us to mutate it in the
@@ -472,7 +472,7 @@ class DogStatsd(object):
             # as a value for disabling the automatic flush timer as well.
             self._send = self._send_to_buffer
             self._start_flush_thread(
-                self._buffer_flush_interval,
+                self._flush_interval,
                 MIN_BUFFERING_FLUSH_INTERVAL,
                 self.flush_buffered_metrics,
                 self._buffering_flush_thread,
@@ -692,7 +692,7 @@ class DogStatsd(object):
             else:
                 self._send = self._send_to_buffer
                 self._start_flush_thread(
-                    self._buffer_flush_interval,
+                    self._flush_interval,
                     MIN_BUFFERING_FLUSH_INTERVAL,
                     self.flush_buffered_metrics,
                     self._buffering_flush_thread,
@@ -1609,7 +1609,7 @@ class DogStatsd(object):
 
         with self._config_lock:
             self._start_flush_thread(
-                self._buffer_flush_interval,
+                self._flush_interval,
                 MIN_BUFFERING_FLUSH_INTERVAL,
                 self.flush_buffered_metrics,
                 self._buffering_flush_thread,

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -666,12 +666,11 @@ class DogStatsd(object):
 
             # If aggregation has been disabled, flush and kill the background thread
             # otherwise start up the flushing thread and enable aggregation.
+            self._send = self._send_to_server
             if is_disabled:
-                self._send = self._send_to_server
                 self._stop_aggregation_flush_thread()
                 log.debug("Statsd aggregation is disabled")
             else:
-                self._send = self._send_to_aggregator
                 self._start_flush_thread(self._aggregation_flush_interval, MIN_AGGREGATION_FLUSH_INTERVAL, self.flush_aggregated_metrics, self._aggregation_flush_thread,
                     self._aggregation_flush_thread_stop)
 

--- a/tests/integration/dogstatsd/test_statsd_sender.py
+++ b/tests/integration/dogstatsd/test_statsd_sender.py
@@ -66,7 +66,7 @@ def test_fork_hooks(disable_background_sender, disable_buffering):
 
     statsd.increment("test.metric")
 
-    assert disable_buffering or statsd._flush_thread.is_alive()
+    assert disable_buffering or statsd._buffering_flush_thread[0].is_alive()
     assert disable_background_sender or statsd._sender_thread.is_alive()
 
     statsd.pre_fork()

--- a/tests/integration/dogstatsd/test_statsd_sender.py
+++ b/tests/integration/dogstatsd/test_statsd_sender.py
@@ -51,10 +51,10 @@ def test_set_socket_timeout():
 
 
 @pytest.mark.parametrize(
-    "disable_background_sender, disable_buffering",
-    list(itertools.product([True, False], [True, False])),
+    "disable_background_sender, disable_buffering, disable_aggregating",
+    list(itertools.product([True, False], [True, False], [True, False])),
 )
-def test_fork_hooks(disable_background_sender, disable_buffering):
+def test_fork_hooks(disable_background_sender, disable_buffering, disable_aggregating):
     statsd = DogStatsd(
         telemetry_min_flush_interval=0,
         disable_background_sender=disable_background_sender,
@@ -66,7 +66,7 @@ def test_fork_hooks(disable_background_sender, disable_buffering):
 
     statsd.increment("test.metric")
 
-    assert disable_buffering or statsd._flush_thread.is_alive()
+    assert (disable_buffering and disable_aggregating) or statsd._flush_thread.is_alive()
     assert disable_background_sender or statsd._sender_thread.is_alive()
 
     statsd.pre_fork()
@@ -78,7 +78,7 @@ def test_fork_hooks(disable_background_sender, disable_buffering):
 
     statsd.post_fork()
 
-    assert disable_buffering or statsd._flush_thread.is_alive()
+    assert (disable_buffering and disable_aggregating) or statsd._flush_thread.is_alive()
     assert disable_background_sender or statsd._sender_thread.is_alive()
 
     foo.close()

--- a/tests/integration/dogstatsd/test_statsd_sender.py
+++ b/tests/integration/dogstatsd/test_statsd_sender.py
@@ -66,19 +66,19 @@ def test_fork_hooks(disable_background_sender, disable_buffering):
 
     statsd.increment("test.metric")
 
-    assert disable_buffering or statsd._buffering_flush_thread[0].is_alive()
+    assert disable_buffering or statsd._flush_thread.is_alive()
     assert disable_background_sender or statsd._sender_thread.is_alive()
 
     statsd.pre_fork()
 
-    assert statsd._buffering_flush_thread[0] is None
+    assert statsd._flush_thread is None
     assert statsd._sender_thread is None
     assert statsd._queue is None or statsd._queue.empty()
     assert len(statsd._buffer) == 0
 
     statsd.post_fork()
 
-    assert disable_buffering or statsd._buffering_flush_thread[0].is_alive()
+    assert disable_buffering or statsd._flush_thread.is_alive()
     assert disable_background_sender or statsd._sender_thread.is_alive()
 
     foo.close()

--- a/tests/integration/dogstatsd/test_statsd_sender.py
+++ b/tests/integration/dogstatsd/test_statsd_sender.py
@@ -51,15 +51,14 @@ def test_set_socket_timeout():
 
 
 @pytest.mark.parametrize(
-    "disable_background_sender, disable_buffering, disable_aggregating",
-    list(itertools.product([True, False], [True, False], [True, False])),
+    "disable_background_sender, disable_buffering",
+    list(itertools.product([True, False], [True, False])),
 )
-def test_fork_hooks(disable_background_sender, disable_buffering, disable_aggregating):
+def test_fork_hooks(disable_background_sender, disable_buffering):
     statsd = DogStatsd(
         telemetry_min_flush_interval=0,
         disable_background_sender=disable_background_sender,
         disable_buffering=disable_buffering,
-        disable_aggregating=disable_aggregating
     )
 
     foo, bar = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM, 0)
@@ -67,7 +66,7 @@ def test_fork_hooks(disable_background_sender, disable_buffering, disable_aggreg
 
     statsd.increment("test.metric")
 
-    assert (disable_buffering and disable_aggregating) or statsd._flush_thread.is_alive()
+    assert disable_buffering or statsd._flush_thread.is_alive()
     assert disable_background_sender or statsd._sender_thread.is_alive()
 
     statsd.pre_fork()
@@ -79,7 +78,7 @@ def test_fork_hooks(disable_background_sender, disable_buffering, disable_aggreg
 
     statsd.post_fork()
 
-    assert (disable_buffering and disable_aggregating) or statsd._flush_thread.is_alive()
+    assert disable_buffering or statsd._flush_thread.is_alive()
     assert disable_background_sender or statsd._sender_thread.is_alive()
 
     foo.close()

--- a/tests/integration/dogstatsd/test_statsd_sender.py
+++ b/tests/integration/dogstatsd/test_statsd_sender.py
@@ -101,3 +101,20 @@ def test_buffering_with_context():
     bar.settimeout(5)
     msg = bar.recv(8192)
     assert msg == b"first:1|c\n"
+
+def test_aggregation_with_context():
+    statsd = DogStatsd(
+        telemetry_min_flush_interval=0,
+        disable_aggregating=False,
+    )
+
+    foo, bar = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM, 0)
+    statsd.socket = foo
+
+    statsd.increment("first")
+    with statsd: 
+        pass
+
+    bar.settimeout(5)
+    msg = bar.recv(8192)
+    assert msg == b"first:1|c\n"

--- a/tests/integration/dogstatsd/test_statsd_sender.py
+++ b/tests/integration/dogstatsd/test_statsd_sender.py
@@ -101,20 +101,3 @@ def test_buffering_with_context():
     bar.settimeout(5)
     msg = bar.recv(8192)
     assert msg == b"first:1|c\n"
-
-def test_aggregation_with_context():
-    statsd = DogStatsd(
-        telemetry_min_flush_interval=0,
-        disable_aggregating=False,
-    )
-
-    foo, bar = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM, 0)
-    statsd.socket = foo
-
-    statsd.increment("first")
-    with statsd: 
-        pass
-
-    bar.settimeout(5)
-    msg = bar.recv(8192)
-    assert msg == b"first:1|c\n"

--- a/tests/integration/dogstatsd/test_statsd_sender.py
+++ b/tests/integration/dogstatsd/test_statsd_sender.py
@@ -59,6 +59,7 @@ def test_fork_hooks(disable_background_sender, disable_buffering, disable_aggreg
         telemetry_min_flush_interval=0,
         disable_background_sender=disable_background_sender,
         disable_buffering=disable_buffering,
+        disable_aggregating=disable_aggregating
     )
 
     foo, bar = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM, 0)

--- a/tests/integration/dogstatsd/test_statsd_sender.py
+++ b/tests/integration/dogstatsd/test_statsd_sender.py
@@ -71,14 +71,14 @@ def test_fork_hooks(disable_background_sender, disable_buffering):
 
     statsd.pre_fork()
 
-    assert statsd._flush_thread is None
+    assert statsd._buffering_flush_thread[0] is None
     assert statsd._sender_thread is None
     assert statsd._queue is None or statsd._queue.empty()
     assert len(statsd._buffer) == 0
 
     statsd.post_fork()
 
-    assert disable_buffering or statsd._flush_thread.is_alive()
+    assert disable_buffering or statsd._buffering_flush_thread[0].is_alive()
     assert disable_background_sender or statsd._sender_thread.is_alive()
 
     foo.close()

--- a/tests/unit/dogstatsd/test_aggregator.py
+++ b/tests/unit/dogstatsd/test_aggregator.py
@@ -50,7 +50,7 @@ class TestAggregator(unittest.TestCase):
         self.aggregator.set("setTest1", "value2", tags, 1)
         self.aggregator.set("setTest2", "value1", tags, 1)
 
-        metrics = self.aggregator.flush_metrics()
+        metrics = self.aggregator.flush_aggregated_metrics()
         self.assertEqual(len(self.aggregator.metrics_map[MetricType.GAUGE]), 0)
         self.assertEqual(len(self.aggregator.metrics_map[MetricType.COUNT]), 0)
         self.assertEqual(len(self.aggregator.metrics_map[MetricType.SET]), 0)

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -914,7 +914,7 @@ class TestDogStatsd(unittest.TestCase):
         name, value = name_value.split(':')
 
         self.assertEqual('ms', type_)
-        self.assertEqual('unit.dogstatsd.test_statsd.func', name)
+        self.assertEqual('tests.unit.dogstatsd.test_statsd.func', name)
         self.assert_almost_equal(0.5, float(value), 0.1)
 
     @unittest.skipIf(not is_higher_py35(), reason="Coroutines are supported on Python 3.5 or higher.")

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -29,7 +29,7 @@ import pytest
 # Datadog libraries
 from datadog import initialize, statsd
 from datadog import __version__ as version
-from datadog.dogstatsd.base import DEFAULT_FLUSH_INTERVAL, DogStatsd, MIN_SEND_BUFFER_SIZE, UDP_OPTIMAL_PAYLOAD_LENGTH, UDS_OPTIMAL_PAYLOAD_LENGTH
+from datadog.dogstatsd.base import DEFAULT_BUFFERING_FLUSH_INTERVAL, DogStatsd, MIN_SEND_BUFFER_SIZE, UDP_OPTIMAL_PAYLOAD_LENGTH, UDS_OPTIMAL_PAYLOAD_LENGTH
 from datadog.dogstatsd.context import TimedContextManagerDecorator
 from datadog.util.compat import is_higher_py35, is_p3k
 from tests.util.contextmanagers import preserve_environment_variable, EnvVars
@@ -41,7 +41,7 @@ class FakeSocket(object):
 
     FLUSH_GRACE_PERIOD = 0.2
 
-    def __init__(self, flush_interval=DEFAULT_FLUSH_INTERVAL):
+    def __init__(self, flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL):
         self.payloads = deque()
 
         self._flush_interval = flush_interval
@@ -1111,7 +1111,7 @@ async def print_foo():
         dogstatsd.increment('page.views')
         self.assertIsNone(fake_socket.recv(no_wait=True))
 
-        time.sleep(DEFAULT_FLUSH_INTERVAL)
+        time.sleep(DEFAULT_BUFFERING_FLUSH_INTERVAL)
         self.assertIsNone(fake_socket.recv(no_wait=True))
 
         time.sleep(0.3)

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -914,7 +914,7 @@ class TestDogStatsd(unittest.TestCase):
         name, value = name_value.split(':')
 
         self.assertEqual('ms', type_)
-        self.assertEqual('tests.unit.dogstatsd.test_statsd.func', name)
+        self.assertEqual('unit.dogstatsd.test_statsd.func', name)
         self.assert_almost_equal(0.5, float(value), 0.1)
 
     @unittest.skipIf(not is_higher_py35(), reason="Coroutines are supported on Python 3.5 or higher.")

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -1072,7 +1072,7 @@ async def print_foo():
         self.assert_equal_telemetry('page.views:1|c\n', fake_socket.recv(2))
 
     def test_flush_interval(self):
-        dogstatsd = DogStatsd(disable_buffering=False, buffer_flush_interval=1, telemetry_min_flush_interval=0)
+        dogstatsd = DogStatsd(disable_buffering=False, flush_interval=1, telemetry_min_flush_interval=0)
         fake_socket = FakeSocket()
         dogstatsd.socket = fake_socket
 
@@ -1102,7 +1102,7 @@ async def print_foo():
     def test_flush_disable(self):
         dogstatsd = DogStatsd(
             disable_buffering=False,
-            buffer_flush_interval=0,
+            flush_interval=0,
             telemetry_min_flush_interval=0
         )
         fake_socket = FakeSocket()
@@ -1798,7 +1798,7 @@ async def print_foo():
             )
 
     def test_default_max_udp_packet_size(self):
-        dogstatsd = DogStatsd(disable_buffering=False, buffer_flush_interval=10000, disable_telemetry=True)
+        dogstatsd = DogStatsd(disable_buffering=False, flush_interval=10000, disable_telemetry=True)
         dogstatsd.socket = FakeSocket()
 
         for _ in range(10000):
@@ -1817,7 +1817,7 @@ async def print_foo():
         dogstatsd = DogStatsd(
             disable_buffering=False,
             socket_path="fake",
-            buffer_flush_interval=10000,
+            flush_interval=10000,
             disable_telemetry=True,
         )
         dogstatsd.socket = FakeSocket()
@@ -1838,7 +1838,7 @@ async def print_foo():
         dogstatsd = DogStatsd(
             disable_buffering=False,
             max_buffer_len=4000,
-            buffer_flush_interval=10000,
+            flush_interval=10000,
             disable_telemetry=True,
         )
         dogstatsd.socket = FakeSocket()

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -1413,7 +1413,6 @@ async def print_foo():
         time1 = time.time()
         # setting the last flush time in the past to trigger a telemetry flush
         dogstatsd._last_flush_time = time1 - statsd._telemetry_flush_interval -1
-
         dogstatsd.close_buffer()
 
         metric = 'gauge1:1|g\ngauge2:2|g\n'

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -802,8 +802,8 @@ class TestDogStatsd(unittest.TestCase):
         self.assertEqual('d', type_)
         self.assertEqual('distributed.test', name)
         self.assert_almost_equal(500, float(value), 100)
-
-
+        
+    def test_timed(self):
         """
         Measure the distribution of a function's run time.
         """


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

[Project description
](https://docs.google.com/document/d/11fPSNMnp5tMLRK16VgXa6FJ7fTpzggKevpiO6MsQ0H0/edit?usp=sharing)
This PR adds simple client side aggregation (aggregating metrics before they are received by the agent) for the python client. This PR combines two previous PRs together ([1](https://github.com/DataDog/datadogpy/pull/841), [2](https://github.com/DataDog/datadogpy/pull/837))

Client side aggregation has already been implemented in [Go](https://github.com/DataDog/datadog-go/pull/139), Java, and the C# dogstatsd clients


### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Periodically aggregates metrics (Count, Gauge, Set) for a given `statsd_aggregation_flush_interval` and then sends the aggregated metrics to intake. A metric will be aggregated if `statsd_disable_aggregating` is `False` and there was another [matching context](https://docs.google.com/document/d/1AoveWKoMQc65hYbvZ27uE7pQ_I5nsGfvv25EcNVPLvQ/edit#heading=h.no4x6fjugsh) sent within the same flush interval.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

Unit tests that verify the aggregator.py class matches the existing behavior in the client side aggregator for the [go client](https://github.com/DataDog/datadog-go/pull/139/files#diff-f554159d70c08124ea27e909de77e6b7162f782cbc12363a0cac8825834a2210).

Unit tests that verify the new metric objects (merics.py) match the existing behavior in the [client side aggregator for Go](https://github.com/DataDog/datadogpy/pull/url).

**Local testing**:
[Confluence doc](https://datadoghq.atlassian.net/wiki/spaces/~71202058eaddc626774b6382b0a98b3e9f4a84/pages/3978855545/Local+testing+for+python+client+side+aggregation+project)
[More Docs](https://dddev.datadoghq.com/notebook/9246140/python-client-side-aggregation-testing)

Bench Mark tests (TODO as a stretch goal)

### Additional Notes

<!-- Anything else we should know when reviewing? -->

We currently do not allow buffering and aggregation at the same time, if both enabled, aggregation will occur instead of buffering.
### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [x] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [x] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

