### PR TITLE
Add DD_DOGSTATSD_URL support for unix and udp urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ options = {
 initialize(**options)
 ```
 
+Alternatively, the environment variable `DD_DOGSTATSD_URL` can be used to define a udp connection:
+`DD_DOGSTATSD_URL=udp://localhost:8125`
+
+Manually supplying a host/port will take precedence over using this environment variable.
+
 See the full list of available [DogStatsD client instantiation parameters](https://docs.datadoghq.com/developers/dogstatsd/?code-lang=python#client-instantiation-parameters).
 
 #### Instantiate the DogStatsd client with UDS
@@ -109,6 +114,12 @@ options = {
 
 initialize(**options)
 ```
+
+Alternatively, the environment variable `DD_DOGSTATSD_URL` can be used to define a UDS connection:
+`DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket`
+
+As with the udp variant, manually supplying a statsd_socket_path will take precedence over the environment variable.
+
 
 #### Origin detection over UDP and UDS
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -40,6 +40,15 @@ Here's an example where the statsd host and port are configured as well::
     )
 
 
+If statsd_host and statsd_port are left at their default values and no socket_path alternative is supplied, 
+the DD_DOGSTATSD_URL environment variable, if it exists, will be used to determine the connection
+information. This must be a URL that start with either `udp://` (to connect using UDP) or with `unix://` 
+(to use a Unix Domain Socket).
+
+* Example for UDP url: `DD_DOGSTATSD_URL=udp://localhost:8125`
+* Example for UDS: `DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket`
+
+
 .. autofunction:: datadog.initialize
 
 


### PR DESCRIPTION
Adds support for the unix:// and udp:// variants of DD_DOGSTATSD_URL.


### Description of the Change
During dogstatsd creation, utilize the DD_DOGSTATSD_URL environment variable if the provided host and port are their default values and no socket_path has been provided. unix:// and udp:// paths are supported, but \\\\.\pipe\ paths (windows named pipes) are not yet implemented. 

### Alternate Designs
### Possible Drawbacks
### Verification Process
Form a Dogstatsd object with different values of DD_DOGSTATSD_URL. The following cases are important to verify:
* A non-default host, port or socket_path provided to the Dogstatsd constructor should take precedence over DD_DOGSTATS_URL.
* unix:// prefixed DOGSTATD_URLS should result in a socket_path and a None host/port pair
* udp:// prefixed DOGSTATSD_URLS should result in a valid host/port pair, with appropriate type safety around casting the port component from a string to an integer. 
* \\\\.\pipe\ prefixed DOGSTATD_URLS should provide an informative debug message and fallback to other connection identifications. 
* An unrecognized prefix for DOGSTATD_URL should fallback to other connection identifications

During fallback, DD_AGENT_HOST and DD_DOGSTATSD_PORT should be utilized if present. Otherwise, udp is selected with DEFAULT_HOST:DEFAULT_PORT. 

### Additional Notes
This PR is reliant on the functionality in [!869](https://github.com/DataDog/datadogpy/pull/869), with a comparison available [here](https://github.com/DataDog/datadogpy/compare/ryan.hall/add_uds_stream_support...ryan.hall/add_dogstatsd_url_support?expand=1)

### Release Notes
### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

