### PR TITLE
refactor: cache constant tags

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -13,7 +13,10 @@ without hindering performance.
 # stdlib
 import logging
 import os
-from typing import Any, List, Optional  # noqa: F401
+import sys
+
+if sys.version_info[0] >= 3:
+    from typing import Any, List, Optional  # noqa: F401
 
 # datadog
 from datadog import api

--- a/datadog/api/__init__.py
+++ b/datadog/api/__init__.py
@@ -3,7 +3,11 @@
 # Copyright 2015-Present Datadog, Inc
 # flake8: noqa
 
-from typing import Optional
+import sys
+
+
+if sys.version_info[0] >= 3:
+    from typing import Optional  # noqa: F401
 
 # API settings
 _api_key = None  # type: Optional[str]

--- a/datadog/api/http_client.py
+++ b/datadog/api/http_client.py
@@ -12,16 +12,19 @@ Priority:
 import copy
 import logging
 import platform
+import sys
 import urllib
-from typing import TYPE_CHECKING
+
 from threading import Lock
 
 # datadog
 from datadog.api.exceptions import ProxyError, ClientError, HTTPError, HttpTimeout
 
-if TYPE_CHECKING:
-    import types  # noqa: F401
-    from typing import Optional  # noqa: F401
+if sys.version_info[:2] >= (3, 5):
+    from typing import TYPE_CHECKING
+    if TYPE_CHECKING:
+        import types  # noqa: F401
+        from typing import Optional  # noqa: F401
 
 
 # 3p

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -1,5 +1,8 @@
 import threading
-from typing import Any, Dict, List, Optional
+import sys
+
+if sys.version_info[:2] >= (3, 5):
+    from typing import Any, Dict, List, Optional  # noqa: F401
 
 from datadog.dogstatsd.metrics import (
     CountMetric,

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -19,7 +19,9 @@ import threading
 import time
 from threading import Lock, RLock
 import weakref
-from typing import TYPE_CHECKING
+
+if sys.version_info[:2] >= (3, 5):
+    from typing import TYPE_CHECKING  # noqa: F401
 
 try:
     import queue
@@ -29,7 +31,13 @@ except ImportError:
 
 
 # pylint: disable=unused-import
-from typing import Any, Optional, List, Text, Type, Union
+if sys.version_info[:2] >= (3, 5):
+    from typing import Any, Optional, List, Text, Type, Union, Iterable, Callable, overload  # noqa: F401
+
+try:
+    from typing import SupportsIndex
+except ImportError:
+    SupportsIndex = int  # type: ignore[assignment,misc]
 # pylint: enable=unused-import
 
 # Datadog libraries
@@ -45,8 +53,103 @@ from datadog.util.compat import text
 from datadog.util.format import normalize_tags, validate_cardinality
 from datadog.version import __version__
 
-if TYPE_CHECKING:
-    from socket import socket as _Socket
+
+if sys.version_info[:2] >= (3, 5):
+    if TYPE_CHECKING:
+        from socket import socket as _Socket
+
+    BaseListClass = List[str]
+else:
+    BaseListClass = list
+
+
+class TagList(BaseListClass):
+    """A list subclass that calls on_change() after any mutation."""
+
+    def __init__(self, iterable=(), on_change=None):
+        # type: (Iterable[str], Optional[Callable[[], None]]) -> None
+        super(TagList, self).__init__(iterable)
+        self._on_change = on_change
+
+    def _notify(self):
+        # type: () -> None
+        if self._on_change is not None:
+            self._on_change()
+
+    if sys.version_info[:2] >= (3, 5):
+        @overload
+        def __setitem__(self, index, value):  # noqa: F811
+            # type: (SupportsIndex, str) -> None
+            pass
+
+        @overload
+        def __setitem__(self, index, value):  # noqa: F811
+            # type: (slice, Iterable[str]) -> None
+            pass
+
+    def __setitem__(self, index, value):  # noqa: F811
+        # type: (Union[SupportsIndex, slice], Union[str, Iterable[str]]) -> None
+        super(TagList, self).__setitem__(index, value)  # type: ignore
+        self._notify()
+
+    def __delitem__(self, index):  # noqa: F811
+        # type: (Union[SupportsIndex, slice]) -> None
+        super(TagList, self).__delitem__(index)
+        self._notify()
+
+    def __iadd__(self, other):  # type: ignore[misc,override]  # noqa: F811
+        # type: (Iterable[str]) -> "TagList"
+        super(TagList, self).__iadd__(other)
+        self._notify()
+        return self
+
+    def __imul__(self, n):  # noqa: F811
+        # type: (SupportsIndex) -> "TagList"
+        super(TagList, self).__imul__(n)
+        self._notify()
+        return self
+
+    def append(self, value):  # noqa: F811
+        # type: (str) -> None
+        super(TagList, self).append(value)
+        self._notify()
+
+    def extend(self, iterable):  # noqa: F811
+        # type: (Iterable[str]) -> None
+        super(TagList, self).extend(iterable)
+        self._notify()
+
+    def insert(self, index, value):  # noqa: F811
+        # type: (SupportsIndex, str) -> None
+        super(TagList, self).insert(index, value)
+        self._notify()
+
+    def remove(self, value):  # noqa: F811
+        # type: (str) -> None
+        super(TagList, self).remove(value)
+        self._notify()
+
+    def pop(self, index=-1):  # noqa: F811
+        # type: (SupportsIndex) -> str
+        value = super(TagList, self).pop(index)
+        self._notify()
+        return value
+
+    def clear(self):  # noqa: F811
+        # type: () -> None
+        super(TagList, self).__delitem__(slice(None))
+        self._notify()
+
+    def sort(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        super(TagList, self).sort(*args, **kwargs)
+        self._notify()
+
+    def reverse(self):
+        # type: () -> None
+        super(TagList, self).reverse()
+        self._notify()
+
 
 # Logging
 log = logging.getLogger("datadog.dogstatsd")
@@ -442,9 +545,18 @@ class DogStatsd(object):
             value = os.environ.get(var, "")
             if value:
                 env_tags.append("{name}:{value}".format(name=tag_name, value=value))
+
+        # This lock is used for all cases where client configuration is being changed: buffering,
+        # aggregation, sender mode.
+        self._config_lock = RLock()
+
         if constant_tags is None:
             constant_tags = []
-        self.constant_tags = constant_tags + env_tags
+
+        self._constant_tags_str = ""
+        self._constant_tags = TagList()
+        self.constant_tags = TagList(constant_tags + env_tags)
+
         if namespace is not None:
             namespace = text(namespace)
         self.namespace = namespace
@@ -475,10 +587,6 @@ class DogStatsd(object):
         self._buffer_lock = RLock()
 
         self._reset_buffer()
-
-        # This lock is used for all cases where client configuration is being changed: buffering,
-        # aggregation, sender mode.
-        self._config_lock = RLock()
 
         self._disable_buffering = disable_buffering
         self._disable_aggregation = disable_aggregation
@@ -1267,9 +1375,16 @@ class DogStatsd(object):
             parts.append("|@")
             parts.append(text(sample_rate))
 
-        if tags:
+        constant_tags_str = self._constant_tags_str
+        if tags or constant_tags_str:
             parts.append("|#")
-            parts.append(",".join(normalize_tags(tags)))
+            if tags:
+                parts.append(",".join(normalize_tags(tags)))
+                if constant_tags_str:
+                    parts.append(",")
+                    parts.append(constant_tags_str)
+            else:
+                parts.append(constant_tags_str)
 
         if self._container_id:
             parts.append("|c:")
@@ -1323,8 +1438,6 @@ class DogStatsd(object):
 
         validate_cardinality(cardinality)
 
-        # Resolve the full tag list
-        tags = self._add_constant_tags(tags)
         payload = self._serialize_metric(
             metric, metric_type, value, tags, sample_rate, timestamp, cardinality
         )
@@ -1642,13 +1755,40 @@ class DogStatsd(object):
 
         self._send(string)
 
+    @staticmethod
+    def _normalize_and_join_tags(tags):
+        # type: (List[str]) -> str
+        """Normalize a tag list and join into a comma-separated string."""
+        if tags:
+            return ",".join(normalize_tags(tags))
+
+        return ""
+
+    def _rebuild_constant_tags_str(self):
+        # type: () -> None
+        with self._config_lock:
+            self._constant_tags_str = self._normalize_and_join_tags(self._constant_tags)
+
+    @property
+    def constant_tags(self):
+        # type: () -> TagList
+        return self._constant_tags
+
+    @constant_tags.setter
+    def constant_tags(self, value):
+        # type: (Union[TagList, List[str]]) -> None
+        with self._config_lock:
+            self._constant_tags = TagList(value or [], on_change=self._rebuild_constant_tags_str)
+            self._rebuild_constant_tags_str()
+
     def _add_constant_tags(self, tags):
         # type: (Optional[List[str]]) -> Optional[List[str]]
-        if self.constant_tags:
-            if tags:
-                return tags + self.constant_tags
+        with self._config_lock:
+            if self._constant_tags:
+                if tags:
+                    return tags + self._constant_tags
 
-            return self.constant_tags
+                return list(self._constant_tags)
         return tags
 
     def _is_origin_detection_enabled(self, container_id, origin_detection_enabled):

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -6,7 +6,10 @@
 import errno
 import os
 import re
-from typing import Optional
+import sys
+
+if sys.version_info[:2] >= (3, 5):
+    from typing import Optional  # noqa: F401
 
 
 class UnresolvableContainerID(Exception):

--- a/datadog/dogstatsd/context.py
+++ b/datadog/dogstatsd/context.py
@@ -3,7 +3,8 @@
 # Copyright 2015-Present Datadog, Inc
 # stdlib
 from functools import wraps
-from typing import Any, Callable, List, Optional, Text, TYPE_CHECKING, Union
+import sys
+
 
 try:
     from time import monotonic  # type: ignore[attr-defined]
@@ -14,8 +15,12 @@ except ImportError:
 from datadog.dogstatsd.context_async import _get_wrapped_co
 from datadog.util.compat import iscoroutinefunction
 
-if TYPE_CHECKING:
-    from datadog.dogstatsd.base import DogStatsd
+
+if sys.version_info[:2] >= (3, 5):
+    from typing import Any, Callable, List, Optional, Text, TYPE_CHECKING, Union  # noqa: F401
+
+    if TYPE_CHECKING:
+        from datadog.dogstatsd.base import DogStatsd  # noqa: F401
 
 
 class TimedContextManagerDecorator(object):

--- a/datadog/dogstatsd/context_async.py
+++ b/datadog/dogstatsd/context_async.py
@@ -8,7 +8,9 @@ Warning: requires Python 3.5 or higher.
 """
 # stdlib
 import sys
-from typing import Any, Callable
+
+if sys.version_info[:2] >= (3, 5):
+    from typing import Any, Callable  # noqa: F401
 
 
 # Wrap the Python 3.5+ function in a docstring to avoid syntax errors when

--- a/datadog/dogstatsd/max_sample_metric.py
+++ b/datadog/dogstatsd/max_sample_metric.py
@@ -1,5 +1,12 @@
 import random
-from typing import List, Optional, cast
+import sys
+
+if sys.version_info[:2] >= (3, 5):
+    from typing import List, Optional, cast  # noqa: F401
+else:
+    from typing import List, Optional  # noqa: F401
+
+    from datadog.util.compat import cast
 
 from datadog.dogstatsd.metric_types import MetricType
 from datadog.dogstatsd.metrics import MetricAggregator

--- a/datadog/dogstatsd/max_sample_metric_context.py
+++ b/datadog/dogstatsd/max_sample_metric_context.py
@@ -1,10 +1,13 @@
 from threading import Lock
 import random
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+import sys
 
-if TYPE_CHECKING:
-    from datadog.dogstatsd.max_sample_metric import MaxSampleMetric
-    from datadog.dogstatsd.metrics import MetricAggregator
+if sys.version_info[:2] >= (3, 5):
+    from typing import Any, Dict, List, Optional, TYPE_CHECKING  # noqa: F401
+
+    if TYPE_CHECKING:
+        from datadog.dogstatsd.max_sample_metric import MaxSampleMetric
+        from datadog.dogstatsd.metrics import MetricAggregator
 
 
 class MaxSampleMetricContexts:

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -1,4 +1,7 @@
-from typing import List, Optional
+import sys
+
+if sys.version_info[:2] >= (3, 5):
+    from typing import List, Optional  # noqa: F401
 
 from datadog.dogstatsd.metric_types import MetricType
 

--- a/datadog/util/compat.py
+++ b/datadog/util/compat.py
@@ -7,6 +7,7 @@ Imports for compatibility with Python 2, Python 3 and Google App Engine.
 """
 import logging
 import sys
+from typing import TypeVar, Any, Type
 
 # Logging
 log = logging.getLogger("datadog.util")
@@ -143,3 +144,10 @@ def conditional_lru_cache(func):
     from functools import lru_cache
 
     return lru_cache(maxsize=512)(func)
+
+
+T = TypeVar('T')
+
+def cast(typ, val):
+    # type: (Type[T], Any) -> T
+    return val

--- a/datadog/util/hostname.py
+++ b/datadog/util/hostname.py
@@ -7,8 +7,11 @@ import logging
 import re
 import socket
 import subprocess
+import sys
 import types
-from typing import Dict, Optional
+
+if sys.version_info[:2] >= (3, 5):
+    from typing import Dict, Optional  # noqa: F401
 
 # datadog
 from datadog.util.compat import url_lib, is_p3k, iteritems

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -749,6 +749,57 @@ class TestDogStatsd(unittest.TestCase):
             ),
         )
 
+    def test_constant_tags_cache_invalidated_on_mutation(self):
+        dogstatsd = DogStatsd(telemetry_min_flush_interval=0, disable_telemetry=True)
+        dogstatsd.socket = FakeSocket()
+
+        dogstatsd.constant_tags = ['original:tag']
+        dogstatsd.gauge('gauge', 1)
+        dogstatsd.flush()
+        self.assertEqual('gauge:1|g|#original:tag\n', dogstatsd.socket.recv())
+
+        # append
+        dogstatsd.constant_tags.append('new:tag')
+        dogstatsd.gauge('gauge', 2)
+        dogstatsd.flush()
+        self.assertEqual('gauge:2|g|#original:tag,new:tag\n', dogstatsd.socket.recv())
+
+        # sort
+        dogstatsd.constant_tags.sort()
+        dogstatsd.gauge('gauge', 3)
+        dogstatsd.flush()
+        self.assertEqual('gauge:3|g|#new:tag,original:tag\n', dogstatsd.socket.recv())
+
+        # remove
+        dogstatsd.constant_tags.remove('new:tag')
+        dogstatsd.gauge('gauge', 4)
+        dogstatsd.flush()
+        self.assertEqual('gauge:4|g|#original:tag\n', dogstatsd.socket.recv())
+
+        # __setitem__
+        dogstatsd.constant_tags[0] = 'replaced:tag'
+        dogstatsd.gauge('gauge', 5)
+        dogstatsd.flush()
+        self.assertEqual('gauge:5|g|#replaced:tag\n', dogstatsd.socket.recv())
+
+        # extend
+        dogstatsd.constant_tags.extend(['a:1', 'b:2'])
+        dogstatsd.gauge('gauge', 6)
+        dogstatsd.flush()
+        self.assertEqual('gauge:6|g|#replaced:tag,a:1,b:2\n', dogstatsd.socket.recv())
+
+        # pop
+        dogstatsd.constant_tags.pop()
+        dogstatsd.gauge('gauge', 7)
+        dogstatsd.flush()
+        self.assertEqual('gauge:7|g|#replaced:tag,a:1\n', dogstatsd.socket.recv())
+
+        # clear
+        dogstatsd.constant_tags.clear()
+        dogstatsd.gauge('gauge', 8)
+        dogstatsd.flush()
+        self.assertEqual('gauge:8|g\n', dogstatsd.socket.recv())
+
     def test_socket_error(self):
         self.statsd.socket = BrokenSocket()
         with mock.patch("datadog.dogstatsd.base.log") as mock_log:


### PR DESCRIPTION
# What is this PR?

This PR updates the way we handle constant tags to improve the overall performance of reporting metrics.
Previously, we would compute the string of user tags + constant tags at every `report` call; now we instead
cache the constant tags part and only compute the string for user tags and the sum of both.

When the `DogStatsD` instance has even a few constant tags, this can make a significant difference in how
many allocations and processing we have to do.

## In practice

- `constant_tags` is now a `@property` with a setter that pre-computes `_constant_tags_str` (the normalised string)
- `_report` does not call `_add_constant_tags` anymore for metrics.
- `_add_constant_tags` is kept for `event` and `service_check` paths, but updated to use `self._constant_tags`.

## The gains

- `_add_constant_tags` list concatenation — previously allocated a new `tags + self.constant_tags` list on every call; this is gone.
- `normalize_tags` ran regex substitution over every tag on every call.  Now constant tags are normalised once at init.
- `",".join(...)` ran over all tags every call. Now constant tags are pre-joined; only user tags need joining at call time.

In order to maintain existing behaviour when using `statsd.constant_tags.<mutating_method>` (e.g. `clear` or `append`), I had to add a `TagList` class that is a very basic subclass of `list` and that updates the cached value when it is mutated.   
The alternative would have been to make it immutable (e.g. return a tuple) but this would have broken potential existing usages, which doesn't sound worth it.

## Benchmark results

**Setup:** 5M `statsd.increment()` calls per case (with buffering enabled).  
The baseline is the code before my changes, optimised adds the constant tags cache.

| Case | Baseline (ops/sec) | Optimised (ops/sec) | Delta |                                                                                                      
|---|---|---|---|
| 5 const + 3 user tags | 1,840k | 2,504k | **+36.1%** |                                                                                                         
| 5 const, no user tags | 1,905k | 3,985k | **+109.2%** |                                                                                                      
| 3 user, no const tags | 2,433k | 2,593k | **+6.6%** |
| No tags | 3,831k | 4,603k | **+20.1%** |
| 10 const + 2 user tags | 1,700k | 2,629k | **+54.6%** |

The win scales with the number of constant tags and to a lower extent user tags.  