### PR TITLE
Fix SLO update via dogshell

### DIFF
--- a/datadog/dogshell/service_level_objective.py
+++ b/datadog/dogshell/service_level_objective.py
@@ -257,7 +257,7 @@ class ServiceLevelObjectiveClient(object):
             for threshold_str in args.thresholds.split(","):
                 parts = threshold_str.split(":")
                 timeframe = parts[0]
-                target = parts[1]
+                target = float(parts[1])
 
                 threshold = {"timeframe": timeframe, "target": target}
 


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

The SLO update is broken. It'll report 

> ERROR: Invalid payload: 'target' should be number 

### Description of the Change

We transform the thresholds `target` string to float, just like in SLO creation.

### Alternate Designs

N/A

### Possible Drawbacks

None. Probably this never worked and clients are not depending on it.

### Verification Process

Empirically on my computer.

### Additional Notes

N/A

### Release Notes

Fix SLO update via dogshell. This fixes a bug in dogshell that always produced `ERROR: Invalid payload: 'target' should be number` error during SLO updates.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

