### PR TITLE
typing: add typing for `dogstatsd`

### DIFF
--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -13,8 +13,7 @@ without hindering performance.
 # stdlib
 import logging
 import os
-import os.path
-from typing import Any, List, Optional
+from typing import Any, List, Optional  # noqa: F401
 
 # datadog
 from datadog import api
@@ -43,7 +42,7 @@ def initialize(
     statsd_use_default_route=False,  # type: bool
     statsd_socket_path=None,  # type: Optional[str]
     statsd_namespace=None,  # type: Optional[str]
-    statsd_max_samples_per_context=0,  # type: Optional[int]
+    statsd_max_samples_per_context=0,  # type: int
     statsd_constant_tags=None,  # type: Optional[List[str]]
     return_raw_response=False,  # type: bool
     hostname_from_config=True,  # type: bool

--- a/datadog/dogstatsd/aggregator.py
+++ b/datadog/dogstatsd/aggregator.py
@@ -1,13 +1,16 @@
 import threading
+from typing import Any, Dict, List, Optional
+
 from datadog.dogstatsd.metrics import (
     CountMetric,
     GaugeMetric,
     SetMetric,
+    MetricAggregator,
 )
 from datadog.dogstatsd.max_sample_metric import (
     HistogramMetric,
     DistributionMetric,
-    TimingMetric
+    TimingMetric,
 )
 from datadog.dogstatsd.metric_types import MetricType
 from datadog.dogstatsd.max_sample_metric_context import MaxSampleMetricContexts
@@ -16,12 +19,13 @@ from datadog.util.format import validate_cardinality
 
 class Aggregator(object):
     def __init__(self, max_samples_per_context=0, cardinality=None):
+        # type: (int, Optional[str]) -> None
         self.max_samples_per_context = max_samples_per_context
         self.metrics_map = {
             MetricType.COUNT: {},
             MetricType.GAUGE: {},
             MetricType.SET: {},
-        }
+        }  # type: Dict[str, Dict[str, MetricAggregator]]
         self.max_sample_metric_map = {
             MetricType.HISTOGRAM: MaxSampleMetricContexts(HistogramMetric),
             MetricType.DISTRIBUTION: MaxSampleMetricContexts(DistributionMetric),
@@ -35,7 +39,8 @@ class Aggregator(object):
         self.cardinality = cardinality
 
     def flush_aggregated_metrics(self):
-        metrics = []
+        # type: () -> List[MetricAggregator]
+        metrics = []  # type: List[MetricAggregator]
         for metric_type in self.metrics_map.keys():
             with self._locks[metric_type]:
                 current_metrics = self.metrics_map[metric_type]
@@ -46,10 +51,12 @@ class Aggregator(object):
         return metrics
 
     def set_max_samples_per_context(self, max_samples_per_context=0):
+        # type: (int) -> None
         self.max_samples_per_context = max_samples_per_context
 
     def flush_aggregated_sampled_metrics(self):
-        metrics = []
+        # type: () -> List[MetricAggregator]
+        metrics = []  # type: List[MetricAggregator]
         for metric_type in self.max_sample_metric_map.keys():
             metric_context = self.max_sample_metric_map[metric_type]
             for metricList in metric_context.flush():
@@ -57,20 +64,24 @@ class Aggregator(object):
         return metrics
 
     def get_context(self, name, tags):
+        # type: (str, Optional[List[str]]) -> str
         tags_str = u",".join(tags) if tags is not None else ""
         return u"{}:{}".format(name, tags_str)
 
     def count(self, name, value, tags, rate, timestamp=0, cardinality=None):
+        # type: (str, Any, Optional[List[str]], Optional[float], int, Optional[str]) -> None
         return self.add_metric(
             MetricType.COUNT, CountMetric, name, value, tags, rate, timestamp, cardinality
         )
 
     def gauge(self, name, value, tags, rate, timestamp=0, cardinality=None):
+        # type: (str, Any, Optional[List[str]], Optional[float], int, Optional[str]) -> None
         return self.add_metric(
             MetricType.GAUGE, GaugeMetric, name, value, tags, rate, timestamp, cardinality
         )
 
     def set(self, name, value, tags, rate, timestamp=0, cardinality=None):
+        # type: (str, Any, Optional[List[str]], Optional[float], int, Optional[str]) -> None
         return self.add_metric(
             MetricType.SET, SetMetric, name, value, tags, rate, timestamp, cardinality
         )
@@ -78,6 +89,7 @@ class Aggregator(object):
     def add_metric(
         self, metric_type, metric_class, name, value, tags, rate, timestamp=0, cardinality=None
     ):
+        # type: (str, Any, str, Any, Optional[List[str]], Optional[float], int, Optional[str]) -> None
         context = self.get_context(name, tags)
         with self._locks[metric_type]:
             if context in self.metrics_map[metric_type]:
@@ -91,16 +103,19 @@ class Aggregator(object):
                 )
 
     def histogram(self, name, value, tags, rate, cardinality=None):
+        # type: (str, Any, Optional[List[str]], Optional[float], Optional[str]) -> None
         return self.add_max_sample_metric(
             MetricType.HISTOGRAM, name, value, tags, rate, cardinality
         )
 
     def distribution(self, name, value, tags, rate, cardinality=None):
+        # type: (str, Any, Optional[List[str]], Optional[float], Optional[str]) -> None
         return self.add_max_sample_metric(
             MetricType.DISTRIBUTION, name, value, tags, rate, cardinality
         )
 
     def timing(self, name, value, tags, rate, cardinality=None):
+        # type: (str, Any, Optional[List[str]], Optional[float], Optional[str]) -> None
         return self.add_max_sample_metric(
             MetricType.TIMING, name, value, tags, rate, cardinality
         )
@@ -108,6 +123,7 @@ class Aggregator(object):
     def add_max_sample_metric(
         self, metric_type, name, value, tags, rate, cardinality=None
     ):
+        # type: (str, str, Any, Optional[List[str]], Optional[float], Optional[str]) -> None
         if rate is None:
             rate = 1
         context_key = self.get_context(name, tags)

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -14,10 +14,12 @@ import os
 import socket
 import errno
 import struct
+import sys
 import threading
 import time
 from threading import Lock, RLock
 import weakref
+from typing import TYPE_CHECKING
 
 try:
     import queue
@@ -27,7 +29,7 @@ except ImportError:
 
 
 # pylint: disable=unused-import
-from typing import Optional, List, Text, Union
+from typing import Any, Optional, List, Text, Type, Union
 # pylint: enable=unused-import
 
 # Datadog libraries
@@ -39,9 +41,12 @@ from datadog.dogstatsd.context import (
 )
 from datadog.dogstatsd.route import get_default_route
 from datadog.dogstatsd.container import Cgroup
-from datadog.util.compat import is_p3k, text
+from datadog.util.compat import text
 from datadog.util.format import normalize_tags, validate_cardinality
 from datadog.version import __version__
+
+if TYPE_CHECKING:
+    from socket import socket as _Socket
 
 # Logging
 log = logging.getLogger("datadog.dogstatsd")
@@ -111,6 +116,7 @@ _instances = weakref.WeakSet()  # type: weakref.WeakSet
 
 
 def pre_fork():
+    # type: () -> None
     """Prepare all client instances for a process fork.
 
     If SUPPORTS_FORKING is true, this will be called automatically before os.fork().
@@ -120,6 +126,7 @@ def pre_fork():
 
 
 def post_fork_parent():
+    # type: () -> None
     """Restore all client instances after a fork.
 
     If SUPPORTS_FORKING is true, this will be called automatically after os.fork().
@@ -129,6 +136,7 @@ def post_fork_parent():
 
 
 def post_fork_child():
+    # type: () -> None
     for c in _instances:
         c.post_fork_child()
 
@@ -156,7 +164,7 @@ class DogStatsd(object):
         self,
         host=DEFAULT_HOST,                      # type: Text
         port=DEFAULT_PORT,                      # type: int
-        max_buffer_size=None,                   # type: None
+        max_buffer_size=None,                   # type: Optional[int]
         flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL,  # type: float
         disable_aggregation=True,               # type: bool
         disable_buffering=True,                 # type: bool
@@ -445,7 +453,7 @@ class DogStatsd(object):
         self.cardinality = cardinality
 
         # Origin detection
-        self._container_id = None
+        self._container_id = None  # type: Optional[Text]
         origin_detection_enabled = self._is_origin_detection_enabled(
             container_id, origin_detection_enabled
         )
@@ -476,7 +484,7 @@ class DogStatsd(object):
         self._disable_aggregation = disable_aggregation
 
         self._flush_interval = flush_interval
-        self._flush_thread = None
+        self._flush_thread = None  # type: Optional[threading.Thread]
         self._flush_thread_stop = threading.Event()
         self.aggregator = Aggregator(max_metric_samples_per_context, self.cardinality)
         # Indicates if the process is about to fork, so we shouldn't start any new threads yet.
@@ -492,8 +500,8 @@ class DogStatsd(object):
         else:
             log.debug("Statsd buffering and aggregation is disabled")
 
-        self._queue = None
-        self._sender_thread = None
+        self._queue = None  # type: Optional[queue.Queue[Union[str, object]]]
+        self._sender_thread = None  # type: Optional[threading.Thread]
         self._sender_enabled = False
 
         if not disable_background_sender:
@@ -504,20 +512,25 @@ class DogStatsd(object):
 
     @property
     def socket_path(self):
+        # type: () -> Optional[Text]
         return self._socket_path
 
     @socket_path.setter
     def socket_path(self, path):
+        # type: (Optional[Text]) -> None
         with self._socket_lock:
             self._socket_path = path
 
     @property
     def socket(self):
+        # type: () -> Optional[_Socket]
         return self._socket
 
     @socket.setter
     def socket(self, new_socket):
+        # type: (Optional[_Socket]) -> None
         self._socket = new_socket
+        self._socket_kind = None  # type: Optional[int]
         if new_socket:
             try:
                 self._socket_kind = new_socket.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE)
@@ -540,11 +553,14 @@ class DogStatsd(object):
 
     @property
     def telemetry_socket(self):
+        # type: () -> Optional[_Socket]
         return self._telemetry_socket
 
     @telemetry_socket.setter
     def telemetry_socket(self, t_socket):
+        # type: (Optional[_Socket]) -> None
         self._telemetry_socket = t_socket
+        self._telemetry_socket_kind = None  # type: Optional[int]
         if t_socket:
             try:
                 self._telemetry_socket_kind = t_socket.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE)
@@ -554,6 +570,7 @@ class DogStatsd(object):
         self._telemetry_socket_kind = None
 
     def enable_background_sender(self, sender_queue_size=0, sender_queue_timeout=0):
+        # type: (int, Optional[float]) -> None
         """
         Use a background thread to communicate with the dogstatsd server.
         When enabled, a background thread will be used to send metric payloads to the Agent.
@@ -588,6 +605,7 @@ class DogStatsd(object):
             self._start_sender_thread()
 
     def disable_background_sender(self):
+        # type: () -> None
         """Disable background sender mode.
 
         This call will block until all previously queued payloads are sent.
@@ -597,13 +615,16 @@ class DogStatsd(object):
             self._stop_sender_thread()
 
     def disable_telemetry(self):
+        # type: () -> None
         self._telemetry = False
 
     def enable_telemetry(self):
+        # type: () -> None
         self._telemetry = True
 
     # Note: Invocations of this method should be thread-safe
     def _start_flush_thread(self):
+        # type: () -> None
         if self._disable_aggregation and self.disable_buffering:
             log.debug("Statsd periodic buffer and aggregation flush is disabled")
             return
@@ -621,6 +642,7 @@ class DogStatsd(object):
             return
 
         def _flush_thread_loop(self, flush_interval):
+            # type: (DogStatsd, float) -> None
             while not self._flush_thread_stop.is_set():
                 time.sleep(flush_interval)
                 if not self._disable_aggregation:
@@ -641,6 +663,7 @@ class DogStatsd(object):
 
     # Note: Invocations of this method should be thread-safe
     def _stop_flush_thread(self):
+        # type: () -> None
         if not self._flush_thread:
             return
         try:
@@ -657,24 +680,29 @@ class DogStatsd(object):
         self._flush_thread_stop.clear()
 
     def _dedicated_telemetry_destination(self):
+        # type: () -> bool
         return bool(self.telemetry_socket_path or self.telemetry_host)
 
     # Context manager helper
     def __enter__(self):
+        # type: () -> DogStatsd
         self.open_buffer()
         return self
 
     # Context manager helper
     def __exit__(self, exc_type, value, traceback):
+        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[Any]) -> None
         self.close_buffer()
 
     @property
     def disable_buffering(self):
+        # type: () -> bool
         with self._config_lock:
             return self._disable_buffering
 
     @disable_buffering.setter
     def disable_buffering(self, is_disabled):
+        # type: (bool) -> None
         with self._config_lock:
             # If the toggle didn't change anything, this method is a noop
             if self._disable_buffering == is_disabled:
@@ -694,6 +722,7 @@ class DogStatsd(object):
                 self._start_flush_thread()
 
     def disable_aggregation(self):
+        # type: () -> None
         with self._config_lock:
             # If the toggle didn't change anything, this method is a noop
             if self._disable_aggregation:
@@ -708,6 +737,7 @@ class DogStatsd(object):
             log.debug("Statsd aggregation is disabled")
 
     def enable_aggregation(self, flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL, max_samples_per_context=0):
+        # type: (float, int) -> None
         with self._config_lock:
             if not self._disable_aggregation:
                 return
@@ -720,6 +750,7 @@ class DogStatsd(object):
 
     @staticmethod
     def resolve_host(host, use_default_route):
+        # type: (Optional[Text], bool) -> Optional[Text]
         """
         Resolve the DogStatsd host.
 
@@ -734,6 +765,7 @@ class DogStatsd(object):
         return get_default_route()
 
     def get_socket(self, telemetry=False):
+        # type: (bool) -> _Socket
         """
         Return a connected socket.
 
@@ -770,6 +802,7 @@ class DogStatsd(object):
             return self.socket
 
     def set_socket_timeout(self, timeout):
+        # type: (Optional[float]) -> None
         """
         Set timeout for socket operations, in seconds.
 
@@ -783,6 +816,7 @@ class DogStatsd(object):
 
     @classmethod
     def _ensure_min_send_buffer_size(cls, sock, min_size=MIN_SEND_BUFFER_SIZE):
+        # type: (_Socket, int) -> None
         # Increase the receiving buffer size where needed (e.g. MacOS has 4k RX
         # buffers which is half of the max packet size that the client will send.
         if os.name == 'posix':
@@ -796,6 +830,7 @@ class DogStatsd(object):
 
     @classmethod
     def _get_uds_socket(cls, socket_path, timeout):
+        # type: (Text, Optional[float]) -> _Socket
         valid_socket_kinds = [socket.SOCK_DGRAM, socket.SOCK_STREAM]
         if socket_path.startswith(UNIX_ADDRESS_DATAGRAM_SCHEME):
             valid_socket_kinds = [socket.SOCK_DGRAM]
@@ -806,7 +841,7 @@ class DogStatsd(object):
         elif socket_path.startswith(UNIX_ADDRESS_SCHEME):
             socket_path = socket_path[len(UNIX_ADDRESS_SCHEME):]
 
-        last_error = ValueError("Invalid socket path")
+        last_error = ValueError("Invalid socket path")  # type: Exception
         for socket_kind in valid_socket_kinds:
             # py2 stores socket kinds differently than py3, determine the name independently from version
             sk_name = {socket.SOCK_STREAM: "stream", socket.SOCK_DGRAM: "datagram"}[socket_kind]
@@ -822,7 +857,7 @@ class DogStatsd(object):
                 if sock is not None:
                     sock.close()
                 log.debug("Failed to connect to %s with kind %s: %s", socket_path, sk_name, e)
-                if e.errno == errno.EPROTOTYPE:
+                if getattr(e, "errno", None) == errno.EPROTOTYPE:
                     last_error = e
                     continue
                 raise e
@@ -830,6 +865,7 @@ class DogStatsd(object):
 
     @classmethod
     def _get_udp_socket(cls, host, port, timeout):
+        # type: (Optional[Text], Optional[int], Optional[float]) -> _Socket
         log.debug("Connecting to %s:%s", host, port)
         addrinfo = socket.getaddrinfo(host, port, 0, socket.SOCK_DGRAM)
         # Override gai.conf order for backwrads compatibility: prefer
@@ -857,6 +893,7 @@ class DogStatsd(object):
             raise ValueError("getaddrinfo returned no addresses to connect to")
 
     def open_buffer(self, max_buffer_size=None):
+        # type: (Optional[int]) -> None
         """
         Open a buffer to send a batch of metrics.
 
@@ -877,6 +914,7 @@ class DogStatsd(object):
             log.warning("The parameter max_buffer_size is now deprecated and is not used anymore")
 
     def close_buffer(self):
+        # type: () -> None
         """
         Flush the buffer and switch back to single metric packets.
 
@@ -892,14 +930,17 @@ class DogStatsd(object):
             self._config_lock.release()
 
     def _reset_buffer(self):
+        # type: () -> None
         with self._buffer_lock:
             self._current_buffer_total_size = 0
             self._buffer = []
 
     def flush(self):
+        # type: () -> None
         self.flush_buffered_metrics()
 
     def flush_buffered_metrics(self):
+        # type: () -> None
         """
         Flush the metrics buffer by sending the data to the server.
         """
@@ -910,6 +951,7 @@ class DogStatsd(object):
                 self._reset_buffer()
 
     def flush_aggregated_metrics(self):
+        # type: () -> None
         """
         Flush the aggregated metrics
         """
@@ -928,7 +970,7 @@ class DogStatsd(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
         cardinality=None,  # type: Optional[str]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         """
         Record the value of a gauge, optionally setting a list of tags and a
         sample rate.
@@ -950,7 +992,7 @@ class DogStatsd(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
         cardinality=None,  # type: Optional[str]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         """u
         Record the value of a gauge with a Unix timestamp (in seconds),
         optionally setting a list of tags and a sample rate.
@@ -972,7 +1014,7 @@ class DogStatsd(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
         cardinality=None,  # type: Optional[str]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         """
         Count tracks how many times something happened per second, tags and a sample
         rate.
@@ -993,7 +1035,7 @@ class DogStatsd(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
         cardinality=None,  # type: Optional[str]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         """
         Count how many times something happened at a given Unix timestamp in seconds,
         tags and a sample rate.
@@ -1014,7 +1056,7 @@ class DogStatsd(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
         cardinality=None,  # type: Optional[str]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         """
         Increment a counter, optionally setting a value, tags and a sample
         rate.
@@ -1034,7 +1076,7 @@ class DogStatsd(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
         cardinality=None,  # type: Optional[str]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         """
         Decrement a counter, optionally setting a value, tags and a sample
         rate.
@@ -1055,7 +1097,7 @@ class DogStatsd(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
         cardinality=None,  # type: Optional[str]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         """
         Sample a histogram value, optionally setting tags and a sample rate.
 
@@ -1074,7 +1116,7 @@ class DogStatsd(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
         cardinality=None,  # type: Optional[str]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         """
         Send a global distribution value, optionally setting tags and a sample rate.
 
@@ -1093,7 +1135,7 @@ class DogStatsd(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
         cardinality=None,  # type: Optional[str]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         """
         Record a timing, optionally setting tags and a sample rate.
 
@@ -1110,7 +1152,7 @@ class DogStatsd(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=None,  # type: Optional[float]
         use_ms=None,  # type: Optional[bool]
-    ):  # type(...) -> TimedContextManagerDecorator
+    ):  # type: (...) -> TimedContextManagerDecorator
         """
         A decorator or context manager that will measure the distribution of a
         function's/context's run time. Optionally specify a list of tags or a
@@ -1138,7 +1180,14 @@ class DogStatsd(object):
         """
         return TimedContextManagerDecorator(self, metric, tags, sample_rate, use_ms)
 
-    def distributed(self, metric=None, tags=None, sample_rate=None, use_ms=None):
+    def distributed(
+        self,
+        metric=None,  # type: Optional[Text]
+        tags=None,  # type: Optional[List[str]]
+        sample_rate=None,  # type: Optional[float]
+        use_ms=None,  # type: Optional[bool]
+    ):
+        # type: (...) -> DistributedContextManagerDecorator
         """
         A decorator or context manager that will measure the distribution of a
         function's/context's run time using custom metric distribution.
@@ -1167,6 +1216,7 @@ class DogStatsd(object):
         return DistributedContextManagerDecorator(self, metric, tags, sample_rate, use_ms)
 
     def set(self, metric, value, tags=None, sample_rate=None, cardinality=None):
+        # type: (Text, Any, Optional[List[str]], Optional[float], Optional[str]) -> None
         """
         Sample a set value.
 
@@ -1178,6 +1228,7 @@ class DogStatsd(object):
             self.aggregator.set(metric, value, tags, sample_rate, cardinality=cardinality)
 
     def close_socket(self):
+        # type: () -> None
         """
         Closes connected socket if connected.
         """
@@ -1199,6 +1250,7 @@ class DogStatsd(object):
     def _serialize_metric(
         self, metric, metric_type, value, tags, sample_rate=1, timestamp=0, cardinality=None
     ):
+        # type: (Text, str, Any, Optional[List[str]], Optional[float], int, Optional[str]) -> str
         # Create/format the metric packet
         parts = [(self.namespace + ".") if self.namespace else "", metric, ":", text(value), "|", metric_type]
 
@@ -1229,6 +1281,7 @@ class DogStatsd(object):
         return "".join(parts)
 
     def _report(self, metric, metric_type, value, tags, sample_rate, timestamp=0, sampling=True, cardinality=None):
+        # type: (Text, str, Any, Optional[List[str]], Optional[float], int, bool, Optional[str]) -> None
         """
         Create a metric packet and send it.
 
@@ -1271,6 +1324,7 @@ class DogStatsd(object):
         self._send(payload)
 
     def _reset_telemetry(self):
+        # type: () -> None
         self.metrics_count = 0
         self.events_count = 0
         self.service_checks_count = 0
@@ -1285,13 +1339,16 @@ class DogStatsd(object):
     # Aliases for backwards compatibility.
     @property
     def packets_dropped(self):
+        # type: () -> int
         return self.packets_dropped_queue + self.packets_dropped_writer
 
     @property
     def bytes_dropped(self):
+        # type: () -> int
         return self.bytes_dropped_queue + self.bytes_dropped_writer
 
     def _flush_telemetry(self):
+        # type: () -> str
         tags = self._client_tags[:]
         tags.append("client_transport:{}".format(self._transport))
         tags.extend(self.constant_tags)
@@ -1323,10 +1380,12 @@ class DogStatsd(object):
         )
 
     def _is_telemetry_flush_time(self):
+        # type: () -> bool
         return self._telemetry and \
             self._last_flush_time + self._telemetry_flush_interval < time.time()
 
     def _send_to_server(self, packet):
+        # type: (str) -> None
         # Skip the lock if the queue is None. There is no race with enable_background_sender.
         if self._queue is not None:
             # Prevent a race with disable_background_sender.
@@ -1342,6 +1401,7 @@ class DogStatsd(object):
         self._xmit_packet_with_telemetry(packet + '\n')
 
     def _xmit_packet_with_telemetry(self, packet):
+        # type: (str) -> None
         self._xmit_packet(packet, False)
 
         if self._is_telemetry_flush_time():
@@ -1357,6 +1417,7 @@ class DogStatsd(object):
                 self.packets_dropped_writer += 1
 
     def _xmit_packet(self, packet, is_telemetry):
+        # type: (str, bool) -> bool
         socket_kind = None
         try:
             if is_telemetry and self._dedicated_telemetry_destination():
@@ -1422,6 +1483,7 @@ class DogStatsd(object):
         return False
 
     def _send_to_buffer(self, packet):
+        # type: (str) -> None
         with self._buffer_lock:
             if self._should_flush(len(packet)):
                 self.flush_buffered_metrics()
@@ -1432,31 +1494,35 @@ class DogStatsd(object):
             self._current_buffer_total_size += len(packet) + 1
 
     def _should_flush(self, length_to_be_added):
+        # type: (int) -> bool
         if self._current_buffer_total_size + length_to_be_added + 1 > self._max_payload_size:
             return True
         return False
 
     @staticmethod
     def _escape_event_content(string):
+        # type: (str) -> str
         return string.replace("\n", "\\n")
 
     @staticmethod
     def _escape_service_check_message(string):
+        # type: (str) -> str
         return string.replace("\n", "\\n").replace("m:", "m\\:")
 
     def event(
         self,
-        title,
-        message,
-        alert_type=None,
-        aggregation_key=None,
-        source_type_name=None,
-        date_happened=None,
-        priority=None,
-        tags=None,
-        hostname=None,
-        cardinality=None,
+        title,  # type: Text
+        message,  # type: Text
+        alert_type=None,  # type: Optional[str]
+        aggregation_key=None,  # type: Optional[Text]
+        source_type_name=None,  # type: Optional[Text]
+        date_happened=None,  # type: Optional[int]
+        priority=None,  # type: Optional[str]
+        tags=None,  # type: Optional[List[str]]
+        hostname=None,  # type: Optional[Text]
+        cardinality=None,  # type: Optional[str]
     ):
+        # type: (...) -> None
         """
         Send an event. Attributes are the same as the Event API.
             http://docs.datadoghq.com/api/
@@ -1468,7 +1534,7 @@ class DogStatsd(object):
         message = DogStatsd._escape_event_content(message)
 
         # pylint: disable=undefined-variable
-        if not is_p3k():
+        if sys.version_info[0] < 3:
             if not isinstance(title, unicode):                                       # noqa: F821
                 title = unicode(DogStatsd._escape_event_content(title), 'utf8')      # noqa: F821
             if not isinstance(message, unicode):                                     # noqa: F821
@@ -1530,6 +1596,7 @@ class DogStatsd(object):
         hostname=None,
         message=None,
     ):
+        # type: (str, int, Optional[List[str]], Optional[int], Optional[str], Optional[str], Optional[str]) -> None
         """
         Send a service check run.
 
@@ -1566,6 +1633,7 @@ class DogStatsd(object):
         self._send(string)
 
     def _add_constant_tags(self, tags):
+        # type: (Optional[List[str]]) -> Optional[List[str]]
         if self.constant_tags:
             if tags:
                 return tags + self.constant_tags
@@ -1574,6 +1642,7 @@ class DogStatsd(object):
         return tags
 
     def _is_origin_detection_enabled(self, container_id, origin_detection_enabled):
+        # type: (Optional[Text], bool) -> bool
         """
         Returns whether the client should fill the container field.
         If a user-defined container ID is provided, we don't ignore origin detection
@@ -1588,6 +1657,7 @@ class DogStatsd(object):
         return value.lower() not in {"no", "false", "0", "n", "off"}
 
     def _set_container_id(self, container_id, origin_detection_enabled):
+        # type: (Optional[Text], bool) -> None
         """
         Initializes the container ID.
         It can either be provided by the user or read from cgroups.
@@ -1604,6 +1674,7 @@ class DogStatsd(object):
                 self._container_id = None
 
     def _start_sender_thread(self):
+        # type: () -> None
         if not self._sender_enabled or self._forking:
             return
 
@@ -1622,6 +1693,7 @@ class DogStatsd(object):
         self._sender_thread.start()
 
     def _stop_sender_thread(self):
+        # type: () -> None
         # Lock ensures that nothing gets added to the queue after we disable it.
         with self._buffer_lock:
             if not self._queue:
@@ -1629,19 +1701,26 @@ class DogStatsd(object):
             self._queue.put(Stop)
             self._queue = None
 
-        self._sender_thread.join()
+        if self._sender_thread is not None:
+            self._sender_thread.join()
         self._sender_thread = None
 
     def _sender_main_loop(self, queue):
+        # type: (queue.Queue[Union[str, object]]) -> None
         while True:
             item = queue.get()
             if item is Stop:
                 queue.task_done()
                 return
-            self._xmit_packet_with_telemetry(item)
+
+            # next line has type ignore because the type checker cannot
+            # know that 'if item is Stop' is the only case where item is
+            # of object type.
+            self._xmit_packet_with_telemetry(item)  # type: ignore[arg-type]  # noqa: F821
             queue.task_done()
 
     def wait_for_pending(self):
+        # type: () -> None
         """
         Flush the buffer and wait for all queued payloads to be written to the server.
         """
@@ -1657,6 +1736,7 @@ class DogStatsd(object):
             queue.join()
 
     def pre_fork(self):
+        # type: () -> None
         """Prepare client for a process fork.
 
         Flush any pending payloads and stop all background threads.
@@ -1677,12 +1757,14 @@ class DogStatsd(object):
         self._stop_sender_thread()
 
     def post_fork_parent(self):
+        # type: () -> None
         """Restore the client state after a fork in the parent process."""
         self._start_flush_thread()
         self._start_sender_thread()
         self._config_lock.release()
 
     def post_fork_child(self):
+        # type: () -> None
         """Restore the client state after a fork in the child process."""
         self._config_lock.release()
 
@@ -1705,6 +1787,7 @@ class DogStatsd(object):
             self._start_sender_thread()
 
     def stop(self):
+        # type: () -> None
         """Stop the client.
 
         Disable buffering, aggregation, background sender and flush any pending payloads to the server.

--- a/datadog/dogstatsd/container.py
+++ b/datadog/dogstatsd/container.py
@@ -6,6 +6,7 @@
 import errno
 import os
 import re
+from typing import Optional
 
 
 class UnresolvableContainerID(Exception):
@@ -42,12 +43,14 @@ class Cgroup(object):
     CONTAINER_RE = re.compile(r"(?:.+)?({0}|{1}|{2})(?:\.scope)?$".format(UUID_SOURCE, CONTAINER_SOURCE, TASK_SOURCE))
 
     def __init__(self):
+        # type: () -> None
         if self._is_host_cgroup_namespace():
             self.container_id = self._read_cgroup_path()
             return
         self.container_id = self._get_cgroup_from_inode()
 
     def _is_host_cgroup_namespace(self):
+        # type: () -> bool
         """Check if the current process is in a host cgroup namespace."""
         try:
             return (
@@ -59,6 +62,7 @@ class Cgroup(object):
             return False
 
     def _read_cgroup_path(self):
+        # type: () -> Optional[str]
         """Read the container ID from the cgroup file."""
         try:
             with open(self.CGROUP_PATH, mode="r") as fp:
@@ -81,6 +85,7 @@ class Cgroup(object):
         return None
 
     def _get_cgroup_from_inode(self):
+        # type: () -> Optional[str]
         """Read the container ID from the cgroup inode."""
         # Parse /proc/self/cgroup and get a map of controller to its associated cgroup node path.
         cgroup_controllers_paths = {}

--- a/datadog/dogstatsd/context.py
+++ b/datadog/dogstatsd/context.py
@@ -31,7 +31,7 @@ class TimedContextManagerDecorator(object):
         tags=None,  # type: Optional[List[str]]
         sample_rate=1,  # type: Optional[float]
         use_ms=None,  # type: Optional[bool]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         self.statsd = statsd
         self.timing_func = statsd.timing
         self.metric = metric
@@ -42,7 +42,7 @@ class TimedContextManagerDecorator(object):
 
     def __call__(
         self, func  # type: Callable[..., Any]
-    ):  # type(...) -> Callable[..., Any]
+    ):  # type: (...) -> Callable[..., Any]
         """
         Decorator which returns the elapsed time of the function call.
 
@@ -58,6 +58,7 @@ class TimedContextManagerDecorator(object):
         # Others
         @wraps(func)
         def wrapped(*args, **kwargs):
+            # type: (*Any, **Any) -> Any
             start = monotonic()
             try:
                 return func(*args, **kwargs)
@@ -66,30 +67,30 @@ class TimedContextManagerDecorator(object):
 
         return wrapped
 
-    def __enter__(self):  # type(...) -> TimedContextManagerDecorator
+    def __enter__(self):  # type: (...) -> TimedContextManagerDecorator
         if not self.metric:
             raise TypeError("Cannot used timed without a metric!")
         self._start = monotonic()
         return self
 
-    def __exit__(self, type, value, traceback):  # type(...) -> None
+    def __exit__(self, type, value, traceback):  # type: (Optional[Any], Optional[Any], Optional[Any]) -> None
         # Report the elapsed time of the context manager.
         self._send(self._start)
 
     def _send(
         self,
         start,  # type: float
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         elapsed = monotonic() - start
         use_ms = self.use_ms if self.use_ms is not None else self.statsd.use_ms
         elapsed = int(round(1000 * elapsed)) if use_ms else elapsed
         self.timing_func(self.metric, elapsed, self.tags, self.sample_rate)  # type: ignore
         self.elapsed = elapsed
 
-    def start(self):  # type(...) -> None
+    def start(self):  # type: (...) -> None
         self.__enter__()
 
-    def stop(self):  # type(...) -> None
+    def stop(self):  # type: (...) -> None
         self.__exit__(None, None, None)
 
 
@@ -106,6 +107,6 @@ class DistributedContextManagerDecorator(TimedContextManagerDecorator):
         tags=None,  # type: Optional[List[str]]
         sample_rate=1,  # type: Optional[float]
         use_ms=None,  # type: Optional[bool]
-    ):  # type(...) -> None
+    ):  # type: (...) -> None
         super(DistributedContextManagerDecorator, self).__init__(statsd, metric, tags, sample_rate, use_ms)
         self.timing_func = statsd.distribution

--- a/datadog/dogstatsd/context_async.py
+++ b/datadog/dogstatsd/context_async.py
@@ -8,6 +8,7 @@ Warning: requires Python 3.5 or higher.
 """
 # stdlib
 import sys
+from typing import Any, Callable
 
 
 # Wrap the Python 3.5+ function in a docstring to avoid syntax errors when
@@ -43,6 +44,7 @@ def _get_wrapped_co(self, func):
 
 
 def _get_wrapped_co(self, func):
+    # type: (Any, Callable[..., Any]) -> Callable[..., Any]
     raise NotImplementedError(
         u"Decorator `timed` compatibility with coroutine functions" u" requires Python 3.5 or higher."
     )

--- a/datadog/dogstatsd/max_sample_metric.py
+++ b/datadog/dogstatsd/max_sample_metric.py
@@ -1,4 +1,6 @@
 import random
+from typing import List, Optional, cast
+
 from datadog.dogstatsd.metric_types import MetricType
 from datadog.dogstatsd.metrics import MetricAggregator
 from threading import Lock
@@ -6,6 +8,7 @@ from threading import Lock
 
 class MaxSampleMetric(object):
     def __init__(self, name, tags, metric_type, specified_rate=1.0, max_metric_samples=0, cardinality=None):
+        # type: (str, Optional[List[str]], str, float, int, Optional[str]) -> None
         self.name = name
         self.tags = tags
         self.lock = Lock()
@@ -13,11 +16,12 @@ class MaxSampleMetric(object):
         self.max_metric_samples = max_metric_samples
         self.cardinality = cardinality
         self.specified_rate = specified_rate
-        self.data = [None] * max_metric_samples if max_metric_samples > 0 else []
+        self.data = [None] * max_metric_samples if max_metric_samples > 0 else []  # type: List[Optional[float]]
         self.stored_metric_samples = 0
         self.total_metric_samples = 0
 
     def sample(self, value):
+        # type: (float) -> None
         if self.max_metric_samples == 0:
             self.data.append(value)
         else:
@@ -26,6 +30,7 @@ class MaxSampleMetric(object):
         self.total_metric_samples += 1
 
     def maybe_keep_sample_work_unsafe(self, value):
+        # type: (float) -> None
         if self.max_metric_samples > 0:
             self.total_metric_samples += 1
             if self.stored_metric_samples < self.max_metric_samples:
@@ -39,14 +44,19 @@ class MaxSampleMetric(object):
             self.sample(value)
 
     def skip_sample(self):
+        # type: () -> None
         self.total_metric_samples += 1
 
     def flush(self):
+        # type: () -> List[MetricAggregator]
         rate = self.stored_metric_samples / self.total_metric_samples
         with self.lock:
             return [
+                # casting self.data[i] to float as it is officially Optional[float]
+                # but always float between 0 and self.stored_metric_samples - 1
                 MetricAggregator(
-                    self.name, self.tags, rate, self.metric_type, self.data[i], cardinality=self.cardinality
+                    self.name, self.tags, rate, self.metric_type,
+                    cast(float, self.data[i]), cardinality=self.cardinality,
                 )
                 for i in range(self.stored_metric_samples)
             ]
@@ -54,11 +64,13 @@ class MaxSampleMetric(object):
 
 class HistogramMetric(MaxSampleMetric):
     def __init__(self, name, tags, rate=1.0, max_metric_samples=0, cardinality=None):
+        # type: (str, Optional[List[str]], float, int, Optional[str]) -> None
         super(HistogramMetric, self).__init__(name, tags, MetricType.HISTOGRAM, rate, max_metric_samples, cardinality)
 
 
 class DistributionMetric(MaxSampleMetric):
     def __init__(self, name, tags, rate=1.0, max_metric_samples=0, cardinality=None):
+        # type: (str, Optional[List[str]], float, int, Optional[str]) -> None
         super(DistributionMetric, self).__init__(
             name, tags, MetricType.DISTRIBUTION, rate, max_metric_samples, cardinality
         )
@@ -66,4 +78,5 @@ class DistributionMetric(MaxSampleMetric):
 
 class TimingMetric(MaxSampleMetric):
     def __init__(self, name, tags, rate=1.0, max_metric_samples=0, cardinality=None):
+        # type: (str, Optional[List[str]], float, int, Optional[str]) -> None
         super(TimingMetric, self).__init__(name, tags, MetricType.TIMING, rate, max_metric_samples, cardinality)

--- a/datadog/dogstatsd/max_sample_metric_context.py
+++ b/datadog/dogstatsd/max_sample_metric_context.py
@@ -1,15 +1,22 @@
 from threading import Lock
 import random
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datadog.dogstatsd.max_sample_metric import MaxSampleMetric
+    from datadog.dogstatsd.metrics import MetricAggregator
 
 
 class MaxSampleMetricContexts:
     def __init__(self, max_sample_metric_type):
+        # type: (Any) -> None
         self.lock = Lock()
-        self.values = {}
+        self.values = {}  # type: Dict[str, MaxSampleMetric]
         self.max_sample_metric_type = max_sample_metric_type
 
     def flush(self):
-        metrics = []
+        # type: () -> List[List[MetricAggregator]]
+        metrics = []  # type: List[List[MetricAggregator]]
         """Flush the metrics and reset the stored values."""
         with self.lock:
             temp = self.values
@@ -19,6 +26,7 @@ class MaxSampleMetricContexts:
         return metrics
 
     def sample(self, name, value, tags, rate, context_key, max_samples_per_context, cardinality=None):
+        # type: (str, Any, Optional[List[str]], float, str, int, Optional[str]) -> None
         """Sample a metric and store it if it meets the criteria."""
         keeping_sample = self.should_sample(rate)
         with self.lock:
@@ -36,6 +44,7 @@ class MaxSampleMetricContexts:
         metric.lock.release()
 
     def should_sample(self, rate):
+        # type: (float) -> bool
         """Determine if a sample should be kept based on the specified rate."""
         if rate >= 1:
             return True

--- a/datadog/dogstatsd/metrics.py
+++ b/datadog/dogstatsd/metrics.py
@@ -1,8 +1,11 @@
+from typing import List, Optional
+
 from datadog.dogstatsd.metric_types import MetricType
 
 
 class MetricAggregator(object):
     def __init__(self, name, tags, rate, metric_type, value=0, timestamp=0, cardinality=None):
+        # type: (str, Optional[List[str]], float, str, float, int, Optional[str]) -> None
         self.name = name
         self.tags = tags
         self.rate = rate
@@ -12,31 +15,37 @@ class MetricAggregator(object):
         self.cardinality = cardinality
 
     def aggregate(self, value):
+        # type: (float) -> None
         raise NotImplementedError("Subclasses should implement this method.")
 
 
 class CountMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate, timestamp=0, cardinality=None):
+        # type: (str, float, Optional[List[str]], float, int, Optional[str]) -> None
         super(CountMetric, self).__init__(
             name, tags, rate, MetricType.COUNT, value, timestamp, cardinality
         )
 
     def aggregate(self, v):
+        # type: (float) -> None
         self.value += v
 
 
 class GaugeMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate, timestamp=0, cardinality=None):
+        # type: (str, float, Optional[List[str]], float, int, Optional[str]) -> None
         super(GaugeMetric, self).__init__(
             name, tags, rate, MetricType.GAUGE, value, timestamp, cardinality
         )
 
     def aggregate(self, v):
+        # type: (float) -> None
         self.value = v
 
 
 class SetMetric(MetricAggregator):
     def __init__(self, name, value, tags, rate, timestamp=0, cardinality=None):
+        # type: (str, float, Optional[List[str]], float, int, Optional[str]) -> None
         default_value = 0
         super(SetMetric, self).__init__(
             name, tags, rate, MetricType.SET, default_value, default_value, cardinality
@@ -45,9 +54,11 @@ class SetMetric(MetricAggregator):
         self.data.add(value)
 
     def aggregate(self, v):
+        # type: (float) -> None
         self.data.add(v)
 
     def get_data(self):
+        # type: () -> List[MetricAggregator]
         return [
             MetricAggregator(self.name, self.tags, self.rate, MetricType.SET, value)
             for value in self.data

--- a/datadog/dogstatsd/route.py
+++ b/datadog/dogstatsd/route.py
@@ -16,6 +16,7 @@ class UnresolvableDefaultRoute(Exception):
 
 
 def get_default_route():
+    # type: () -> str
     """
     Return the system default interface using the proc filesystem.
 
@@ -34,7 +35,7 @@ def get_default_route():
                     return socket.inet_ntoa(struct.pack("<L", int(fields[2], 16)))
     except IOError:
         raise NotImplementedError(
-            u"Unable to open `/proc/net/route`. " u"`use_default_route` option is available on Linux only."
+            u"Unable to open `/proc/net/route`. `use_default_route` option is available on Linux only."
         )
 
     raise UnresolvableDefaultRoute(u"Unable to resolve the system default's route.")

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,10 +35,6 @@ ignore_missing_imports = True
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-datadog.dogstatsd.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
 [mypy-datadog.threadstats.*]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False


### PR DESCRIPTION
## What does this PR do?

This PR adds typing annotations for the `dogstatsd` package. 

The only changes are typing comments, except for
- Adding `self._telemetry_socket_kind = None` so that it's always set (even if the `try` fails)
- Using `getattr(e, "errno", None) == errno.EPROTOTYPE` over `e.errno == errno.EPROTOTYPE` since `e` is not properly typed to have `errno` and it's not easy to do it in a Py2-and-Py3 compatible way. 
- Adding a `cast` to an `Optional[float]` value passed to a function expected `float`; reason is that "we know" it can only be `None` in certain cases and not in that specific one but the type checker can't know it statically (see comment)