### PR TITLE
Use PyPI OIDC when releasing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,9 @@ jobs:
   build_wheels:
     name: Build wheels on Ubuntu latest
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: secure_publish_environment
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
@@ -30,11 +33,12 @@ jobs:
         run: |
           python -m pip install datadog_checks_dev[cli]==20.0.1
 
-      - name: Set ddev pypi credentials
-        run: |
-          ddev config set pypi.user __token__
-          ddev config set pypi.pass ${{ secrets.PYPI_TOKEN }}
-
-      - name: Publish the wheel to PyPI
-        run: |
-          ddev release upload . --sdist
+      # Publish wheels to PyPI using Trusted Publishers.
+      # https://docs.pypi.org/trusted-publishers/using-a-publisher/
+      # This job needs to run from within the pypi-datadog-checks-base environment. PyPi
+      # validates the workflow file name, environment and repository the request is
+      # comming from to provide the valid JWT token.
+      - name: Release base package to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          skip-existing: true


### PR DESCRIPTION
This changes the release process to use trusted publishing so that we don't have to store the PYPI_TOKEN secret in this repository.