### PR TITLE
Fix imports in __init__.py files to explicitly re-export symbols

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -18,11 +18,15 @@ from typing import Any, List, Optional
 
 # datadog
 from datadog import api
-from datadog.dogstatsd import DogStatsd, statsd  # noqa
-from datadog.threadstats import ThreadStats, datadog_lambda_wrapper, lambda_metric  # noqa
+from datadog.dogstatsd import DogStatsd as DogStatsd, statsd as statsd  # noqa
+from datadog.threadstats import (  # noqa
+    ThreadStats as ThreadStats,
+    datadog_lambda_wrapper as datadog_lambda_wrapper,
+    lambda_metric as lambda_metric,
+)
 from datadog.util.compat import iteritems, NullHandler, text
 from datadog.util.hostname import get_hostname
-from datadog.version import __version__  # noqa
+from datadog.version import __version__ as __version__  # noqa
 
 # Loggers
 logging.getLogger("datadog.api").addHandler(NullHandler())

--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -24,29 +24,31 @@ _mute = True
 _return_raw_response = False
 
 # Resources
-from datadog.api.comments import Comment
-from datadog.api.dashboard_lists import DashboardList
-from datadog.api.distributions import Distribution
-from datadog.api.downtimes import Downtime
-from datadog.api.timeboards import Timeboard
-from datadog.api.dashboards import Dashboard
-from datadog.api.events import Event
-from datadog.api.infrastructure import Infrastructure
-from datadog.api.metadata import Metadata
-from datadog.api.metrics import Metric
-from datadog.api.monitors import Monitor
-from datadog.api.screenboards import Screenboard
-from datadog.api.graphs import Graph, Embed
-from datadog.api.hosts import Host, Hosts
-from datadog.api.service_checks import ServiceCheck
-from datadog.api.tags import Tag
-from datadog.api.users import User
-from datadog.api.aws_integration import AwsIntegration
-from datadog.api.aws_log_integration import AwsLogsIntegration
-from datadog.api.azure_integration import AzureIntegration
-from datadog.api.gcp_integration import GcpIntegration
-from datadog.api.roles import Roles
-from datadog.api.permissions import Permissions
-from datadog.api.service_level_objectives import ServiceLevelObjective
-from datadog.api.synthetics import Synthetics
-from datadog.api.logs import Logs
+from datadog.api.comments import Comment as Comment
+from datadog.api.dashboard_lists import DashboardList as DashboardList
+from datadog.api.distributions import Distribution as Distribution
+from datadog.api.downtimes import Downtime as Downtime
+from datadog.api.timeboards import Timeboard as Timeboard
+from datadog.api.dashboards import Dashboard as Dashboard
+from datadog.api.events import Event as Event
+from datadog.api.infrastructure import Infrastructure as Infrastructure
+from datadog.api.metadata import Metadata as Metadata
+from datadog.api.metrics import Metric as Metric
+from datadog.api.monitors import Monitor as Monitor
+from datadog.api.screenboards import Screenboard as Screenboard
+from datadog.api.graphs import Graph as Graph, Embed as Embed
+from datadog.api.hosts import Host as Host, Hosts as Hosts
+from datadog.api.service_checks import ServiceCheck as ServiceCheck
+from datadog.api.tags import Tag as Tag
+from datadog.api.users import User as User
+from datadog.api.aws_integration import AwsIntegration as AwsIntegration
+from datadog.api.aws_log_integration import AwsLogsIntegration as AwsLogsIntegration
+from datadog.api.azure_integration import AzureIntegration as AzureIntegration
+from datadog.api.gcp_integration import GcpIntegration as GcpIntegration
+from datadog.api.roles import Roles as Roles
+from datadog.api.permissions import Permissions as Permissions
+from datadog.api.service_level_objectives import (
+    ServiceLevelObjective as ServiceLevelObjective,
+)
+from datadog.api.synthetics import Synthetics as Synthetics
+from datadog.api.logs import Logs as Logs

--- a/datadog/dogstatsd/__init__.py
+++ b/datadog/dogstatsd/__init__.py
@@ -1,4 +1,4 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
-from datadog.dogstatsd.base import DogStatsd, statsd  # noqa
+from datadog.dogstatsd.base import DogStatsd as DogStatsd, statsd as statsd  # noqa

--- a/datadog/threadstats/__init__.py
+++ b/datadog/threadstats/__init__.py
@@ -1,5 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
-from datadog.threadstats.base import ThreadStats  # noqa
-from datadog.threadstats.aws_lambda import lambda_metric, datadog_lambda_wrapper  # noqa
+from datadog.threadstats.base import ThreadStats as ThreadStats  # noqa
+from datadog.threadstats.aws_lambda import (  # noqa
+    lambda_metric as lambda_metric,
+    datadog_lambda_wrapper as datadog_lambda_wrapper,
+)


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Fixes #842.
By default imports in `__init__.py` files are treated by type checkers (like mypy or pyright) as private.
With this PR type checkers start to recognize selected symbols imported in `__init__.py` files as re-exported, so that code like this:
```
from datadog import statsd
```
is no longer treated as importing private implementation details of the library.

### Description of the Change

In order to mark symbols as intended to be re-exported you can use one of the special import forms. This change does that by adding `from Y import X as X` (a redundant symbol alias) as described in official [Import Conventions](https://typing.readthedocs.io/en/latest/spec/distributing.html#import-conventions) written by The Python Typing Team.

### Alternate Designs

As an alternative one might define the  `__all__` module-level attribute in `__init__.py` file that lists all the symbols intended to be re-exported. The symbols listed in `__all__` are represented by `str`. Making sure that this is list up-to-date might become problematic as only type checkers use that information and not every IDE supports recognizing those strings as symbols, making it hard to maintain them.

### Possible Drawbacks

One have to remember to keep those re-export up-to-date to keep type checkers happy.

### Verification Process

I've checked by running pyright on
```
from datadog import statsd
```
if it gives a warning `reportPrivateImportUsage`.

### Additional Notes

### Release Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

