### PR TITLE
enable the ability for buffering and aggregation to work at the same

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -82,7 +82,7 @@ def initialize(
                                      (default: True).
     :type statsd_disable_aggregator: boolean
 
-    :param statsd_aggregation_flush_interval: If aggregation is enabled, set the flush interval for 
+    :param statsd_aggregation_flush_interval: If aggregation is enabled, set the flush interval for
                     aggregation/buffering
                                      (default: 0.3 seconds)
     :type statsd_aggregation_flush_interval: float

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -37,7 +37,7 @@ def initialize(
     api_host=None,  # type: Optional[str]
     statsd_host=None,  # type: Optional[str]
     statsd_port=None,  # type: Optional[int]
-    statsd_disable_aggregator=True,  # type: bool
+    statsd_disable_aggregation=True,  # type: bool
     statsd_disable_buffering=True,  # type: bool
     statsd_aggregation_flush_interval=0.3,  # type: float
     statsd_use_default_route=False,  # type: bool
@@ -78,9 +78,9 @@ def initialize(
                                      (default: True).
     :type statsd_disable_buffering: boolean
 
-    :param statsd_disable_aggregator: Enable/disable statsd client aggregation support
+    :param statsd_disable_aggregation: Enable/disable statsd client aggregation support
                                      (default: True).
-    :type statsd_disable_aggregator: boolean
+    :type statsd_disable_aggregation: boolean
 
     :param statsd_aggregation_flush_interval: If aggregation is enabled, set the flush interval for
                     aggregation/buffering
@@ -139,7 +139,7 @@ def initialize(
     if statsd_constant_tags:
         statsd.constant_tags += statsd_constant_tags
 
-    if statsd_disable_aggregator:
+    if statsd_disable_aggregation:
         statsd.disable_aggregation()
     else:
         statsd.enable_aggregation(statsd_aggregation_flush_interval)

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -82,7 +82,8 @@ def initialize(
                                      (default: True).
     :type statsd_disable_aggregator: boolean
 
-    :param statsd_aggregation_flush_interval: If aggregation is enabled, set the flush interval for aggregation/buffering
+    :param statsd_aggregation_flush_interval: If aggregation is enabled, set the flush interval for 
+                    aggregation/buffering
                                      (default: 0.3 seconds)
     :type statsd_aggregation_flush_interval: float
 

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -39,7 +39,7 @@ def initialize(
     statsd_port=None,  # type: Optional[int]
     statsd_disable_aggregator=True,  # type: bool
     statsd_disable_buffering=True,  # type: bool
-    statsd_aggregation_flush_interval=2,  # type: float
+    statsd_aggregation_flush_interval=0.3,  # type: float
     statsd_use_default_route=False,  # type: bool
     statsd_socket_path=None,  # type: Optional[str]
     statsd_namespace=None,  # type: Optional[str]
@@ -82,8 +82,8 @@ def initialize(
                                      (default: True).
     :type statsd_disable_aggregator: boolean
 
-    :param statsd_aggregation_flush_interval: Sets the flush interval for aggregation
-                                     (default: 2 seconds)
+    :param statsd_aggregation_flush_interval: If aggregation is enabled, set the flush interval for aggregation/buffering
+                                     (default: 0.3 seconds)
     :type statsd_aggregation_flush_interval: float
 
     :param statsd_use_default_route: Dynamically set the statsd host to the default route

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -637,7 +637,7 @@ class DogStatsd(object):
 
             self._disable_aggregating = True
 
-            # If aggregation has been disabled, flush and kill the background thread
+            # If aggregation and buffering has been disabled, flush and kill the background thread
             # otherwise start up the flushing thread and enable aggregation.
             if self._disable_aggregating and self.disable_buffering:
                 self._stop_flush_thread()
@@ -812,7 +812,6 @@ class DogStatsd(object):
         with self._buffer_lock:
             # Only send packets if there are packets to send
             if self._buffer:
-                print("flush buffered metrics?")
                 self._send_to_server("\n".join(self._buffer))
                 self._reset_buffer()
 
@@ -1123,6 +1122,7 @@ class DogStatsd(object):
         payload = self._serialize_metric(
             metric, metric_type, value, tags, sample_rate, timestamp
         )
+
         # Send it
         self._send(payload)
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -652,6 +652,7 @@ class DogStatsd(object):
             if self._disable_buffering:
                 self._send = self._send_to_server
             self._start_flush_thread()
+            
     @staticmethod
     def resolve_host(host, use_default_route):
         """

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -50,11 +50,9 @@ DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 8125
 
 # Buffering-related values (in seconds)
-DEFAULT_BUFFERING_FLUSH_INTERVAL = 10
+DEFAULT_FLUSH_INTERVAL = 0.3
 MIN_FLUSH_INTERVAL = 0.0001
 
-# Aggregation-related values (in seconds)
-DEFAULT_AGGREGATION_FLUSH_INTERVAL = 2
 # Env var to enable/disable sending the container ID field
 ORIGIN_DETECTION_ENABLED = "DD_ORIGIN_DETECTION_ENABLED"
 
@@ -147,7 +145,7 @@ class DogStatsd(object):
         host=DEFAULT_HOST,                      # type: Text
         port=DEFAULT_PORT,                      # type: int
         max_buffer_size=None,                   # type: None
-        flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL,  # type: float
+        flush_interval=DEFAULT_FLUSH_INTERVAL,  # type: float
         disable_aggregating=True,               # type: bool
         disable_buffering=True,                 # type: bool
         namespace=None,                         # type: Optional[Text]
@@ -645,7 +643,7 @@ class DogStatsd(object):
                 self._stop_flush_thread()
             log.debug("Statsd aggregation is disabled")
 
-    def enable_aggregation(self, flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL):
+    def enable_aggregation(self, flush_interval=DEFAULT_FLUSH_INTERVAL):
         with self._config_lock:
             if not self._disable_aggregating:
                 return
@@ -1124,7 +1122,6 @@ class DogStatsd(object):
         payload = self._serialize_metric(
             metric, metric_type, value, tags, sample_rate, timestamp
         )
-        print("payload is ", payload)
         # Send it
         self._send(payload)
 
@@ -1272,7 +1269,6 @@ class DogStatsd(object):
             self._buffer.append(packet)
             # Update the current buffer length, including line break to anticipate
             # the final packet size
-            print("buffer is ", self._buffer)
             self._current_buffer_total_size += len(packet) + 1
 
     def _should_flush(self, length_to_be_added):
@@ -1543,8 +1539,8 @@ class DogStatsd(object):
         self.disable_background_sender()
         self._disable_buffering = True
         self._disable_aggregating = True
-        self.flush_buffered_metrics()
         self.flush_aggregated_metrics()
+        self.flush_buffered_metrics()
         self.close_socket()
 
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -652,7 +652,7 @@ class DogStatsd(object):
             if self._disable_buffering:
                 self._send = self._send_to_server
             self._start_flush_thread()
-            
+
     @staticmethod
     def resolve_host(host, use_default_route):
         """

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -29,7 +29,7 @@ import pytest
 # Datadog libraries
 from datadog import initialize, statsd
 from datadog import __version__ as version
-from datadog.dogstatsd.base import DEFAULT_BUFFERING_FLUSH_INTERVAL, DogStatsd, MIN_SEND_BUFFER_SIZE, UDP_OPTIMAL_PAYLOAD_LENGTH, UDS_OPTIMAL_PAYLOAD_LENGTH
+from datadog.dogstatsd.base import DEFAULT_FLUSH_INTERVAL, DogStatsd, MIN_SEND_BUFFER_SIZE, UDP_OPTIMAL_PAYLOAD_LENGTH, UDS_OPTIMAL_PAYLOAD_LENGTH
 from datadog.dogstatsd.context import TimedContextManagerDecorator
 from datadog.util.compat import is_higher_py35, is_p3k
 from tests.util.contextmanagers import preserve_environment_variable, EnvVars
@@ -41,7 +41,7 @@ class FakeSocket(object):
 
     FLUSH_GRACE_PERIOD = 0.2
 
-    def __init__(self, flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL):
+    def __init__(self, flush_interval=DEFAULT_FLUSH_INTERVAL):
         self.payloads = deque()
 
         self._flush_interval = flush_interval
@@ -1111,7 +1111,7 @@ async def print_foo():
         dogstatsd.increment('page.views')
         self.assertIsNone(fake_socket.recv(no_wait=True))
 
-        time.sleep(DEFAULT_BUFFERING_FLUSH_INTERVAL)
+        time.sleep(DEFAULT_FLUSH_INTERVAL)
         self.assertIsNone(fake_socket.recv(no_wait=True))
 
         time.sleep(0.3)

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -1089,7 +1089,7 @@ async def print_foo():
         )
     
     def test_aggregation_buffering_simultaneously(self):
-        dogstatsd = DogStatsd(disable_buffering=False, disable_aggregating=False, telemetry_min_flush_interval=0)
+        dogstatsd = DogStatsd(disable_buffering=False, disable_aggregation=False, telemetry_min_flush_interval=0)
         fake_socket = FakeSocket()
         dogstatsd.socket = fake_socket
         for _ in range(10):
@@ -1100,7 +1100,7 @@ async def print_foo():
         self.assert_equal_telemetry('test.aggregation_and_buffering:10|c\n', fake_socket.recv(2))
 
     def test_aggregation_buffering_simultaneously_with_interval(self):
-        dogstatsd = DogStatsd(disable_buffering=False, disable_aggregating=False, flush_interval=1, telemetry_min_flush_interval=0)
+        dogstatsd = DogStatsd(disable_buffering=False, disable_aggregation=False, flush_interval=1, telemetry_min_flush_interval=0)
         fake_socket = FakeSocket()
         dogstatsd.socket = fake_socket
         for _ in range(10):


### PR DESCRIPTION
### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->
[Issue](https://datadoghq.atlassian.net/jira/software/c/projects/AMLII/boards/5315?selectedIssue=AMLII-1982)

enable the ability for buffering and aggregation to work at the same

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Refactors code to enable aggregation/buffering at the same time. The aggregator will add the aggregated metrics into the buffer at the end of every flush interval before the buffer sends them to the agent. Aggregation/buffering share the same flush thread and flush interval.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

aggregation and buffering seems tightly coupled, for [example](https://github.com/DataDog/datadogpy/blob/enable-buffering-aggregation-simultaneously/datadog/dogstatsd/base.py#L625)

Instead of killing the flush thread when buffering is disabled, (I assume) it needs to check if both aggregation and buffering is disabled before killing the flush thread. May be a good idea to add a if statement in [stop_flush_thread](https://github.com/DataDog/datadogpy/blob/enable-buffering-aggregation-simultaneously/datadog/dogstatsd/base.py#L579) to not kill the flush thread if either aggregation or buffering is enabled?
### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->
Added unit tests to test aggregation and buffering at the same time.

For Local testing:
Follow these [steps](https://datadoghq.atlassian.net/wiki/spaces/~71202058eaddc626774b6382b0a98b3e9f4a84/pages/3978855545/Local+testing+for+python+client+side+aggregation+project) for local testing and in the main.py file, enable aggregation and buffering at the same time

main.py
```
from datadog import initialize, statsd
import time

options = {
    "statsd_host": "127.0.0.1",
    "statsd_port": 8125,
    "statsd_disable_buffering" : False,
    "statsd_disable_aggregation" : False,
    "statsd_aggregation_flush_interval" : 10
}

initialize(**options)

while(1):
  print("-------------------------------------------------")
  print("metric added")
  statsd.count('testandrew123.count', 1, tags=["environment:dev"], sample_rate=1)
  time.sleep(1)
```
You can add a print statement [here](https://github.com/DataDog/datadogpy/blob/enable-buffering-aggregation-simultaneously/datadog/dogstatsd/base.py#L814) to ensure that the agggregated metrics are added to buffer, we would expect that the count metrics are aggregated (single metric with value of 10) inside the buffer
### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

