### PR TITLE
Add Homebrew install option for dogshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ To install from source:
 
     python setup.py install
 
+To install [dogshell](https://docs.datadoghq.com/developers/guide/dogshell/) via [Homebrew](https://brew.sh):
+
+    brew tap heathdutton/dogshell && brew install dogshell
+
 ## Datadog API
 
 To support all Datadog HTTP APIs, a generated library is


### PR DESCRIPTION
## Summary
- Adds a Homebrew install option to the README for dogshell

Closes #908

Tap: https://github.com/heathdutton/homebrew-dogshell