### PR TITLE
typing: add typing to dogshell

### DIFF
--- a/datadog/dogshell/__init__.py
+++ b/datadog/dogshell/__init__.py
@@ -31,6 +31,7 @@ from datadog.dogshell.security_monitoring import SecurityMonitoringClient
 
 
 def main():
+    # type: () -> None
     if sys.argv[0].endswith("dog"):
         warnings.warn("dog is pending deprecation. Please use dogshell instead.", PendingDeprecationWarning)
 

--- a/datadog/dogshell/comment.py
+++ b/datadog/dogshell/comment.py
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # stdlib
+import argparse
 import json
 import sys
 
@@ -13,6 +14,7 @@ from datadog.dogshell.common import report_errors, report_warnings
 class CommentClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("comment", help="Post, update, and delete comments.")
 
         verb_parsers = parser.add_subparsers(title="Verbs", dest="verb")
@@ -41,6 +43,7 @@ class CommentClient(object):
 
     @classmethod
     def _post(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         handle = args.handle
         comment = args.comment
@@ -70,6 +73,7 @@ class CommentClient(object):
 
     @classmethod
     def _update(cls, args):
+        # type: (argparse.Namespace) -> None
         handle = args.handle
         comment = args.comment
         id = args.comment_id
@@ -99,6 +103,7 @@ class CommentClient(object):
 
     @classmethod
     def _reply(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         handle = args.handle
         comment = args.comment
@@ -129,6 +134,7 @@ class CommentClient(object):
 
     @classmethod
     def _show(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         id = args.comment_id
         format = args.format

--- a/datadog/dogshell/common.py
+++ b/datadog/dogshell/common.py
@@ -5,12 +5,14 @@
 from __future__ import print_function
 import os
 import sys
+from typing import Any, Dict, Optional
 
 # datadog
 from datadog.util.compat import is_p3k, configparser, IterableUserDict, get_input
 
 
 def print_err(msg):
+    # type: (str) -> None
     if is_p3k():
         print(msg + "\n", file=sys.stderr)
     else:
@@ -19,6 +21,7 @@ def print_err(msg):
 
 
 def report_errors(res):
+    # type: (Dict[str, Any]) -> bool
     if "errors" in res:
         errors = res["errors"]
         if isinstance(errors, list):
@@ -31,6 +34,7 @@ def report_errors(res):
 
 
 def report_warnings(res):
+    # type: (Dict[str, Any]) -> bool
     if "warnings" in res:
         warnings = res["warnings"]
         if isinstance(warnings, list):
@@ -44,6 +48,7 @@ def report_warnings(res):
 
 class DogshellConfig(IterableUserDict):
     def load(self, config_file, api_key, app_key, api_host):
+        # type: (str, Optional[str], Optional[str], Optional[str]) -> None
         config = configparser.ConfigParser()
 
         if api_host is not None:

--- a/datadog/dogshell/dashboard.py
+++ b/datadog/dogshell/dashboard.py
@@ -7,6 +7,7 @@ import sys
 
 # 3p
 import argparse
+from typing import Any
 
 # datadog
 from datadog import api
@@ -17,6 +18,7 @@ from datadog.util.format import pretty_json
 class DashboardClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("dashboard", help="Create, edit, and delete dashboards")
 
         verb_parsers = parser.add_subparsers(title="Verbs", dest="verb")
@@ -89,6 +91,7 @@ class DashboardClient(object):
 
     @classmethod
     def _post(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         widgets = args.widgets
@@ -118,6 +121,7 @@ class DashboardClient(object):
 
     @classmethod
     def _update(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         widgets = args.widgets
@@ -147,6 +151,7 @@ class DashboardClient(object):
 
     @classmethod
     def _show(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Dashboard.get(args.dashboard_id)
@@ -160,6 +165,7 @@ class DashboardClient(object):
 
     @classmethod
     def _delete(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         res = api.Dashboard.delete(args.dashboard_id)
         if res is not None:
@@ -168,6 +174,7 @@ class DashboardClient(object):
 
 
 def _json_string(str):
+    # type: (str) -> Any
     try:
         return json.loads(str)
     except Exception:

--- a/datadog/dogshell/dashboard_list.py
+++ b/datadog/dogshell/dashboard_list.py
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # stdlib
+import argparse
 import json
 
 # 3p
@@ -15,6 +16,7 @@ from datadog.dogshell.common import report_errors, report_warnings
 class DashboardListClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("dashboard_list", help="Create, edit, and delete dashboard lists")
         verb_parsers = parser.add_subparsers(title="Verbs", dest="verb")
         verb_parsers.required = True
@@ -139,6 +141,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _post(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         name = args.name
@@ -154,6 +157,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _update(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id
@@ -170,6 +174,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _show(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id
@@ -185,6 +190,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _show_all(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
 
@@ -199,6 +205,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _delete(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id
@@ -214,6 +221,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _show_dashboards(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id
@@ -229,6 +237,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _show_dashboards_v2(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id
@@ -244,6 +253,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _add_dashboards(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id
@@ -260,6 +270,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _add_dashboards_v2(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id
@@ -276,6 +287,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _update_dashboards(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id
@@ -292,6 +304,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _update_dashboards_v2(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id
@@ -308,6 +321,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _delete_dashboards(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id
@@ -324,6 +338,7 @@ class DashboardListClient(object):
 
     @classmethod
     def _delete_dashboards_v2(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         dashboard_list_id = args.dashboard_list_id

--- a/datadog/dogshell/downtime.py
+++ b/datadog/dogshell/downtime.py
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # stdlib
+import argparse
 import json
 
 # 3p
@@ -15,6 +16,7 @@ from datadog.dogshell.common import report_errors, report_warnings
 class DowntimeClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("downtime", help="Create, edit, and delete downtimes")
         parser.add_argument(
             "--string_ids",
@@ -65,6 +67,7 @@ class DowntimeClient(object):
 
     @classmethod
     def _schedule_downtime(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Downtime.create(scope=args.scope, start=args.start, end=args.end, message=args.message)
@@ -77,6 +80,7 @@ class DowntimeClient(object):
 
     @classmethod
     def _update_downtime(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Downtime.update(
@@ -91,6 +95,7 @@ class DowntimeClient(object):
 
     @classmethod
     def _cancel_downtime(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         res = api.Downtime.delete(args.downtime_id)
         if res is not None:
@@ -99,6 +104,7 @@ class DowntimeClient(object):
 
     @classmethod
     def _show_downtime(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Downtime.get(args.downtime_id)
@@ -111,6 +117,7 @@ class DowntimeClient(object):
 
     @classmethod
     def _show_all_downtime(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Downtime.get_all(current_only=args.current_only)
@@ -123,6 +130,7 @@ class DowntimeClient(object):
 
     @classmethod
     def _cancel_downtime_by_scope(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Downtime.cancel_downtime_by_scope(scope=args.scope)

--- a/datadog/dogshell/event.py
+++ b/datadog/dogshell/event.py
@@ -2,11 +2,15 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # stdlib
+import argparse
 import datetime
 import time
 import re
 import sys
 import json
+
+# 3p
+from typing import Any, Dict, Optional
 
 # datadog
 from datadog import api
@@ -17,6 +21,7 @@ time_pat = re.compile(r"(?P<delta>[0-9]*\.?[0-9]+)(?P<unit>[mhd])")
 
 
 def prettyprint_event(event):
+    # type: (Dict[str, Any]) -> None
     title = event["title"] or ""
     text = event.get("text", "") or ""
     handle = event.get("handle", "") or ""
@@ -30,18 +35,22 @@ def prettyprint_event(event):
 
 
 def print_event(event):
+    # type: (Dict[str, Any]) -> None
     prettyprint_event(event)
 
 
 def prettyprint_event_details(event):
+    # type: (Dict[str, Any]) -> None
     prettyprint_event(event)
 
 
 def print_event_details(event):
+    # type: (Dict[str, Any]) -> None
     prettyprint_event(event)
 
 
 def parse_time(timestring):
+    # type: (Optional[str]) -> int
     now = time.mktime(datetime.datetime.now().timetuple())
     if timestring is None:
         t = now
@@ -67,6 +76,7 @@ def parse_time(timestring):
 class EventClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("event", help="Post events, get event details," " and view the event stream.")
         verb_parsers = parser.add_subparsers(title="Verbs", dest="verb")
         verb_parsers.required = True
@@ -115,6 +125,7 @@ class EventClient(object):
 
     @classmethod
     def _post(cls, args):
+        # type: (argparse.Namespace) -> None
         """
         Post an event.
         """
@@ -158,6 +169,7 @@ class EventClient(object):
 
     @classmethod
     def _show(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Event.get(args.event_id)
@@ -172,6 +184,7 @@ class EventClient(object):
 
     @classmethod
     def _stream(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         if args.sources is not None:

--- a/datadog/dogshell/host.py
+++ b/datadog/dogshell/host.py
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # stdlib
+import argparse
 import json
 
 # 3p
@@ -15,6 +16,7 @@ from datadog.dogshell.common import report_errors, report_warnings
 class HostClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("host", help="Mute, unmute hosts")
         verb_parsers = parser.add_subparsers(title="Verbs", dest="verb")
         verb_parsers.required = True
@@ -38,6 +40,7 @@ class HostClient(object):
 
     @classmethod
     def _mute(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Host.mute(args.host_name, end=args.end, message=args.message, override=args.override)
@@ -50,6 +53,7 @@ class HostClient(object):
 
     @classmethod
     def _unmute(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Host.unmute(args.host_name)

--- a/datadog/dogshell/hosts.py
+++ b/datadog/dogshell/hosts.py
@@ -2,7 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # stdlib
-
+import argparse
 import json
 
 # 3p
@@ -16,6 +16,7 @@ from datadog.dogshell.common import report_errors, report_warnings
 class HostsClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("hosts", help="Get information about hosts")
         verb_parsers = parser.add_subparsers(title="Verbs", dest="verb")
         verb_parsers.required = True
@@ -67,6 +68,7 @@ class HostsClient(object):
 
     @classmethod
     def _list(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Hosts.get_all(
@@ -89,6 +91,7 @@ class HostsClient(object):
 
     @classmethod
     def _totals(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Hosts.totals(from_=args.from_)

--- a/datadog/dogshell/metric.py
+++ b/datadog/dogshell/metric.py
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # stdlib
+import argparse
 from collections import defaultdict
 
 # datadog
@@ -12,6 +13,7 @@ from datadog.dogshell.common import report_errors, report_warnings
 class MetricClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("metric", help="Post metrics.")
         verb_parsers = parser.add_subparsers(title="Verbs", dest="verb")
         verb_parsers.required = True
@@ -41,6 +43,7 @@ class MetricClient(object):
 
     @classmethod
     def _post(cls, args):
+        # type: (argparse.Namespace) -> None
         """
         Post a metric.
         """

--- a/datadog/dogshell/monitor.py
+++ b/datadog/dogshell/monitor.py
@@ -16,6 +16,7 @@ from datadog.dogshell.common import report_errors, report_warnings, print_err
 class MonitorClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("monitor", help="Create, edit, and delete monitors")
         parser.add_argument(
             "--string_ids",
@@ -169,6 +170,7 @@ class MonitorClient(object):
 
     @classmethod
     def _post(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         options = None
@@ -209,6 +211,7 @@ class MonitorClient(object):
 
     @classmethod
     def _file_post(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         monitor = json.load(args.file)
@@ -239,6 +242,7 @@ class MonitorClient(object):
 
     @classmethod
     def _update(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
 
@@ -292,6 +296,7 @@ class MonitorClient(object):
 
     @classmethod
     def _file_update(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         monitor = json.load(args.file)
@@ -324,6 +329,7 @@ class MonitorClient(object):
 
     @classmethod
     def _show(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Monitor.get(args.monitor_id)
@@ -340,6 +346,7 @@ class MonitorClient(object):
 
     @classmethod
     def _show_all(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
 
@@ -375,6 +382,7 @@ class MonitorClient(object):
 
     @classmethod
     def _delete(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         # TODO CHECK
         res = api.Monitor.delete(args.monitor_id)
@@ -384,10 +392,12 @@ class MonitorClient(object):
 
     @classmethod
     def _escape(cls, s):
+        # type: (str) -> str
         return s.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
 
     @classmethod
     def _mute_all(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Monitor.mute_all()
@@ -400,6 +410,7 @@ class MonitorClient(object):
 
     @classmethod
     def _unmute_all(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         res = api.Monitor.unmute_all()
         if res is not None:
@@ -408,6 +419,7 @@ class MonitorClient(object):
 
     @classmethod
     def _mute(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Monitor.mute(args.monitor_id, scope=args.scope, end=args.end)
@@ -420,6 +432,7 @@ class MonitorClient(object):
 
     @classmethod
     def _unmute(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Monitor.unmute(args.monitor_id, scope=args.scope, all_scopes=args.all_scopes)
@@ -432,6 +445,7 @@ class MonitorClient(object):
 
     @classmethod
     def _can_delete(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         monitor_ids = [i.strip() for i in args.monitor_ids.split(",") if i.strip()]
@@ -443,6 +457,7 @@ class MonitorClient(object):
 
     @classmethod
     def _validate(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         options = None

--- a/datadog/dogshell/screenboard.py
+++ b/datadog/dogshell/screenboard.py
@@ -10,6 +10,7 @@ import webbrowser
 
 # 3p
 from datadog.util.format import pretty_json
+from typing import Dict, List, Union
 
 # datadog
 from datadog import api
@@ -20,6 +21,7 @@ from datetime import datetime
 class ScreenboardClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("screenboard", help="Create, edit, and delete screenboards.")
         parser.add_argument(
             "--string_ids",
@@ -114,11 +116,13 @@ class ScreenboardClient(object):
 
     @classmethod
     def _pull(cls, args):
+        # type: (argparse.Namespace) -> None
         cls._write_screen_to_file(args.screenboard_id, args.filename, args.timeout, args.format, args.string_ids)
 
     # TODO Is there a test for this one ?
     @classmethod
     def _push(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         for f in args.file:
             screen_obj = json.load(f)
@@ -153,6 +157,7 @@ class ScreenboardClient(object):
 
     @classmethod
     def _write_screen_to_file(cls, screenboard_id, filename, timeout, format="raw", string_ids=False):
+        # type: (Union[str, int], str, int, str, bool) -> None
         with open(filename, "w") as f:
             res = api.Screenboard.get(screenboard_id)
             report_warnings(res)
@@ -176,6 +181,7 @@ class ScreenboardClient(object):
 
     @classmethod
     def _post(cls, args):
+        # type: (argparse.Namespace) -> None
         graphs = sys.stdin.read()
         api._timeout = args.timeout
         format = args.format
@@ -200,6 +206,7 @@ class ScreenboardClient(object):
 
     @classmethod
     def _update(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         graphs = args.graphs
@@ -225,12 +232,14 @@ class ScreenboardClient(object):
 
     @classmethod
     def _web_view(cls, args):
+        # type: (argparse.Namespace) -> None
         dash_id = json.load(args.file)["id"]
-        url = api._api_host + "/dash/dash/{0}".format(dash_id)
+        url = (api._api_host or "") + "/dash/dash/{0}".format(dash_id)
         webbrowser.open(url)
 
     @classmethod
     def _show(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Screenboard.get(args.screenboard_id)
@@ -247,6 +256,7 @@ class ScreenboardClient(object):
 
     @classmethod
     def _delete(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         # TODO CHECK
         res = api.Screenboard.delete(args.screenboard_id)
@@ -256,6 +266,7 @@ class ScreenboardClient(object):
 
     @classmethod
     def _share(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Screenboard.share(args.screenboard_id)
@@ -267,6 +278,7 @@ class ScreenboardClient(object):
 
     @classmethod
     def _revoke(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Screenboard.revoke(args.screenboard_id)
@@ -278,6 +290,7 @@ class ScreenboardClient(object):
 
     @classmethod
     def _new_file(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         graphs = args.graphs
@@ -299,6 +312,7 @@ class ScreenboardClient(object):
 
 
 def _template_variables(tpl_var_input):
+    # type: (str) -> Union[List[str], List[Dict[str, str]]]
     if "[" not in tpl_var_input:
         return [v.strip() for v in tpl_var_input.split(",")]
     else:

--- a/datadog/dogshell/search.py
+++ b/datadog/dogshell/search.py
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # stdlib
+import argparse
 import json
 
 # datadog
@@ -13,6 +14,7 @@ from datadog.dogshell.common import report_errors, report_warnings
 class SearchClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("search", help="search datadog")
         verb_parsers = parser.add_subparsers(title="Verbs", dest="verb")
         verb_parsers.required = True
@@ -23,6 +25,7 @@ class SearchClient(object):
 
     @classmethod
     def _query(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Infrastructure.search(q=args.query)

--- a/datadog/dogshell/security_monitoring.py
+++ b/datadog/dogshell/security_monitoring.py
@@ -6,9 +6,12 @@ Security Monitoring client - dogshell implementation.
 """
 from __future__ import print_function
 
+import argparse
 import json
 import sys
 from functools import wraps
+
+from typing import Any, Callable, Dict, Optional
 
 from datadog.dogshell.common import report_errors, report_warnings, print_err
 from datadog.api.security_monitoring_rules import SecurityMonitoringRule
@@ -18,11 +21,13 @@ from datadog import api
 
 
 def api_cmd(f):
+    # type: (Callable[[argparse.Namespace], Optional[Dict[str, Any]]]) -> Callable[[argparse.Namespace], int]
     """
     Decorator for security monitoring commands.
     """
     @wraps(f)
     def wrapper(args):
+        # type: (argparse.Namespace) -> int
         """
         A decorator that reports errors and warnings.
         """
@@ -52,6 +57,7 @@ class SecurityMonitoringClient(object):
 
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         """
         Set up the command line parser for security monitoring commands.
         """
@@ -155,15 +161,19 @@ class SecurityMonitoringClient(object):
 
     @classmethod
     def _show_rule(cls, args):
+        # type: (argparse.Namespace) -> int
         @api_cmd
         def show_rule_cmd(args):
+            # type: (argparse.Namespace) -> Optional[Dict[str, Any]]
             return SecurityMonitoringRule.get(args.rule_id)
         return show_rule_cmd(args)
 
     @classmethod
     def _show_all_rules(cls, args):
+        # type: (argparse.Namespace) -> int
         @api_cmd
         def show_all_rules_cmd(args):
+            # type: (argparse.Namespace) -> Optional[Dict[str, Any]]
             params = {}
 
             if args.page_size:
@@ -176,11 +186,13 @@ class SecurityMonitoringClient(object):
 
     @classmethod
     def _create_rule(cls, args):
+        # type: (argparse.Namespace) -> int
         """
         Create a security monitoring rule.
         """
         @api_cmd
         def create_rule_cmd(args):
+            # type: (argparse.Namespace) -> Optional[Dict[str, Any]]
             try:
                 with open(args.file, "r") as f:
                     rule_data = json.load(f)
@@ -193,11 +205,13 @@ class SecurityMonitoringClient(object):
 
     @classmethod
     def _update_rule(cls, args):
+        # type: (argparse.Namespace) -> int
         """
         Update a security monitoring rule.
         """
         @api_cmd
         def update_rule_cmd(args):
+            # type: (argparse.Namespace) -> Optional[Dict[str, Any]]
             try:
                 with open(args.file, "r") as f:
                     rule_data = json.load(f)
@@ -210,21 +224,25 @@ class SecurityMonitoringClient(object):
 
     @classmethod
     def _delete_rule(cls, args):
+        # type: (argparse.Namespace) -> int
         """
         Delete a security monitoring rule.
         """
         @api_cmd
         def delete_rule_cmd(args):
+            # type: (argparse.Namespace) -> Optional[Dict[str, Any]]
             return SecurityMonitoringRule.delete(args.rule_id)
         return delete_rule_cmd(args)
 
     @classmethod
     def _list_signals(cls, args):
+        # type: (argparse.Namespace) -> int
         """
         List security monitoring signals.
         """
         @api_cmd
         def list_signals_cmd(args):
+            # type: (argparse.Namespace) -> Optional[Dict[str, Any]]
             params = {}
 
             if args.query:
@@ -245,20 +263,24 @@ class SecurityMonitoringClient(object):
 
     @classmethod
     def _get_signal(cls, args):
+        # type: (argparse.Namespace) -> int
         """
         Get a security monitoring signal.
         """
         @api_cmd
         def get_signal_cmd(args):
+            # type: (argparse.Namespace) -> Optional[Dict[str, Any]]
             return SecurityMonitoringSignal.get(args.signal_id)
         return get_signal_cmd(args)
 
     @classmethod
     def _change_triage_state(cls, args):
+        # type: (argparse.Namespace) -> int
         """
         Change triage state of security signals.
         """
         @api_cmd
         def change_triage_state_cmd(args):
+            # type: (argparse.Namespace) -> Optional[Dict[str, Any]]
             return SecurityMonitoringSignal.change_triage_state(args.signal_id, args.state)
         return change_triage_state_cmd(args)

--- a/datadog/dogshell/service_check.py
+++ b/datadog/dogshell/service_check.py
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # stdlib
+import argparse
 import json
 
 # 3p
@@ -15,6 +16,7 @@ from datadog.dogshell.common import report_errors, report_warnings
 class ServiceCheckClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("service_check", help="Perform service checks")
         verb_parsers = parser.add_subparsers(title="Verbs", dest="verb")
         verb_parsers.required = True
@@ -33,6 +35,7 @@ class ServiceCheckClient(object):
 
     @classmethod
     def _check(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         if args.tags:

--- a/datadog/dogshell/service_level_objective.py
+++ b/datadog/dogshell/service_level_objective.py
@@ -22,6 +22,7 @@ from datadog.dogshell.common import report_errors, report_warnings
 class ServiceLevelObjectiveClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser(
             "service_level_objective",
             help="Create, edit, and delete service level objectives",
@@ -176,6 +177,7 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _create(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
 
@@ -234,6 +236,7 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _file_create(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         slo = json.load(args.file)
@@ -247,6 +250,7 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _update(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
 
@@ -306,6 +310,7 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _file_update(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         slo = json.load(args.file)
@@ -320,6 +325,7 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _show(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.ServiceLevelObjective.get(args.slo_id, return_raw=True)
@@ -336,6 +342,7 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _show_all(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
 
@@ -356,6 +363,7 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _delete(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         res = api.ServiceLevelObjective.delete(args.slo_id, return_raw=True)
         if res is not None:
@@ -369,6 +377,7 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _delete_many(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         res = api.ServiceLevelObjective.delete_many(args.slo_ids)
         if res is not None:
@@ -382,6 +391,7 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _delete_timeframe(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
 
         ops = {args.slo_id: args.timeframes}
@@ -398,6 +408,7 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _can_delete(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
 
         res = api.ServiceLevelObjective.can_delete(args.slo_ids)
@@ -412,9 +423,10 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _history(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
 
-        res = api.ServiceLevelObjective.history(args.slo_id)
+        res = api.ServiceLevelObjective.history(args.slo_id, args.from_ts, args.to_ts)
         if res is not None:
             report_warnings(res)
             report_errors(res)
@@ -426,4 +438,5 @@ class ServiceLevelObjectiveClient(object):
 
     @classmethod
     def _escape(cls, s):
+        # type: (str) -> str
         return s.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")

--- a/datadog/dogshell/tag.py
+++ b/datadog/dogshell/tag.py
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # stdlib
+import argparse
 import json
 
 # datadog
@@ -12,6 +13,7 @@ from datadog.dogshell.common import report_errors, report_warnings
 class TagClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("tag", help="View and modify host tags.")
         verb_parsers = parser.add_subparsers(title="Verbs", dest="verb")
         verb_parsers.required = True
@@ -46,6 +48,7 @@ class TagClient(object):
 
     @classmethod
     def _add(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Tag.create(args.host, tags=args.tag)
@@ -63,6 +66,7 @@ class TagClient(object):
 
     @classmethod
     def _replace(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Tag.update(args.host, tags=args.tag)
@@ -80,6 +84,7 @@ class TagClient(object):
 
     @classmethod
     def _show(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         if args.host == "all":
@@ -113,6 +118,7 @@ class TagClient(object):
 
     @classmethod
     def _detach(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         res = api.Tag.delete(args.host)
         if res is not None:

--- a/datadog/dogshell/timeboard.py
+++ b/datadog/dogshell/timeboard.py
@@ -10,6 +10,7 @@ import webbrowser
 
 # 3p
 import argparse
+from typing import Dict, List, Optional, Union
 
 # datadog
 from datadog import api
@@ -21,6 +22,7 @@ from datetime import datetime
 class TimeboardClient(object):
     @classmethod
     def setup_parser(cls, subparsers):
+        # type: (argparse._SubParsersAction[argparse.ArgumentParser]) -> None
         parser = subparsers.add_parser("timeboard", help="Create, edit, and delete timeboards")
         parser.add_argument(
             "--string_ids",
@@ -116,13 +118,16 @@ class TimeboardClient(object):
 
     @classmethod
     def _pull(cls, args):
+        # type: (argparse.Namespace) -> None
         cls._write_dash_to_file(args.timeboard_id, args.filename, args.timeout, args.format, args.string_ids)
 
     @classmethod
     def _pull_all(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
 
         def _title_to_filename(title):
+            # type: (str) -> str
             # Get a lowercased version with most punctuation stripped out...
             no_punct = "".join([c for c in title.lower() if c.isalnum() or c in [" ", "_", "-"]])
             # Now replace all -'s, _'s and spaces with "_", and strip trailing _
@@ -157,6 +162,7 @@ class TimeboardClient(object):
 
     @classmethod
     def _new_file(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         graphs = args.graphs
@@ -179,6 +185,7 @@ class TimeboardClient(object):
 
     @classmethod
     def _write_dash_to_file(cls, dash_id, filename, timeout, format="raw", string_ids=False):
+        # type: (Union[str, int], str, int, str, bool) -> None
         with open(filename, "w") as f:
             res = api.Timeboard.get(dash_id)
             report_warnings(res)
@@ -205,6 +212,7 @@ class TimeboardClient(object):
 
     @classmethod
     def _push(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         for f in args.file:
             try:
@@ -252,6 +260,7 @@ class TimeboardClient(object):
 
     @classmethod
     def _post(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         graphs = args.graphs
@@ -270,6 +279,7 @@ class TimeboardClient(object):
 
     @classmethod
     def _update(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         graphs = args.graphs
@@ -293,6 +303,7 @@ class TimeboardClient(object):
 
     @classmethod
     def _show(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Timeboard.get(args.timeboard_id)
@@ -309,6 +320,7 @@ class TimeboardClient(object):
 
     @classmethod
     def _show_all(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         format = args.format
         res = api.Timeboard.get_all()
@@ -329,6 +341,7 @@ class TimeboardClient(object):
 
     @classmethod
     def _delete(cls, args):
+        # type: (argparse.Namespace) -> None
         api._timeout = args.timeout
         res = api.Timeboard.delete(args.timeboard_id)
         if res is not None:
@@ -337,16 +350,19 @@ class TimeboardClient(object):
 
     @classmethod
     def _web_view(cls, args):
+        # type: (argparse.Namespace) -> None
         dash_id = json.load(args.file)["id"]
-        url = api._api_host + "/dash/dash/{0}".format(dash_id)
+        url = (api._api_host or "") + "/dash/dash/{0}".format(dash_id)
         webbrowser.open(url)
 
     @classmethod
     def _escape(cls, s):
+        # type: (Optional[str]) -> str
         return s.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t") if s else ""
 
 
 def _template_variables(tpl_var_input):
+    # type: (str) -> Union[List[str], List[Dict[str, str]]]
     if "[" not in tpl_var_input:
         return [v.strip() for v in tpl_var_input.split(",")]
     else:

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -32,6 +32,9 @@ import threading
 import time
 import warnings
 
+# 3p
+from typing import Any, IO, List, Optional, Tuple, Type, Union
+
 # datadog
 from datadog import initialize, api, __version__
 from datadog.util.compat import is_p3k
@@ -55,6 +58,7 @@ class OutputReader(threading.Thread):
     """
 
     def __init__(self, proc_out, fwd_out=None):
+        # type: (IO[bytes], Optional[IO[Any]]) -> None
         """
         Instantiates an OutputReader.
         :param proc_out: the output to read
@@ -69,6 +73,7 @@ class OutputReader(threading.Thread):
         self._fwd_out = fwd_out
 
     def run(self):
+        # type: () -> None
         """
         Thread's main loop: collects the output optionnally forwarding it to
         the file descriptor passed in the constructor.
@@ -81,6 +86,7 @@ class OutputReader(threading.Thread):
 
     @property
     def content(self):
+        # type: () -> bytes
         """
         The content stored in out so far. (Not threadsafe, wait with .join())
         """
@@ -88,6 +94,7 @@ class OutputReader(threading.Thread):
 
 
 def poll_proc(proc, sleep_interval, timeout):
+    # type: (subprocess.Popen[bytes], float, float) -> int
     """
     Polls the process until it returns or a given timeout has been reached
     """
@@ -103,11 +110,12 @@ def poll_proc(proc, sleep_interval, timeout):
 
 
 def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout, proc_poll_interval, buffer_outs):
+    # type: (str, float, float, float, float, bool) -> Tuple[Union[int, Type[Timeout]], bytes, bytes, float]
     """
     Launches the process and monitors its outputs
     """
     start_time = time.time()
-    returncode = -1
+    returncode = -1  # type: Union[int, Type[Timeout]]
     stdout = b""
     stderr = b""
     try:
@@ -120,6 +128,8 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout, proc_poll_interv
         # background
         stdout_buffer = sys.stdout.buffer if is_p3k() else sys.stdout
         stderr_buffer = sys.stderr.buffer if is_p3k() else sys.stderr
+        assert proc.stdout is not None
+        assert proc.stderr is not None
         out_reader = OutputReader(proc.stdout, stdout_buffer if not buffer_outs else None)
         err_reader = OutputReader(proc.stderr, stderr_buffer if not buffer_outs else None)
         out_reader.start()
@@ -167,6 +177,7 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout, proc_poll_interv
 
 
 def trim_text(text, max_len):
+    # type: (str, int) -> str
     """
     Trim input text to fit the `max_len` condition.
 
@@ -190,6 +201,7 @@ def trim_text(text, max_len):
 
 
 def build_event_body(cmd, returncode, stdout, stderr, notifications):
+    # type: (str, Union[int, Type[Timeout]], bytes, bytes, Union[str, bytes]) -> str
     """
     Format and return an event body.
 
@@ -233,6 +245,7 @@ def build_event_body(cmd, returncode, stdout, stderr, notifications):
 
 
 def generate_warning_codes(option, opt, options_warning):
+    # type: (optparse.Option, str, str) -> List[str]
     try:
         # options_warning is a string e.g.: --warning_codes 123,456,789
         # we need to create a list from it
@@ -250,6 +263,7 @@ class DogwrapOption(optparse.Option):
 
 
 def parse_options(raw_args=None):
+    # type: (Optional[List[str]]) -> Tuple[optparse.Values, str]
     """
     Parse the raw command line options into an options object and the remaining command string
     """
@@ -399,12 +413,13 @@ returned (the command outputs remains buffered in dogwrap meanwhile)",
     if is_p3k():
         cmd = " ".join(args)
     else:
-        cmd = b" ".join(args).decode("utf-8")
+        cmd = b" ".join(a.encode("utf-8") for a in args).decode("utf-8")
 
     return options, cmd
 
 
 def main():
+    # type: () -> None
     options, cmd = parse_options()
 
     # If silent is checked we force the outputs to be buffered (and therefore
@@ -494,12 +509,11 @@ def main():
     }
 
     if options.buffer_outs:
-        if is_p3k():
-            stderr = stderr.decode("utf-8")
-            stdout = stdout.decode("utf-8")
+        stderr_out = stderr.decode("utf-8") if is_p3k() else stderr  # type: Union[bytes, str]
+        stdout_out = stdout.decode("utf-8") if is_p3k() else stdout  # type: Union[bytes, str]
 
-        print(stderr.strip(), file=sys.stderr)
-        print(stdout.strip(), file=sys.stdout)
+        print(stderr_out.strip(), file=sys.stderr)
+        print(stdout_out.strip(), file=sys.stdout)
 
     if options.submit_mode == "all" or returncode != 0:
         if options.send_metric:
@@ -511,6 +525,7 @@ def main():
             api.Metric.send(metric="dogwrap.duration", points=duration, tags=duration_tags, type="gauge")
         api.Event.create(title=event_title, text=event_body, **event)
 
+    assert isinstance(returncode, int)
     sys.exit(returncode)
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,10 +35,6 @@ ignore_missing_imports = True
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-datadog.dogshell.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
 [mypy-datadog.dogstatsd.*]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False


### PR DESCRIPTION
### What does this PR do?

This PR adds static typing (Python 2.7 compatible, through typing comments and not the actual type hinting syntax) to `datadogpy`, following a discussion we had on another PR. 

**Note** this was mostly AI generated, but it was reviewed and amended by myself. The typing makes sense as far as I can tell.  There are two caveats to the current typing (that I don't like):
- Using `argparse.Namespace` to pass `args` everywhere -- it's correct, but it also doesn't validate much as this is not statically typed so e.g. getting `args.some_attr` will not trigger any type checking error if `some_attr` doesn't exist in the `ArgumentParser` we have.
- Using `Any`, specifically `dict[str, Any]` for anything we know is a JSON object, or exceptionally `Any` as the result type of a function parsing JSON. Since we don't have proper typing for the Datadog API (the `api` module isn't typed yet, but even if it was, we wouldn't have the specifics for each type returned by the API), there's no other way and it's a good middleground.