### PR TITLE
refactor: use list `join` instead of % formatting in `_serialize_metric`

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1200,18 +1200,33 @@ class DogStatsd(object):
         self, metric, metric_type, value, tags, sample_rate=1, timestamp=0, cardinality=None
     ):
         # Create/format the metric packet
-        return "%s%s:%s|%s%s%s%s%s%s%s" % (
-            (self.namespace + ".") if self.namespace else "",
-            metric,
-            value,
-            metric_type,
-            ("|@" + text(sample_rate)) if sample_rate != 1 else "",
-            ("|#" + ",".join(normalize_tags(tags))) if tags else "",
-            ("|c:" + self._container_id if self._container_id else ""),
-            ("|e:" + self._external_data if self._external_data else ""),
-            ("|card:" + cardinality if cardinality else ""),
-            ("|T" + text(timestamp)) if timestamp > 0 else "",
-        )
+        parts = [(self.namespace + ".") if self.namespace else "", metric, ":", text(value), "|", metric_type]
+
+        if sample_rate != 1:
+            parts.append("|@")
+            parts.append(text(sample_rate))
+
+        if tags:
+            parts.append("|#")
+            parts.append(",".join(normalize_tags(tags)))
+
+        if self._container_id:
+            parts.append("|c:")
+            parts.append(self._container_id)
+
+        if self._external_data:
+            parts.append("|e:")
+            parts.append(self._external_data)
+
+        if cardinality:
+            parts.append("|card:")
+            parts.append(cardinality)
+
+        if timestamp > 0:
+            parts.append("|T")
+            parts.append(text(timestamp))
+
+        return "".join(parts)
 
     def _report(self, metric, metric_type, value, tags, sample_rate, timestamp=0, sampling=True, cardinality=None):
         """


### PR DESCRIPTION
### What does this PR do?

This PR makes a few changes that should improve the performance of the module after profiling it. 

`_serialize_metric` is called on every metric submission and accounts for ~5% of CPU and ~55% of all allocations in the hot path. The `%` formatter with 10 positional args creates intermediate empty strings for every absent optional field and does more internal work than a simple list `join`.

### Description of the Change

This rewrites `_serialize_metric` from a single `"%s%s:%s|%s%s%s%s%s%s%s" % (...)` expression to building a `parts` list with conditional appends and `"".join(parts)`

Optional fields (sample rate, tags, container ID, etc.) are only appended when present, instead of always evaluating to `""` in the format tuple

The behaviour is unchanged -- the output string is the same as before. 

### Verification Process

This was benchmarked locally and profiled with `ddtrace`, 20M `statsd.increment()` calls, namespace + 5 constant tags + 3 per-call tags, profiled with dd-trace-py (`ddtrace-run`), UDP sink on localhost.

#### Wall time

| | master | this PR | delta |
|---|---|---|---|
| ops/sec | 369k | 377k | **+2.2%** |

#### CPU (flat time in `_serialize_metric`)

| | master | this PR | delta |
|---|---|---|---|
| flat | 2.72s (5.11%) | 2.28s (4.37%) | **-16.2%** |

#### Allocations

| metric | master | this PR | delta |
|---|---|---|---|
| `_serialize_metric` alloc-space | 12,451 MB | 9,312 MB | **-25.2%** |
| `_serialize_metric` alloc-samples | 121.8M | 100.1M | **-17.8%** |
| total alloc-space | 22,508 MB | 19,417 MB | **-13.7%** |
| total alloc-samples | 137.9M | 115.9M | **-15.9%** |

