### PR TITLE
Add ability to disable statsd via new disable_statsd parameter in initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Unreleased
 * [Fixed] Fix missing transport attribute when flushing telemetry.
+* [Added] Add ability to disable statsd via new `statsd_disable` parameter in `initialize`.
 
 ## v0.52.0 / 2025-07-08
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ tags = ["version:1", "application:web"]
 api.Event.create(title=title, text=text, tags=tags)
 ```
 
-In development, you can disable any `statsd` metric collection using `DD_DOGSTATSD_DISABLE=True` (or any not-empty value).
+In development, you can disable any `statsd` metric collection by either:
+1. Setting environment variable `DD_DOGSTATSD_DISABLE` to `True`, `true`, `yes`, or `1`.
+2. Setting the `statsd_disable` option to `True` in the `initialize` function.
 
 ## DogStatsD
 

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -37,6 +37,7 @@ def initialize(
     api_host=None,  # type: Optional[str]
     statsd_host=None,  # type: Optional[str]
     statsd_port=None,  # type: Optional[int]
+    statsd_disable=False,  # type: bool
     statsd_disable_aggregation=True,  # type: bool
     statsd_disable_buffering=True,  # type: bool
     statsd_aggregation_flush_interval=0.3,  # type: float
@@ -75,6 +76,9 @@ def initialize(
 
     :param statsd_port: Port of DogStatsd server or statsd daemon
     :type statsd_port: port
+
+    :param statsd_disable: Disable any statsd metric collection (default False).
+    :type statsd_disable: bool
 
     :param statsd_disable_buffering: Enable/disable statsd client buffering support
                                      (default: True).
@@ -150,6 +154,11 @@ def initialize(
         statsd.namespace = text(statsd_namespace)
     if statsd_constant_tags:
         statsd.constant_tags += statsd_constant_tags
+
+    if statsd_disable:
+        statsd.disable_statsd()
+    else:
+        statsd.enable_statsd()
 
     if statsd_disable_aggregation:
         statsd.disable_aggregation()

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -1164,6 +1164,20 @@ async def print_foo():
             u'page.®views®:1|c\n',
             fake_socket.recv(2, no_wait=True)
         )
+
+    def test_statsd_disabled_dgram(self):
+        self._test_statsd_disabled(socket.SOCK_DGRAM)
+
+    def test_statsd_disabled_stream(self):
+        self._test_statsd_disabled(socket.SOCK_STREAM)
+
+    def _test_statsd_disabled(self, socket_kind):
+        dogstatsd = DogStatsd(disable_statsd=True, telemetry_min_flush_interval=0)
+        fake_socket = FakeSocket(socket_kind=socket_kind)
+        dogstatsd.socket = fake_socket
+        dogstatsd.increment('_test_statsd_disabled')
+        dogstatsd.flush()
+        self.assertIsNone(fake_socket.recv(no_wait=True))
     
     def test_aggregation_buffering_simultaneously_dgram(self):
         self._test_aggregation_buffering_simultaneously(socket.SOCK_DGRAM)


### PR DESCRIPTION
Closes #778.

### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

This merge request makes it possible to disable emitting statsd metrics when calling the `initialize()` function or `Dogstatsd` constructor instead of just the `DD_DOGSTATSD_DISABLE` environment variable.

I was inspired to make this change because I am working on project that uses [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) to manage configuration settings - not just environment variables. This is a purer way to disable statsd with that dependency, as environment variables are only one of several ways to manage configuration. I noticed a similar concern from another engineer in #778.

### Description of the Change

- This allows statsd emittance to be disabled via configuration managed beyond just environment variables (e.g. Pydantic Settings).
- It fixes the `README` so that it accurately describes the existing behavior of `DD_DOGSTATSD_DISABLE` and includes this new behavior.

### Alternate Designs

No alternative designs were considered.

### Possible Drawbacks

No obvious ones. This is a minor additive change to existing functionality.

### Verification Process

I wrote unit tests to verify the new behavior via the constructor. I did not see a great way to write unit tests over this case when invoked via `initialize()`.

### Additional Notes

N/A

### Release Notes

I think the PR description and CHANGELOG updates are self-sufficient.

### Review checklist (to be filled by reviewers)

- [X] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [X] PR should not have `do-not-merge/` label attached.
- [x] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
