### PR TITLE
Avoid potential deadlock in getaddrinfo

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1531,8 +1531,15 @@ class DogStatsd(object):
         self._stop_flush_thread()
         self._stop_sender_thread()
 
+        # Prevent concurrent calls to system libraries (notably
+        # getaddrinfo) which may leave internal locks in a locked
+        # state and deadlock the child.
+        self._socket_lock.acquire()
+
     def post_fork_parent(self):
         """Restore the client state after a fork in the parent process."""
+        self._socket_lock.release()
+
         if self._disable_aggregating:
             self._start_flush_thread(
                 self._flush_interval,
@@ -1548,21 +1555,17 @@ class DogStatsd(object):
 
     def post_fork_child(self):
         """Restore the client state after a fork in the child process."""
+        self._socket_lock.release()
         self._config_lock.release()
 
         # Discard the locks that could have been locked at the time
         # when we forked. This may cause inconsistent internal state,
         # which we will fix in the next steps.
-        self._socket_lock = Lock()
         self._buffer_lock = RLock()
 
         # Reset the buffer so we don't send metrics from the parent
         # process. Also makes sure buffer properties are consistent.
         self._reset_buffer()
-        # Execute the socket_path setter to reconcile transport and
-        # payload size properties in respect to socket_path value.
-        self.socket_path = self.socket_path
-        self.close_socket()
 
         with self._config_lock:
             if self._disable_aggregating:

--- a/tests/integration/dogstatsd/test_statsd_fork.py
+++ b/tests/integration/dogstatsd/test_statsd_fork.py
@@ -82,6 +82,7 @@ def test_fork_with_thread(disable_background_sender, disable_buffering, sender_f
 
         pid = os.fork()
         if pid == 0:
+            statsd.gauge("spam", 2)
             os._exit(42)
 
         assert pid > 0

--- a/tests/integration/dogstatsd/test_statsd_fork.py
+++ b/tests/integration/dogstatsd/test_statsd_fork.py
@@ -3,6 +3,7 @@ import itertools
 import socket
 import threading
 import logging
+import time
 
 import pytest
 
@@ -49,12 +50,14 @@ def test_register_at_fork(disable_background_sender, disable_buffering):
 def sender_a(statsd, running):
     while running[0]:
         statsd.gauge("spam", 1)
+        time.sleep(0)
 
 
 def sender_b(statsd, running):
     while running[0]:
         with statsd:
             statsd.gauge("spam", 1)
+            time.sleep(0)
 
 @pytest.mark.parametrize(
     "disable_background_sender, disable_buffering, sender_fn",
@@ -86,7 +89,7 @@ def test_fork_with_thread(disable_background_sender, disable_buffering, sender_f
 
         assert os.WEXITSTATUS(status) == 42
     finally:
-        statsd.stop()
         if sender:
             sender_running[0] = False
             sender.join()
+        statsd.stop()


### PR DESCRIPTION
### What does this PR do?

Avoid deadlock in the child process in getaddrinfo if the application forks while a thread is trying to create a socket.

### Description of the Change

Acquire socket lock before forking to prevent the client library from calling getaddrinfo at the same time.

### Alternate Designs

### Possible Drawbacks

### Verification Process

### Additional Notes

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

