### PR TITLE
Fix missing transport attribute when flushing telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* [Fixed] Fix missing transport attribute when flushing telemetry.
+
 ## v0.52.0 / 2025-07-08
 
 * [Added] Add Cardinality common field. See [#883](https://github.com/DataDog/datadogpy/pull/883)

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -534,13 +534,7 @@ class DogStatsd(object):
             except AttributeError:  # _socket can't have a type if it doesn't have sockopts
                 log.info("Unexpected socket provided with no support for getsockopt")
         self._socket_kind = None
-        if self.socket_path:
-            if self.socket_path.startswith(UNIX_ADDRESS_STREAM_SCHEME):
-                self._transport = "uds-stream"
-            else:
-                self._transport = "uds"
-        else:
-            self._transport = "udp"
+        self._transport = "udp"
         # When the socket is None, we use the UDP optimal payload length
         self._max_payload_size = UDP_OPTIMAL_PAYLOAD_LENGTH
 

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -534,6 +534,13 @@ class DogStatsd(object):
             except AttributeError:  # _socket can't have a type if it doesn't have sockopts
                 log.info("Unexpected socket provided with no support for getsockopt")
         self._socket_kind = None
+        if self.socket_path:
+            if self.socket_path.startswith(UNIX_ADDRESS_STREAM_SCHEME):
+                self._transport = "uds-stream"
+            else:
+                self._transport = "uds"
+        else:
+            self._transport = "udp"
         # When the socket is None, we use the UDP optimal payload length
         self._max_payload_size = UDP_OPTIMAL_PAYLOAD_LENGTH
 


### PR DESCRIPTION
### What does this PR do?
Fixes bug where `self._transport` was never set, thus causing `self._flush_telemetry` to fail when adding the `client_transport` tag.

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change
Sets `self._transport` to `udp` as a default.
<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

