### PR TITLE
typing: add typing for `api`

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -6,6 +6,7 @@ import json
 import logging
 import time
 import zlib
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
 # datadog
 from datadog.api import _api_version, _max_timeouts, _backoff_period
@@ -13,6 +14,9 @@ from datadog.api.exceptions import ClientError, ApiError, HttpBackoff, HttpTimeo
 from datadog.api.http_client import resolve_http_client
 from datadog.util.compat import is_p3k
 from datadog.util.format import construct_url, normalize_tags
+
+if TYPE_CHECKING:
+    from datadog.api.http_client import HTTPClient  # noqa: F401
 
 
 log = logging.getLogger("datadog.api")
@@ -27,7 +31,7 @@ class APIClient(object):
     # HTTP transport parameters
     _backoff_period = _backoff_period
     _max_timeouts = _max_timeouts
-    _backoff_timestamp = None
+    _backoff_timestamp = None  # type: Optional[float]
     _timeout_counter = 0
     _sort_keys = False
 
@@ -36,6 +40,7 @@ class APIClient(object):
 
     @classmethod
     def _get_http_client(cls):
+        # type: () -> Type[HTTPClient]
         """
         Getter for the embedded HTTP client.
         """
@@ -47,17 +52,18 @@ class APIClient(object):
     @classmethod
     def submit(
         cls,
-        method,
-        path,
-        api_version=None,
-        body=None,
-        attach_host_name=False,
-        response_formatter=None,
-        error_formatter=None,
-        suppress_response_errors_on_codes=None,
-        compress_payload=False,
-        **params
+        method,  # type: str
+        path,  # type: str
+        api_version=None,  # type: Optional[str]
+        body=None,  # type: Optional[Any]
+        attach_host_name=False,  # type: bool
+        response_formatter=None,  # type: Optional[Any]
+        error_formatter=None,  # type: Optional[Any]
+        suppress_response_errors_on_codes=None,  # type: Optional[List[int]]
+        compress_payload=False,  # type: bool
+        **params  # type: Any
     ):
+        # type: (...) -> Any
         """
         Make an HTTP API request
 
@@ -154,6 +160,7 @@ class APIClient(object):
                 headers["Content-Type"] = "application/json"
 
             if compress_payload:
+                assert body is not None
                 body = zlib.compress(body.encode("utf-8"))
                 headers["Content-Encoding"] = "deflate"
 
@@ -244,6 +251,7 @@ class APIClient(object):
 
     @classmethod
     def _should_submit(cls):
+        # type: () -> bool
         """
         Returns True if we're in a state where we should make a request
         (backoff expired, no backoff in effect), false otherwise.
@@ -288,10 +296,12 @@ class APIClient(object):
 
     @classmethod
     def _backoff_status(cls):
+        # type: () -> Tuple[float, float]
         """
         Get a backoff report, i.e. backoff total and remaining time.
         """
         now = time.time()
+        assert cls._backoff_timestamp is not None
         backed_off_time = now - cls._backoff_timestamp
         backoff_time_left = cls._backoff_period - backed_off_time
         return round(backed_off_time, 2), round(backoff_time_left, 2)

--- a/datadog/api/aws_integration.py
+++ b/datadog/api/aws_integration.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any, Optional
+
 from datadog.api.resources import (
     GetableAPIResource,
     CreateableAPIResource,
@@ -25,9 +27,11 @@ class AwsIntegration(
 
     _resource_name = "integration"
     _resource_id = "aws"
+    _sub_resource_name = ""  # type: str
 
     @classmethod
     def list(cls, **params):
+        # type: (**Any) -> Any
         """
         List all Datadog-AWS integrations available in your Datadog organization.
 
@@ -36,7 +40,8 @@ class AwsIntegration(
         return super(AwsIntegration, cls).get(id=cls._resource_id, **params)
 
     @classmethod
-    def create(cls, **params):
+    def create(cls, attach_host_name=False, method="POST", id=None, params=None, **body):
+        # type: (bool, str, Optional[Any], Optional[Any], **Any) -> Any
         """
         Add a new AWS integration config.
 
@@ -94,10 +99,11 @@ class AwsIntegration(
         account_specific_namespace_rules=account_specific_namespace_rules \
         excluded_regions=excluded_regions)
         """
-        return super(AwsIntegration, cls).create(id=cls._resource_id, **params)
+        return super(AwsIntegration, cls).create(id=cls._resource_id, **body)
 
     @classmethod
-    def update(cls, **body):
+    def update(cls, id=None, params=None, **body):
+        # type: (Optional[Any], Optional[Any], **Any) -> Any
         """
         Update an AWS integration config.
 
@@ -213,7 +219,8 @@ class AwsIntegration(
         return super(AwsIntegration, cls).update(id=cls._resource_id, params=params, **body)
 
     @classmethod
-    def delete(cls, **body):
+    def delete(cls, id=None, **body):
+        # type: (Optional[Any], **Any) -> Any
         """
         Delete a given Datadog-AWS integration.
 
@@ -226,6 +233,7 @@ class AwsIntegration(
 
     @classmethod
     def list_namespace_rules(cls, **params):
+        # type: (**Any) -> Any
         """
         List all namespace rules available as options.
 
@@ -236,6 +244,7 @@ class AwsIntegration(
 
     @classmethod
     def generate_new_external_id(cls, **params):
+        # type: (**Any) -> Any
         """
         Generate a new AWS external id for a given AWS account id and role name pair.
 

--- a/datadog/api/aws_log_integration.py
+++ b/datadog/api/aws_log_integration.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any
+
 from datadog.api.resources import DeletableAPISubResource, ListableAPISubResource, AddableAPISubResource
 
 
@@ -11,9 +13,11 @@ class AwsLogsIntegration(DeletableAPISubResource, ListableAPISubResource, Addabl
 
     _resource_name = "integration"
     _resource_id = "aws"
+    _sub_resource_name = ""  # type: str
 
     @classmethod
     def list_log_services(cls, **params):
+        # type: (**Any) -> Any
         """
         List all namespace rules available as options.
 
@@ -24,6 +28,7 @@ class AwsLogsIntegration(DeletableAPISubResource, ListableAPISubResource, Addabl
 
     @classmethod
     def add_log_lambda_arn(cls, **params):
+        # type: (**Any) -> Any
         """
         Attach the Lambda ARN of the Lambda created for the Datadog-AWS \
         log collection to your AWS account ID to enable log collection.
@@ -38,6 +43,7 @@ class AwsLogsIntegration(DeletableAPISubResource, ListableAPISubResource, Addabl
 
     @classmethod
     def save_services(cls, **params):
+        # type: (**Any) -> Any
         """
         Enable Automatic Log collection for your AWS services.
 
@@ -51,6 +57,7 @@ class AwsLogsIntegration(DeletableAPISubResource, ListableAPISubResource, Addabl
 
     @classmethod
     def delete_config(cls, **params):
+        # type: (**Any) -> Any
         """
         Delete a Datadog-AWS log collection configuration by removing the specific Lambda ARN \
         associated with a given AWS account.
@@ -65,6 +72,7 @@ class AwsLogsIntegration(DeletableAPISubResource, ListableAPISubResource, Addabl
 
     @classmethod
     def check_lambda(cls, **params):
+        # type: (**Any) -> Any
         """
         Check function to see if a lambda_arn exists within an account. \
         This sends a job on our side if it does not exist, then immediately returns \
@@ -86,6 +94,7 @@ class AwsLogsIntegration(DeletableAPISubResource, ListableAPISubResource, Addabl
 
     @classmethod
     def check_services(cls, **params):
+        # type: (**Any) -> Any
         """
         Test if permissions are present to add log-forwarding triggers for the \
         given services + AWS account. Input is the same as for save_services.
@@ -102,6 +111,7 @@ class AwsLogsIntegration(DeletableAPISubResource, ListableAPISubResource, Addabl
 
     @classmethod
     def list(cls, **params):
+        # type: (**Any) -> Any
         """
         List all Datadog-AWS Logs integrations available in your Datadog organization.
 

--- a/datadog/api/azure_integration.py
+++ b/datadog/api/azure_integration.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any, Dict, Optional
+
 from datadog.api.resources import (
     GetableAPIResource,
     CreateableAPIResource,
@@ -19,9 +21,11 @@ class AzureIntegration(
 
     _resource_name = "integration"
     _resource_id = "azure"
+    _sub_resource_name = ""  # type: str
 
     @classmethod
     def list(cls, **params):
+        # type: (**Any) -> Any
         """
         List all Datadog-Azure integrations available in your Datadog organization.
 
@@ -30,7 +34,8 @@ class AzureIntegration(
         return super(AzureIntegration, cls).get(id=cls._resource_id, **params)
 
     @classmethod
-    def create(cls, **params):
+    def create(cls, attach_host_name=False, method="POST", id=None, params=None, **body):
+        # type: (bool, str, Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Add a new Azure integration config.
 
@@ -42,10 +47,11 @@ class AzureIntegration(
         >>> api.AzureIntegration.create(tenant_name=tenant_name, client_id=client_id, \
         client_secret=client_secret,host_filters=host_filters)
         """
-        return super(AzureIntegration, cls).create(id=cls._resource_id, **params)
+        return super(AzureIntegration, cls).create(id=cls._resource_id, **body)
 
     @classmethod
-    def delete(cls, **body):
+    def delete(cls, id=None, **body):
+        # type: (Optional[Any], **Any) -> Any
         """
         Delete a given Datadog-Azure integration.
 
@@ -58,6 +64,7 @@ class AzureIntegration(
 
     @classmethod
     def update_host_filters(cls, **params):
+        # type: (**Any) -> Any
         """
         Update the defined list of host filters for a given Datadog-Azure integration. \
 
@@ -72,7 +79,8 @@ class AzureIntegration(
         return super(AzureIntegration, cls).add_items(id=cls._resource_id, **params)
 
     @classmethod
-    def update(cls, **body):
+    def update(cls, id=None, params=None, **body):
+        # type: (Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Update an Azure account configuration.
 
@@ -87,5 +95,5 @@ class AzureIntegration(
         new_tenant_name=new_tenant_name, new_client_id=new_client_id,\
         client_secret=client_secret, host_filters=host_filters)
         """
-        params = {}
-        return super(AzureIntegration, cls).update(id=cls._resource_id, params=params, **body)
+        actual_params = {}  # type: Dict[str, Any]
+        return super(AzureIntegration, cls).update(id=cls._resource_id, params=actual_params, **body)

--- a/datadog/api/distributions.py
+++ b/datadog/api/distributions.py
@@ -2,6 +2,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # datadog
+from typing import Any, Optional
+
 from datadog.api.format import format_points
 from datadog.api.resources import SendableAPIResource
 
@@ -12,7 +14,14 @@ class Distribution(SendableAPIResource):
     _resource_name = "distribution_points"
 
     @classmethod
-    def send(cls, distributions=None, attach_host_name=True, compress_payload=False, **distribution):
+    def send(  # type: ignore[override]
+        cls,
+        distributions=None,  # type: Optional[Any]
+        attach_host_name=True,  # type: bool
+        compress_payload=False,  # type: bool
+        **distribution  # type: Any
+    ):
+        # type: (...) -> Any
         """
         Submit a distribution metric or a list of distribution metrics to the distribution metric
         API

--- a/datadog/api/downtimes.py
+++ b/datadog/api/downtimes.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any
+
 from datadog.api.resources import (
     GetableAPIResource,
     CreateableAPIResource,
@@ -27,6 +29,7 @@ class Downtime(
 
     @classmethod
     def cancel_downtime_by_scope(cls, **body):
+        # type: (**Any) -> Any
         """
         Cancels all downtimes matching the scope.
 

--- a/datadog/api/events.py
+++ b/datadog/api/events.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any, Dict, Optional
+
 from datadog.api.exceptions import ApiError
 from datadog.api.resources import GetableAPIResource, CreateableAPIResource, SearchableAPIResource
 from datadog.util.compat import iteritems
@@ -15,7 +17,8 @@ class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource):
     _timestamp_keys = set(["start", "end"])
 
     @classmethod
-    def create(cls, attach_host_name=True, **params):
+    def create(cls, attach_host_name=True, method="POST", id=None, params=None, **body):
+        # type: (bool, str, Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Post an event.
 
@@ -62,14 +65,15 @@ class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource):
 
         >>> api.Event.create(title=title, text=text, tags=tags)
         """
-        if params.get("alert_type"):
-            if params["alert_type"] not in ["error", "warning", "info", "success"]:
+        if body.get("alert_type"):
+            if body["alert_type"] not in ["error", "warning", "info", "success"]:
                 raise ApiError("Parameter alert_type must be either error, warning, info or success")
 
-        return super(Event, cls).create(attach_host_name=attach_host_name, **params)
+        return super(Event, cls).create(attach_host_name=attach_host_name, method=method, id=id, params=params, **body)
 
     @classmethod
     def query(cls, **params):
+        # type: (**Any) -> Any
         """
         Get the events that occurred between the *start* and *end* POSIX timestamps,
         optional filtered by *priority* ("low" or "normal"), *sources* and
@@ -85,6 +89,7 @@ class Event(GetableAPIResource, CreateableAPIResource, SearchableAPIResource):
         """
 
         def timestamp_to_integer(k, v):
+            # type: (str, Any) -> Any
             if k in cls._timestamp_keys:
                 return int(v)
             else:

--- a/datadog/api/exceptions.py
+++ b/datadog/api/exceptions.py
@@ -4,6 +4,7 @@
 """
 API & HTTP Clients exceptions.
 """
+from typing import Optional
 
 
 class DatadogException(Exception):
@@ -23,6 +24,7 @@ class ProxyError(DatadogException):
     """
 
     def __init__(self, method, url, exception):
+        # type: (str, str, Exception) -> None
         message = (
             u"Could not request {method} {url}: Unable to connect to proxy. "
             u"Please check the proxy configuration and try again.".format(method=method, url=url)
@@ -36,6 +38,7 @@ class ClientError(DatadogException):
     """
 
     def __init__(self, method, url, exception):
+        # type: (str, str, Exception) -> None
         message = (
             u"Could not request {method} {url}: {exception}. "
             u"Please check the network connection or try again later. "
@@ -52,6 +55,7 @@ class HttpTimeout(DatadogException):
     """
 
     def __init__(self, method, url, timeout):
+        # type: (str, str, float) -> None
         message = (
             u"{method} {url} timed out after {timeout}. "
             u"Please try again later. "
@@ -68,6 +72,7 @@ class HttpBackoff(DatadogException):
     """
 
     def __init__(self, backoff_period):
+        # type: (float) -> None
         message = u"Too many timeouts. Won't try again for {backoff_period} seconds. ".format(
             backoff_period=backoff_period
         )
@@ -80,6 +85,7 @@ class HTTPError(DatadogException):
     """
 
     def __init__(self, status_code=None, reason=None):
+        # type: (Optional[int], Optional[str]) -> None
         reason = u" - {reason}".format(reason=reason) if reason else u""
         message = (
             u"Datadog returned a bad HTTP response code: {status_code}{reason}. "

--- a/datadog/api/format.py
+++ b/datadog/api/format.py
@@ -4,6 +4,7 @@
 from numbers import Number
 import sys
 import time
+from typing import Any, List, Tuple, cast
 
 if sys.version_info[0] >= 3:
     from collections.abc import Iterable
@@ -12,6 +13,7 @@ else:
 
 
 def format_points(points):
+    # type: (Any) -> List[Tuple[float, Any]]
     """
     Format `points` parameter.
 
@@ -26,11 +28,11 @@ def format_points(points):
     if not isinstance(points, list):
         points = [points]
 
-    formatted_points = []
+    formatted_points = []  # type: List[Tuple[float, Any]]
     for point in points:
         if isinstance(point, Number):
             timestamp = now
-            value = float(point)
+            value = float(cast(float, point))  # type: Any
         # Distributions contain a list of points
         else:
             timestamp = point[0]

--- a/datadog/api/gcp_integration.py
+++ b/datadog/api/gcp_integration.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any, Dict, Optional
+
 from datadog.api.resources import GetableAPIResource, CreateableAPIResource, DeletableAPIResource, UpdatableAPIResource
 
 
@@ -14,6 +16,7 @@ class GcpIntegration(GetableAPIResource, CreateableAPIResource, DeletableAPIReso
 
     @classmethod
     def list(cls, **params):
+        # type: (**Any) -> Any
         """
         List all Datadog-Gcp integrations available in your Datadog organization.
 
@@ -22,7 +25,8 @@ class GcpIntegration(GetableAPIResource, CreateableAPIResource, DeletableAPIReso
         return super(GcpIntegration, cls).get(id=cls._resource_id, **params)
 
     @classmethod
-    def delete(cls, **body):
+    def delete(cls, id=None, **body):
+        # type: (Optional[Any], **Any) -> Any
         """
         Delete a given Datadog-GCP integration.
 
@@ -34,7 +38,8 @@ class GcpIntegration(GetableAPIResource, CreateableAPIResource, DeletableAPIReso
         return super(GcpIntegration, cls).delete(id=cls._resource_id, body=body)
 
     @classmethod
-    def create(cls, **params):
+    def create(cls, attach_host_name=False, method="POST", id=None, params=None, **body):
+        # type: (bool, str, Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Add a new GCP integration config.
 
@@ -64,10 +69,11 @@ class GcpIntegration(GetableAPIResource, CreateableAPIResource, DeletableAPIReso
         auth_provider_x509_cert_url=auth_provider_x509_cert_url, \
         client_x509_cert_url=client_x509_cert_url, host_filters=host_filters)
         """
-        return super(GcpIntegration, cls).create(id=cls._resource_id, **params)
+        return super(GcpIntegration, cls).create(id=cls._resource_id, **body)
 
     @classmethod
-    def update(cls, **body):
+    def update(cls, id=None, params=None, **body):
+        # type: (Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Update an existing service account partially (one or multiple fields), \
         by supplying a new value for the field(s) to be updated.
@@ -89,5 +95,5 @@ class GcpIntegration(GetableAPIResource, CreateableAPIResource, DeletableAPIReso
         client_email=client_email, host_filters=host_filters, \
         automute=automute)
         """
-        params = {}
-        return super(GcpIntegration, cls).update(id=cls._resource_id, params=params, **body)
+        actual_params = {}  # type: Dict[str, Any]
+        return super(GcpIntegration, cls).update(id=cls._resource_id, params=actual_params, **body)

--- a/datadog/api/graphs.py
+++ b/datadog/api/graphs.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any, Dict, Optional
+
 from datadog.util.compat import urlparse
 from datadog.api.resources import CreateableAPIResource, ActionAPIResource, GetableAPIResource, ListableAPIResource
 
@@ -13,7 +15,8 @@ class Graph(CreateableAPIResource, ActionAPIResource):
     _resource_name = "graph/snapshot"
 
     @classmethod
-    def create(cls, **params):
+    def create(cls, attach_host_name=False, method="GET", id=None, params=None, **body):
+        # type: (bool, str, Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Take a snapshot of a graph, returning the full url to the snapshot.
 
@@ -31,10 +34,11 @@ class Graph(CreateableAPIResource, ActionAPIResource):
 
         :returns: Dictionary representing the API's JSON response
         """
-        return super(Graph, cls).create(method="GET", **params)
+        return super(Graph, cls).create(method="GET", **body)
 
     @classmethod
     def status(cls, snapshot_url):
+        # type: (str) -> Any
         """
         Returns the status code of snapshot. Can be used to know when the
         snapshot is ready for download.
@@ -61,6 +65,7 @@ class Embed(ListableAPIResource, GetableAPIResource, ActionAPIResource, Createab
 
     @classmethod
     def enable(cls, embed_id):
+        # type: (str) -> Any
         """
         Enable a specified embed.
 
@@ -73,6 +78,7 @@ class Embed(ListableAPIResource, GetableAPIResource, ActionAPIResource, Createab
 
     @classmethod
     def revoke(cls, embed_id):
+        # type: (str) -> Any
         """
         Revoke a specified embed.
 

--- a/datadog/api/hosts.py
+++ b/datadog/api/hosts.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any
+
 from datadog.api.resources import ActionAPIResource, SearchableAPIResource, ListableAPIResource
 
 
@@ -13,6 +15,7 @@ class Host(ActionAPIResource):
 
     @classmethod
     def mute(cls, host_name, **body):
+        # type: (str, **Any) -> Any
         """
         Mute a host.
 
@@ -36,6 +39,7 @@ class Host(ActionAPIResource):
 
     @classmethod
     def unmute(cls, host_name):
+        # type: (str) -> Any
         """
         Unmute a host.
 
@@ -57,6 +61,7 @@ class Hosts(ActionAPIResource, SearchableAPIResource, ListableAPIResource):
 
     @classmethod
     def search(cls, **params):
+        # type: (**Any) -> Any
         """
         Search among hosts live within the past 2 hours. Max 100
         results at a time.
@@ -83,6 +88,7 @@ class Hosts(ActionAPIResource, SearchableAPIResource, ListableAPIResource):
 
     @classmethod
     def totals(cls, **params):
+        # type: (**Any) -> Any
         """
         Get total number of hosts active and up.
 
@@ -95,6 +101,7 @@ class Hosts(ActionAPIResource, SearchableAPIResource, ListableAPIResource):
 
     @classmethod
     def get_all(cls, **params):
+        # type: (**Any) -> Any
         """
         Get all hosts.
 

--- a/datadog/api/http_client.py
+++ b/datadog/api/http_client.py
@@ -13,9 +13,12 @@ import copy
 import logging
 import platform
 import sys
-import urllib
-
 from threading import Lock
+
+try:
+    from urllib.parse import urlencode as urllib_urlencode
+except ImportError:
+    from urllib import urlencode as urllib_urlencode  # type: ignore[attr-defined,no-redef]
 
 # datadog
 from datadog.api.exceptions import ProxyError, ClientError, HTTPError, HttpTimeout
@@ -24,11 +27,11 @@ if sys.version_info[:2] >= (3, 5):
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
         import types  # noqa: F401
-        from typing import Optional  # noqa: F401
+        from typing import Any, Dict, Optional, Type  # noqa: F401
 
 
 # 3p
-requests = None  # type: Optional[types.ModuleType]
+requests = None  # type: Any
 try:
     requests = __import__("requests")
     __import__("requests.adapters")
@@ -43,7 +46,7 @@ try:
 except ImportError:
     pass
 
-urllib3 = None  # type: Optional[types.ModuleType]
+urllib3 = None  # type: Any
 try:
     urllib3 = __import__("urllib3")
 except ImportError:
@@ -54,6 +57,7 @@ log = logging.getLogger("datadog.api")
 
 
 def _get_user_agent_header():
+    # type: () -> str
     from datadog import version
 
     return "datadogpy/{version} (python {pyver}; os {os}; arch {arch})".format(
@@ -65,6 +69,7 @@ def _get_user_agent_header():
 
 
 def _remove_context(exc):
+    # type: (Exception) -> Exception
     """Python3: remove context from chained exceptions to prevent leaking API keys in tracebacks."""
     exc.__cause__ = None
     return exc
@@ -77,6 +82,7 @@ class HTTPClient(object):
 
     @classmethod
     def request(cls, method, url, headers, params, data, timeout, proxies, verify, max_retries):
+        # type: (str, str, Dict[str, str], Dict[str, Any], Any, float, Optional[Any], Any, int) -> Any
         """
         Main method to be implemented by HTTP clients.
 
@@ -103,6 +109,7 @@ class RequestClient(HTTPClient):
 
     @classmethod
     def request(cls, method, url, headers, params, data, timeout, proxies, verify, max_retries):
+        # type: (str, str, Dict[str, str], Dict[str, Any], Any, float, Optional[Any], Any, int) -> Any
         try:
 
             with cls._session_lock:
@@ -147,6 +154,7 @@ class URLFetchClient(HTTPClient):
 
     @classmethod
     def request(cls, method, url, headers, params, data, timeout, proxies, verify, max_retries):
+        # type: (str, str, Dict[str, str], Dict[str, Any], Any, float, Optional[Any], Any, int) -> Any
         """
         Wrapper around `urlfetch.fetch` method.
 
@@ -157,12 +165,12 @@ class URLFetchClient(HTTPClient):
         validate_certificate = True if verify else False
 
         # Encode parameters in the url
-        url_with_params = "{url}?{params}".format(url=url, params=urllib.urlencode(params))
+        url_with_params = "{url}?{params}".format(url=url, params=urllib_urlencode(params))
         newheaders = copy.deepcopy(headers)
         newheaders["User-Agent"] = _get_user_agent_header()
 
         try:
-            result = urlfetch.fetch(
+            result = urlfetch.fetch(  # type: ignore[union-attr]
                 url=url_with_params,
                 method=method,
                 headers=newheaders,
@@ -176,15 +184,16 @@ class URLFetchClient(HTTPClient):
 
             cls.raise_on_status(result)
 
-        except urlfetch.DownloadError as e:
+        except urlfetch.DownloadError as e:  # type: ignore[union-attr]
             raise ClientError(method, url, e)
-        except urlfetch_errors.DeadlineExceededError:
+        except urlfetch_errors.DeadlineExceededError:  # type: ignore[union-attr]
             raise HttpTimeout(method, url, timeout)
 
         return result
 
     @classmethod
     def raise_on_status(cls, result):
+        # type: (Any) -> None
         """
         Raise on HTTP status code errors.
         """
@@ -207,6 +216,7 @@ class Urllib3Client(HTTPClient):
 
     @classmethod
     def request(cls, method, url, headers, params, data, timeout, proxies, verify, max_retries):
+        # type: (str, str, Dict[str, str], Dict[str, Any], Any, float, Optional[Any], Any, int) -> Any
         """
         Wrapper around `urllib3.PoolManager.request` method. This method will raise
         exceptions for HTTP status codes that are not 2xx.
@@ -240,6 +250,7 @@ class Urllib3Client(HTTPClient):
 
     @classmethod
     def raise_on_status(cls, response):
+        # type: (Any) -> None
         """
         Raise on HTTP status code errors.
         """
@@ -250,6 +261,7 @@ class Urllib3Client(HTTPClient):
 
 
 def resolve_http_client():
+    # type: () -> Type[HTTPClient]
     """
     Resolve an appropriate HTTP client based the defined priority and user environment.
     """

--- a/datadog/api/infrastructure.py
+++ b/datadog/api/infrastructure.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any
+
 from datadog.api.resources import SearchableAPIResource
 
 
@@ -13,6 +15,7 @@ class Infrastructure(SearchableAPIResource):
 
     @classmethod
     def search(cls, **params):
+        # type: (**Any) -> Any
         """
         Search for entities in Datadog.
 

--- a/datadog/api/logs.py
+++ b/datadog/api/logs.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any
+
 from datadog.api.resources import CreateableAPIResource
 from datadog.api.api_client import APIClient
 
@@ -14,6 +16,7 @@ class Logs(CreateableAPIResource):
 
     @classmethod
     def list(cls, data):
+        # type: (Any) -> Any
         path = "{resource_name}/list".format(
             resource_name=cls._resource_name,
         )

--- a/datadog/api/metadata.py
+++ b/datadog/api/metadata.py
@@ -2,6 +2,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # datadog
+from typing import Any
+
 from datadog.api.resources import GetableAPIResource, UpdatableAPIResource
 
 
@@ -13,7 +15,8 @@ class Metadata(GetableAPIResource, UpdatableAPIResource):
     _resource_name = "metrics"
 
     @classmethod
-    def get(cls, metric_name):
+    def get(cls, metric_name):  # type: ignore[override]
+        # type: (str) -> Any
         """
         Get metadata information on an existing Datadog metric
 
@@ -27,7 +30,8 @@ class Metadata(GetableAPIResource, UpdatableAPIResource):
         return super(Metadata, cls).get(metric_name)
 
     @classmethod
-    def update(cls, metric_name, **params):
+    def update(cls, metric_name, **params):  # type: ignore[override]
+        # type: (str, **Any) -> Any
         """
         Update metadata fields for an existing Datadog metric.
         If the metadata does not exist for the metric it is created by

--- a/datadog/api/metrics.py
+++ b/datadog/api/metrics.py
@@ -2,6 +2,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 # datadog
+from typing import Any, Dict, Optional
+
 from datadog.api.exceptions import ApiError
 from datadog.api.format import format_points
 from datadog.api.resources import SearchableAPIResource, SendableAPIResource, ListableAPIResource
@@ -12,7 +14,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
     A wrapper around Metric HTTP API
     """
 
-    _resource_name = None
+    _resource_name = ""  # type: str
 
     _METRIC_QUERY_ENDPOINT = "query"
     _METRIC_SUBMIT_ENDPOINT = "series"
@@ -20,6 +22,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
 
     @classmethod
     def list(cls, from_epoch):
+        # type: (Any) -> Any
         """
         Get a list of active metrics since a given time (Unix Epoc)
 
@@ -40,6 +43,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
 
     @staticmethod
     def _rename_metric_type(metric):
+        # type: (Dict[str, Any]) -> None
         """
         FIXME DROPME in 1.0:
 
@@ -51,7 +55,14 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
             metric["type"] = metric.pop("metric_type")
 
     @classmethod
-    def send(cls, metrics=None, attach_host_name=True, compress_payload=False, **single_metric):
+    def send(  # type: ignore[override]
+        cls,
+        metrics=None,  # type: Optional[Any]
+        attach_host_name=True,  # type: bool
+        compress_payload=False,  # type: bool
+        **single_metric  # type: Any
+    ):
+        # type: (...) -> Any
         """
         Submit a metric or a list of metrics to the metric API
         A metric dictionary should consist of 5 keys: metric, points, host, tags, type (some of which optional),
@@ -112,6 +123,7 @@ class Metric(SearchableAPIResource, SendableAPIResource, ListableAPIResource):
 
     @classmethod
     def query(cls, **params):
+        # type: (**Any) -> Any
         """
         Query metrics from Datadog
 

--- a/datadog/api/monitors.py
+++ b/datadog/api/monitors.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any
+
 from datadog.api.resources import (
     GetableAPIResource,
     CreateableAPIResource,
@@ -27,6 +29,7 @@ class Monitor(
 
     @classmethod
     def get(cls, id, **params):
+        # type: (Any, **Any) -> Any
         """
         Get monitor's details.
 
@@ -46,6 +49,7 @@ class Monitor(
 
     @classmethod
     def get_all(cls, **params):
+        # type: (**Any) -> Any
         """
         Get all monitor details.
 
@@ -73,6 +77,7 @@ class Monitor(
 
     @classmethod
     def mute(cls, id, **body):
+        # type: (Any, **Any) -> Any
         """
         Mute a monitor.
 
@@ -89,6 +94,7 @@ class Monitor(
 
     @classmethod
     def unmute(cls, id, **body):
+        # type: (Any, **Any) -> Any
         """
         Unmute a monitor.
 
@@ -104,6 +110,7 @@ class Monitor(
 
     @classmethod
     def mute_all(cls):
+        # type: () -> Any
         """
         Globally mute monitors.
 
@@ -113,6 +120,7 @@ class Monitor(
 
     @classmethod
     def unmute_all(cls):
+        # type: () -> Any
         """
         Cancel global monitor mute setting (does not remove mute settings for individual monitors).
 
@@ -122,6 +130,7 @@ class Monitor(
 
     @classmethod
     def search(cls, **params):
+        # type: (**Any) -> Any
         """
         Search monitors.
 
@@ -131,6 +140,7 @@ class Monitor(
 
     @classmethod
     def search_groups(cls, **params):
+        # type: (**Any) -> Any
         """
         Search monitor groups.
 
@@ -140,6 +150,7 @@ class Monitor(
 
     @classmethod
     def can_delete(cls, **params):
+        # type: (**Any) -> Any
         """
         Checks if the monitors corresponding to the monitor ids can be deleted.
 
@@ -149,6 +160,7 @@ class Monitor(
 
     @classmethod
     def validate(cls, **body):
+        # type: (**Any) -> Any
         """
         Checks if the monitors definition is valid.
 

--- a/datadog/api/resources.py
+++ b/datadog/api/resources.py
@@ -4,6 +4,7 @@
 """
 Datadog API resources.
 """
+from typing import Any, Dict, Optional
 
 from datadog.api.api_client import APIClient
 
@@ -13,8 +14,12 @@ class CreateableAPIResource(object):
     Creatable API Resource
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def create(cls, attach_host_name=False, method="POST", id=None, params=None, **body):
+        # type: (bool, str, Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Create a new API resource object
 
@@ -55,8 +60,12 @@ class SendableAPIResource(object):
     Fork of CreateableAPIResource class with different method names
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def send(cls, attach_host_name=False, id=None, compress_payload=False, **body):
+        # type: (bool, Optional[Any], bool, **Any) -> Any
         """
         Create an API resource object
 
@@ -97,8 +106,12 @@ class UpdatableAPIResource(object):
     Updatable API Resource
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def update(cls, id, params=None, **body):
+        # type: (Any, Optional[Dict[str, Any]], **Any) -> Any
         """
         Update an API resource object
 
@@ -124,8 +137,12 @@ class CustomUpdatableAPIResource(object):
     Updatable API Resource with custom HTTP Verb
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def update(cls, method=None, id=None, params=None, **body):
+        # type: (Optional[str], Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Update an API resource object
 
@@ -160,8 +177,12 @@ class DeletableAPIResource(object):
     Deletable API Resource
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def delete(cls, id, **params):
+        # type: (Any, **Any) -> Any
         """
         Delete an API resource object
 
@@ -181,8 +202,12 @@ class GetableAPIResource(object):
     Getable API Resource
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def get(cls, id, **params):
+        # type: (Any, **Any) -> Any
         """
         Get information about an API resource object
 
@@ -205,8 +230,12 @@ class ListableAPIResource(object):
     Listable API Resource
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def get_all(cls, **params):
+        # type: (**Any) -> Any
         """
         List API resource objects
 
@@ -225,8 +254,13 @@ class ListableAPISubResource(object):
     Listable API Sub-Resource
     """
 
+    _resource_name = ""  # type: str
+    _sub_resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def get_items(cls, id, **params):
+        # type: (Any, **Any) -> Any
         """
         List API sub-resource objects from a resource
 
@@ -252,8 +286,13 @@ class AddableAPISubResource(object):
     Addable API Sub-Resource
     """
 
+    _resource_name = ""  # type: str
+    _sub_resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def add_items(cls, id, params=None, **body):
+        # type: (Any, Optional[Dict[str, Any]], **Any) -> Any
         """
         Add new API sub-resource objects to a resource
 
@@ -284,8 +323,13 @@ class UpdatableAPISubResource(object):
     Updatable API Sub-Resource
     """
 
+    _resource_name = ""  # type: str
+    _sub_resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def update_items(cls, id, params=None, **body):
+        # type: (Any, Optional[Dict[str, Any]], **Any) -> Any
         """
         Update API sub-resource objects of a resource
 
@@ -316,8 +360,13 @@ class DeletableAPISubResource(object):
     Deletable API Sub-Resource
     """
 
+    _resource_name = ""  # type: str
+    _sub_resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def delete_items(cls, id, params=None, **body):
+        # type: (Any, Optional[Dict[str, Any]], **Any) -> Any
         """
         Delete API sub-resource objects from a resource
 
@@ -348,8 +397,12 @@ class SearchableAPIResource(object):
     Fork of ListableAPIResource class with different method names
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def _search(cls, **params):
+        # type: (**Any) -> Any
         """
         Query an API resource stream
 
@@ -368,8 +421,12 @@ class ActionAPIResource(object):
     Actionable API Resource
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def _trigger_class_action(cls, method, action_name, id=None, params=None, **body):
+        # type: (str, str, Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Trigger an action
 
@@ -401,13 +458,12 @@ class ActionAPIResource(object):
             path = "{resource_name}/{resource_id}/{action_name}".format(
                 resource_name=cls._resource_name, resource_id=id, action_name=action_name
             )
-        if method == "GET":
-            # Do not add body to GET requests, it causes 400 Bad request responses on EU site
-            body = None
-        return APIClient.submit(method, path, api_version, body, **params)
+        body_request = None if method == "GET" else body  # type: Optional[Dict[str, Any]]
+        return APIClient.submit(method, path, api_version, body_request, **params)
 
     @classmethod
     def _trigger_action(cls, method, name, id=None, **body):
+        # type: (str, str, Optional[Any], **Any) -> Any
         """
         Trigger an action
 
@@ -430,10 +486,8 @@ class ActionAPIResource(object):
             return APIClient.submit(method, name, api_version, body)
 
         path = "{action_name}/{resource_id}".format(action_name=name, resource_id=id)
-        if method == "GET":
-            # Do not add body to GET requests, it causes 400 Bad request responses on EU site
-            body = None
-        return APIClient.submit(method, path, api_version, body)
+        body_request = None if method == "GET" else body  # type: Optional[Dict[str, Any]]
+        return APIClient.submit(method, path, api_version, body_request)
 
 
 class UpdatableAPISyntheticsSubResource(object):
@@ -441,8 +495,13 @@ class UpdatableAPISyntheticsSubResource(object):
     Update Synthetics sub resource
     """
 
+    _resource_name = ""  # type: str
+    _sub_resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def update_synthetics_items(cls, id, params=None, **body):
+        # type: (Any, Optional[Dict[str, Any]], **Any) -> Any
         """
         Update API sub-resource objects of a resource
 
@@ -473,8 +532,12 @@ class UpdatableAPISyntheticsResource(object):
     Update Synthetics resource
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def update_synthetics(cls, id, params=None, **body):
+        # type: (Any, Optional[Dict[str, Any]], **Any) -> Any
         """
         Update an API resource object
 
@@ -500,8 +563,12 @@ class ActionAPISyntheticsResource(object):
     Actionable Synthetics API Resource
     """
 
+    _resource_name = ""  # type: str
+    _api_version = None  # type: Optional[str]
+
     @classmethod
     def _trigger_synthetics_class_action(cls, method, name, id=None, params=None, **body):
+        # type: (str, str, Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Trigger an action
 
@@ -533,7 +600,5 @@ class ActionAPISyntheticsResource(object):
             path = "{resource_name}/{action_name}/{resource_id}".format(
                 resource_name=cls._resource_name, resource_id=id, action_name=name
             )
-        if method == "GET":
-            # Do not add body to GET requests, it causes 400 Bad request responses on EU site
-            body = None
-        return APIClient.submit(method, path, api_version, body, **params)
+        body_request = None if method == "GET" else body  # type: Optional[Dict[str, Any]]
+        return APIClient.submit(method, path, api_version, body_request, **params)

--- a/datadog/api/roles.py
+++ b/datadog/api/roles.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any, Dict
+
 from datadog.api.resources import (
     ActionAPIResource,
     CreateableAPIResource,
@@ -29,7 +31,8 @@ class Roles(
     _api_version = "v2"
 
     @classmethod
-    def update(cls, id, **body):
+    def update(cls, id, **body):  # type: ignore[override]
+        # type: (str, **Any) -> Any
         """
         Update a role's attributes
 
@@ -37,11 +40,12 @@ class Roles(
         :param body: dict with type of the input, role `id`, and modified attributes
         :returns: Dictionary representing the API's JSON response
         """
-        params = {}
+        params = {}  # type: Dict[str, Any]
         return super(Roles, cls).update("PATCH", id, params=params, **body)
 
     @classmethod
     def assign_permission(cls, id, **body):
+        # type: (str, **Any) -> Any
         """
         Assign permission to a role
 
@@ -49,7 +53,7 @@ class Roles(
         :param body: dict with "type": "permissions" and uuid of permission to assign
         :returns: Dictionary representing the API's JSON response
         """
-        params = {}
+        params = {}  # type: Dict[str, Any]
         path = "{resource_name}/{resource_id}/permissions".format(resource_name=cls._resource_name, resource_id=id)
         api_version = getattr(cls, "_api_version", None)
 
@@ -57,6 +61,7 @@ class Roles(
 
     @classmethod
     def unassign_permission(cls, id, **body):
+        # type: (str, **Any) -> Any
         """
         Unassign permission from a role
 
@@ -64,7 +69,7 @@ class Roles(
         :param body: dict with "type": "permissions" and uuid of permission to unassign
         :returns: Dictionary representing the API's JSON response
         """
-        params = {}
+        params = {}  # type: Dict[str, Any]
         path = "{resource_name}/{resource_id}/permissions".format(resource_name=cls._resource_name, resource_id=id)
         api_version = getattr(cls, "_api_version", None)
 

--- a/datadog/api/screenboards.py
+++ b/datadog/api/screenboards.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any
+
 from datadog.api.resources import (
     GetableAPIResource,
     CreateableAPIResource,
@@ -27,6 +29,7 @@ class Screenboard(
 
     @classmethod
     def share(cls, board_id):
+        # type: (Any) -> Any
         """
         Share the screenboard with given id
 
@@ -39,6 +42,7 @@ class Screenboard(
 
     @classmethod
     def revoke(cls, board_id):
+        # type: (Any) -> Any
         """
         Revoke a shared screenboard with given id
 

--- a/datadog/api/security_monitoring_rules.py
+++ b/datadog/api/security_monitoring_rules.py
@@ -4,6 +4,7 @@
 """
 Security Monitoring Rule API.
 """
+from typing import Any, Dict, Optional
 
 from datadog.api.resources import (
     GetableAPIResource,
@@ -32,6 +33,7 @@ class SecurityMonitoringRule(
 
     @classmethod
     def get_all(cls, **params):
+        # type: (**Any) -> Any
         """
         Get all security monitoring rules.
 
@@ -43,7 +45,8 @@ class SecurityMonitoringRule(
         return super(SecurityMonitoringRule, cls).get_all(**params)
 
     @classmethod
-    def get(cls, rule_id, **params):
+    def get(cls, rule_id, **params):  # type: ignore[override]
+        # type: (str, **Any) -> Any
         """
         Get a security monitoring rule's details.
 
@@ -55,19 +58,23 @@ class SecurityMonitoringRule(
         return super(SecurityMonitoringRule, cls).get(rule_id, **params)
 
     @classmethod
-    def create(cls, **params):
+    def create(cls, attach_host_name=False, method="POST", id=None, params=None, **body):
+        # type: (bool, str, Optional[Any], Optional[Dict[str, Any]], **Any) -> Any
         """
         Create a security monitoring rule.
 
-        :param params: Parameters to create the security monitoring rule with
-        :type params: dict
+        :param body: Parameters to create the security monitoring rule with
+        :type body: dict
 
         :returns: Dictionary representing the API's JSON response
         """
-        return super(SecurityMonitoringRule, cls).create(**params)
+        return super(SecurityMonitoringRule, cls).create(
+            attach_host_name=attach_host_name, method=method, id=id, params=params, **body
+        )
 
     @classmethod
-    def update(cls, rule_id, **params):
+    def update(cls, rule_id, **params):  # type: ignore[override]
+        # type: (str, **Any) -> Any
         """
         Update a security monitoring rule.
 
@@ -81,7 +88,8 @@ class SecurityMonitoringRule(
         return super(SecurityMonitoringRule, cls).update(rule_id, **params)
 
     @classmethod
-    def delete(cls, rule_id, **params):
+    def delete(cls, rule_id, **params):  # type: ignore[override]
+        # type: (str, **Any) -> Any
         """
         Delete a security monitoring rule.
 

--- a/datadog/api/security_monitoring_signals.py
+++ b/datadog/api/security_monitoring_signals.py
@@ -4,6 +4,7 @@
 """
 Security Monitoring Signals API.
 """
+from typing import Any
 
 from datadog.api.resources import (
     GetableAPIResource,
@@ -27,7 +28,8 @@ class SecurityMonitoringSignal(
     _api_version = "v2"
 
     @classmethod
-    def get(cls, signal_id, **params):
+    def get(cls, signal_id, **params):  # type: ignore[override]
+        # type: (str, **Any) -> Any
         """
         Get a security signal's details.
 
@@ -40,6 +42,7 @@ class SecurityMonitoringSignal(
 
     @classmethod
     def get_all(cls, **params):
+        # type: (**Any) -> Any
         """
         Get all security signals.
 
@@ -59,6 +62,7 @@ class SecurityMonitoringSignal(
 
     @classmethod
     def change_triage_state(cls, signal_id, state, **params):
+        # type: (str, str, **Any) -> Any
         """
         Change the triage state of security signals.
 

--- a/datadog/api/service_checks.py
+++ b/datadog/api/service_checks.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any
+
 from datadog.api.constants import CheckStatus
 from datadog.api.exceptions import ApiError
 from datadog.api.resources import ActionAPIResource
@@ -13,6 +15,7 @@ class ServiceCheck(ActionAPIResource):
 
     @classmethod
     def check(cls, **body):
+        # type: (**Any) -> Any
         """
         Post check statuses for use with monitors
 

--- a/datadog/api/service_level_objectives.py
+++ b/datadog/api/service_level_objectives.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any, Dict, List, Optional
+
 from datadog.util.format import force_to_epoch_seconds
 from datadog.api.resources import (
     GetableAPIResource,
@@ -28,6 +30,7 @@ class ServiceLevelObjective(
 
     @classmethod
     def create(cls, attach_host_name=False, method="POST", id=None, params=None, **body):
+        # type: (bool, str, Optional[Any], Optional[Any], **Any) -> Any
         """
         Create a SLO
 
@@ -39,6 +42,7 @@ class ServiceLevelObjective(
 
     @classmethod
     def get(cls, id, **params):
+        # type: (str, **Any) -> Any
         """
         Get a specific SLO details.
 
@@ -51,6 +55,7 @@ class ServiceLevelObjective(
 
     @classmethod
     def get_all(cls, query=None, tags_query=None, metrics_query=None, ids=None, offset=0, limit=100, **params):
+        # type: (Optional[str], Optional[str], Optional[str], Optional[List[str]], int, int, **Any) -> Any
         """
         Get all SLO details.
 
@@ -74,7 +79,7 @@ class ServiceLevelObjective(
 
         :returns: SLOs matching the query
         """
-        search_terms = {}
+        search_terms = {}  # type: Dict[str, Any]
         if query:
             search_terms["query"] = query
         if ids:
@@ -90,6 +95,7 @@ class ServiceLevelObjective(
 
     @classmethod
     def update(cls, id, params=None, **body):
+        # type: (str, Optional[Any], **Any) -> Any
         """
         Update a specific SLO details.
 
@@ -102,6 +108,7 @@ class ServiceLevelObjective(
 
     @classmethod
     def delete(cls, id, **params):
+        # type: (str, **Any) -> Any
         """
         Delete a specific SLO.
 
@@ -114,6 +121,7 @@ class ServiceLevelObjective(
 
     @classmethod
     def bulk_delete(cls, ops, **params):
+        # type: (Dict[str, List[str]], **Any) -> Any
         """
         Bulk Delete Timeframes from multiple SLOs.
 
@@ -134,6 +142,7 @@ class ServiceLevelObjective(
 
     @classmethod
     def delete_many(cls, ids, **params):
+        # type: (List[str], **Any) -> Any
         """
         Delete Multiple SLOs
 
@@ -152,6 +161,7 @@ class ServiceLevelObjective(
 
     @classmethod
     def can_delete(cls, ids, **params):
+        # type: (List[str], **Any) -> Any
         """
         Check if the following SLOs can be safely deleted.
 
@@ -175,6 +185,7 @@ class ServiceLevelObjective(
 
     @classmethod
     def history(cls, id, from_ts, to_ts, **params):
+        # type: (str, Any, Any, **Any) -> Any
         """
         Get the SLO's history from the given time range.
 
@@ -205,6 +216,7 @@ class ServiceLevelObjective(
 
     @classmethod
     def search(cls, **params):
+        # type: (**Any) -> Any
         """
         Search SLOs.
 

--- a/datadog/api/synthetics.py
+++ b/datadog/api/synthetics.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any
+
 from datadog.api.exceptions import ApiError
 from datadog.api.resources import (
     CreateableAPIResource,
@@ -29,6 +31,7 @@ class Synthetics(
 
     @classmethod
     def get_test(cls, id, **params):
+        # type: (str, **Any) -> Any
         """
         Get test's details.
 
@@ -46,6 +49,7 @@ class Synthetics(
 
     @classmethod
     def get_all_tests(cls, **params):
+        # type: (**Any) -> Any
         """
         Get all tests' details.
 
@@ -62,6 +66,7 @@ class Synthetics(
 
     @classmethod
     def get_devices(cls, **params):
+        # type: (**Any) -> Any
         """
         Get a list of devices for browser checks
 
@@ -76,6 +81,7 @@ class Synthetics(
 
     @classmethod
     def get_locations(cls, **params):
+        # type: (**Any) -> Any
         """
         Get a list of all available locations
 
@@ -90,6 +96,7 @@ class Synthetics(
 
     @classmethod
     def get_results(cls, id, **params):
+        # type: (str, **Any) -> Any
         """
         Get the most recent results for a test
 
@@ -107,6 +114,7 @@ class Synthetics(
 
     @classmethod
     def get_result(cls, id, result_id, **params):
+        # type: (str, str, **Any) -> Any
         """
         Get a specific result for a given test.
 
@@ -127,6 +135,7 @@ class Synthetics(
 
     @classmethod
     def create_test(cls, **params):
+        # type: (**Any) -> Any
         """
         Create a test
 
@@ -164,6 +173,7 @@ class Synthetics(
 
     @classmethod
     def edit_test(cls, id, **params):
+        # type: (str, **Any) -> Any
         """
         Edit a test
 
@@ -179,6 +189,7 @@ class Synthetics(
 
     @classmethod
     def start_or_pause_test(cls, id, **body):
+        # type: (str, **Any) -> Any
         """
         Pause a given test
 
@@ -197,6 +208,7 @@ class Synthetics(
 
     @classmethod
     def delete_test(cls, **body):
+        # type: (**Any) -> Any
         """
         Delete a test
 

--- a/datadog/api/tags.py
+++ b/datadog/api/tags.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any
+
 from datadog.api.resources import (
     CreateableAPIResource,
     UpdatableAPIResource,
@@ -18,7 +20,8 @@ class Tag(CreateableAPIResource, UpdatableAPIResource, GetableAPIResource, Lista
     _resource_name = "tags/hosts"
 
     @classmethod
-    def create(cls, host, **body):
+    def create(cls, host, **body):  # type: ignore[override]
+        # type: (str, **Any) -> Any
         """
         Add tags to a host
 
@@ -36,7 +39,8 @@ class Tag(CreateableAPIResource, UpdatableAPIResource, GetableAPIResource, Lista
         return super(Tag, cls).create(id=host, params=params, **body)
 
     @classmethod
-    def update(cls, host, **body):
+    def update(cls, host, **body):  # type: ignore[override]
+        # type: (str, **Any) -> Any
         """
         Update all tags for a given host
 

--- a/datadog/api/users.py
+++ b/datadog/api/users.py
@@ -1,6 +1,8 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
+from typing import Any, List, Union
+
 from datadog.api.resources import (
     ActionAPIResource,
     GetableAPIResource,
@@ -28,6 +30,7 @@ class User(
 
     @classmethod
     def invite(cls, emails):
+        # type: (Union[str, List[str]]) -> Any
         """
         Send an invite to join datadog to each of the email addresses in the
         *emails* list. If *emails* is a string, it will be wrapped in a list and

--- a/mypy.ini
+++ b/mypy.ini
@@ -31,10 +31,6 @@ ignore_missing_imports = True
 
 # TODO: add type hints incrementally, then remove these overrides
 
-[mypy-datadog.api.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
 [mypy-datadog.threadstats.*]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False


### PR DESCRIPTION
## What does this PR do?

This PR adds typing for `api` and fixes inconsistent typing where adding type annotations broke existing typing.