### PR TITLE
Remove black while support is maintained for python 2.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     flake8
     integration
     mypy
-    black
+    # black - see comments below
 
 [testenv]
 passenv = DD_TEST_CLIENT*
@@ -43,15 +43,18 @@ deps =
     flake8==3.7.9
 commands = flake8 datadog
 
-[testenv:black]
-deps =
-    black
-commands = black --line-length 120 {posargs} datadog
+# Black isn't safe to run while support is being maintained for python2.7, but 
+# can be re-enabled when support for 2.7 is dropped. 
+#
+# [testenv:black]
+# deps =
+#     black
+# commands = black --line-length 120 {posargs} datadog
 
 [testenv:mypy]
-# Mypy requires Python 3.5 or higher (but it can still type-check Python 2
+# Mypy requires Python >= 3.5 and <=3.8  (but it can still type-check Python 2
 # code).
-basepython = python3
+basepython = python3.8
 skip_install = true
 deps =
     mypy==0.770


### PR DESCRIPTION
### What does this PR do?
Remove the black tox command.
Force the mypy tox env to one that is supported. 

### Description of the Change

Python 2.7 support is being retired in a number of the utilities we're using to perform code verification. Black, a python formatter, is currently unsafe to run for python < 3.3 and therefore the ability to do so is being disabled while python 2.7 is still under support for this repo. 
MyPy is currently version locked to support 2.7 static analysis, and fails to run successfully on python > 3.8. As such, it is defaulted to 3.8, the latest stable version that, at the time of writing, also boasts the most extensive pipeline support for the repo. 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
We want a formatter for the project, so disabling black is not the solution we ultimately wish to run with. While it might be possible to isolate a specific older version of black that 1) won't break support for 2.7 and 2) won't recommend unideal format changes for 3.12, such a solution would be brittle and increasingly unlikely to work as new python versions get released. We've already disabled the black run in the pipeline and don't seem to be running it locally, so a total removal was judged as more sensible while support for 2.7 remains. 


### Verification Process
None, no code changed. 

### Additional Notes

### Release Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

