### PR TITLE
Provide urllib3 implementation of HTTPClient.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version: ['pypy2.7', '3.7', 'pypy3.8']
         # os: [ubuntu-latest, windows-latest, macos-latest]
         # python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.8']

--- a/datadog/api/http_client.py
+++ b/datadog/api/http_client.py
@@ -27,6 +27,11 @@ try:
 except ImportError:
     urlfetch, urlfetch_errors = None, None
 
+try:
+    import urllib3
+except ImportError:
+    urllib3 = None
+
 # datadog
 from datadog.api.exceptions import ProxyError, ClientError, HTTPError, HttpTimeout
 
@@ -178,6 +183,58 @@ class URLFetchClient(HTTPClient):
                 raise HTTPError(status_code)
 
 
+class Urllib3Client(HTTPClient):
+    """
+    HTTP client based on 3rd party `urllib3` module.
+    """
+
+    _pool = None
+    _pool_lock = Lock()
+
+    @classmethod
+    def request(cls, method, url, headers, params, data, timeout, proxies, verify, max_retries):
+        """
+        Wrapper around `urllib3.PoolManager.request` method. This method will raise
+        exceptions for HTTP status codes that are not 2xx.
+        """
+        try:
+            with cls._pool_lock:
+                if cls._pool is None:
+                    cls._pool = urllib3.PoolManager(
+                        retries=max_retries,
+                        timeout=timeout,
+                        cert_reqs="CERT_REQUIRED" if verify else "CERT_NONE",
+                    )
+
+            newheaders = copy.deepcopy(headers)
+            newheaders["User-Agent"] = _get_user_agent_header()
+            response = cls._pool.request(
+                method, url, body=data, fields=params, headers=newheaders
+            )
+            cls.raise_on_status(response)
+
+        except urllib3.exceptions.ProxyError as e:
+            raise _remove_context(ProxyError(method, url, e))
+        except urllib3.exceptions.MaxRetryError as e:
+            raise _remove_context(ClientError(method, url, e))
+        except urllib3.exceptions.TimeoutError as e:
+            raise _remove_context(HttpTimeout(method, url, e))
+        except urllib3.exceptions.HTTPError as e:
+            raise _remove_context(HTTPError(e))
+
+        return response
+
+    @classmethod
+    def raise_on_status(cls, response):
+        """
+        Raise on HTTP status code errors.
+        """
+        status_code = response.status
+        if status_code < 200 or status_code >= 300:
+            if status_code not in (400, 401, 403, 404, 409, 429):
+                raise HTTPError(status_code, response.reason)
+
+
 def resolve_http_client():
     """
     Resolve an appropriate HTTP client based the defined priority and user environment.
@@ -189,6 +246,10 @@ def resolve_http_client():
     if urlfetch and urlfetch_errors:
         log.debug(u"Use `urlfetch` based HTTP client.")
         return URLFetchClient
+
+    if urllib3:
+        log.debug(u"Use `urllib3` based HTTP client.")
+        return Urllib3Client
 
     raise ImportError(
         u"Datadog API client was unable to resolve a HTTP client. " u" Please install `requests` library."

--- a/datadog/api/http_client.py
+++ b/datadog/api/http_client.py
@@ -28,7 +28,7 @@ except ImportError:
     urlfetch, urlfetch_errors = None, None
 
 try:
-    import urllib3
+    import urllib3  # type: ignore
 except ImportError:
     urllib3 = None
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,6 @@ basepython = python3.8
 skip_install = true
 deps =
     mypy==0.770
-    urllib3==2.2.3
 commands =
     mypy --config-file mypy.ini datadog
     mypy --config-file mypy.ini --py2 datadog

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ basepython = python3.8
 skip_install = true
 deps =
     mypy==0.770
+    urllib3==2.2.3
 commands =
     mypy --config-file mypy.ini datadog
     mypy --config-file mypy.ini --py2 datadog


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Adds a third implementation for `HTTPClient` using `urllib3`.

### Description of the Change

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

The [`datadog-lambda-python`](https://github.com/DataDog/datadog-lambda-python) package depends on `datadogpy` for submitting metrics in certain cases. The package is used in AWS Lambda environments where resources are very constrained. There is a hard limit of 250MB for all code plus dependencies. Customers are often hitting this limit and so keeping our package size down is important.

One of the largest dependencies of `datadog-lambda-python` is the `requests` package and it's dependencies. Removing this dependency would reduce the size of our installed package by roughly 8.5%.

This PR offers a new solution to this problem. We know that `urllib3` is installed by default on all python lambda runtime containers, and thus does not count toward the 250MB limit. Switching from `requests` to `urllib3` therefore would allow us to benefit from the 8.5% size reduction.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

I created a testing python lambda layer using these changes and then removing requests and dependencies. It is deployed to the serverless sandbox as `arn:aws:lambda:sa-east-1:425362996713:layer:Python39-REY:40`.

I then created a handler that submits a metric using the `datadogpy` package. It then returns a list of installed packages and which http client class was used.

```python
import json
import time

from datadog.api.http_client import resolve_http_client
from datadog_lambda.metric import lambda_metric

def get_version(module_name, *version_path):
    if not version_path:
        version_path = ['__version__']
    try:
        module = __import__(module_name)
        for attr in version_path:
            module = getattr(module, attr)
        return module
    except ImportError:
        return None

body = json.dumps(dict(
    requests_version=get_version('requests'),
    protobuf_version=get_version('google.protobuf', 'protobuf', '__version__'),
    urllib3_version=get_version('urllib3'),
    certifi_version=get_version('certifi'),
    idna_version=get_version('idna'),
    chardet_version=get_version('chardet'),
    charset_normalizer_version=get_version('charset_normalizer'),
    http_client_class=resolve_http_client().__name__,
))

def handler(event, context):
    lambda_metric('rey.kittens', 1, timestamp=time.time() - 60)
    return {'statusCode': 200, 'body': body}
```

The response shows that `requests` and dependencies -- `certifi`, `idna`, `chardet`, and `charset-normalizer` -- are no longer installed. Despite removing `urllib3` from our layer, we can see that it is still found in the lambda runtime. Lastly, we see that the newly added `Urllib3Client` is used to submit metrics.

```json
{
  "requests_version": null,
  "protobuf_version": "5.29.2",
  "urllib3_version": "1.26.19",
  "certifi_version": null,
  "idna_version": null,
  "chardet_version": null,
  "charset_normalizer_version": null,
  "http_client_class": "Urllib3Client"
}
```

The metric explorer shows the custom metric `rey.kittens` has been ingested.

<img width="704" alt="Screenshot 2024-12-23 at 1 11 48 PM" src="https://github.com/user-attachments/assets/23442cf6-0a1a-4a82-bec5-8baabbc88741" />


### Additional Notes

<!-- Anything else we should know when reviewing? -->

This change will have many additional positive impacts as well. We see a 12% reduction in cold start time for example.

<img width="1307" alt="Screenshot 2024-12-23 at 1 40 24 PM" src="https://github.com/user-attachments/assets/12e8ab30-3b88-4550-8897-146a38149021" />

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

