### PR TITLE
typing: add typing for `util`

### DIFF
--- a/datadog/api/api_client.py
+++ b/datadog/api/api_client.py
@@ -158,6 +158,7 @@ class APIClient(object):
                 headers["Content-Encoding"] = "deflate"
 
             # Construct the URL
+            assert _api_host is not None
             url = construct_url(_api_host, api_version, path)
 
             # Process requesting

--- a/datadog/util/cli.py
+++ b/datadog/util/cli.py
@@ -5,22 +5,30 @@ from datetime import datetime, timedelta
 from argparse import ArgumentTypeError
 import json
 import re
-from datadog.util.format import force_to_epoch_seconds
 import time
+from typing import Callable, List, Optional, Set, Union, TypeVar
+
+from datadog.util.format import force_to_epoch_seconds
+
+T = TypeVar("T")
 
 
 def comma_list(list_str, item_func=None):
+    # type: (str, Optional[Callable[[str], Union[T, str]]]) -> List[Union[T, str]]
     if not list_str:
         raise ArgumentTypeError("Invalid comma list")
+
     item_func = item_func or (lambda i: i)
     return [item_func(i.strip()) for i in list_str.split(",") if i.strip()]
 
 
 def comma_set(list_str, item_func=None):
+    # type: (str, Optional[Callable[[str], Union[T, str]]]) -> Set[Union[T, str]]
     return set(comma_list(list_str, item_func=item_func))
 
 
 def comma_list_or_empty(list_str):
+    # type: (Optional[str]) -> List[str]
     if not list_str:
         return []
     else:
@@ -28,6 +36,7 @@ def comma_list_or_empty(list_str):
 
 
 def list_of_ints(int_csv):
+    # type: (Optional[str]) -> List[int]
     if not int_csv:
         raise ArgumentTypeError("Invalid list of ints")
     try:
@@ -46,7 +55,9 @@ def list_of_ints(int_csv):
 
 
 def list_of_ints_and_strs(csv):
+    # type: (str) -> List[Union[int, str]]
     def int_or_str(item):
+        # type: (str) -> Union[int, str]
         try:
             return int(item)
         except ValueError:
@@ -56,6 +67,7 @@ def list_of_ints_and_strs(csv):
 
 
 def set_of_ints(int_csv):
+    # type: (Optional[str]) -> Set[int]
     return set(list_of_ints(int_csv))
 
 
@@ -67,23 +79,27 @@ _date_fieldre = re.compile(r"(\d+)\s?(\w+) (ago|ahead)")
 
 
 def _midnight():
-    """ Truncate a date to midnight. Default to UTC midnight today."""
+    # type: () -> datetime
+    """Truncate a date to midnight. Default to UTC midnight today."""
     return datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 def parse_date_as_epoch_timestamp(date_str):
+    # type: (str) -> datetime
     return parse_date(date_str, to_epoch_ts=True)
 
 
 def _parse_date_noop_formatter(d):
-    """ NOOP - only here for pylint """
+    # type: (datetime) -> datetime
+    """NOOP - only here for pylint"""
     return d
 
 
 def parse_date(date_str, to_epoch_ts=False):
-    formatter = _parse_date_noop_formatter
+    # type: (Union[str, datetime, time.struct_time], bool) -> datetime
+    formatter = _parse_date_noop_formatter  # type: Callable[[datetime], datetime]
     if to_epoch_ts:
-        formatter = force_to_epoch_seconds
+        formatter = force_to_epoch_seconds  # type: ignore[assignment]
 
     if isinstance(date_str, datetime):
         return formatter(date_str)
@@ -100,7 +116,7 @@ def parse_date(date_str, to_epoch_ts=False):
     elif date_str.endswith(("ago", "ahead")):
         m = _date_fieldre.match(date_str)
         if m:
-            fields = m.groups()
+            fields = list(m.groups())
         else:
             fields = date_str.split(" ")[1:]
         num = int(fields[0])
@@ -120,10 +136,12 @@ def parse_date(date_str, to_epoch_ts=False):
         return formatter(datetime.utcnow())
 
     def _from_epoch_timestamp(seconds):
+        # type: (Union[str, float]) -> datetime
         print("_from_epoch_timestamp({})".format(seconds))
         return datetime.utcfromtimestamp(float(seconds))
 
     def _from_epoch_ms_timestamp(millis):
+        # type: (str) -> datetime
         print("_from_epoch_ms_timestamp({})".format(millis))
         in_sec = float(millis) / 1000.0
         print("_from_epoch_ms_timestamp({}) -> {}".format(millis, in_sec))
@@ -142,11 +160,11 @@ def parse_date(date_str, to_epoch_ts=False):
         lambda d: datetime.strptime(d, "%Y"),
         _from_epoch_timestamp,  # an epoch in seconds
         _from_epoch_ms_timestamp,  # an epoch in milliseconds
-    ]
+    ]  # type: List[Callable[[str], datetime]]
 
     for parse_func in parse_funcs:
         try:
-            return formatter(parse_func(date_str))
+            return formatter(parse_func(date_str))  # type: ignore[arg-type]
         except Exception:
             pass
-    raise DateParsingError(u"Could not parse {0} as date".format(date_str))
+    raise DateParsingError("Could not parse {0} as date".format(date_str))

--- a/datadog/util/compat.py
+++ b/datadog/util/compat.py
@@ -8,6 +8,14 @@ Imports for compatibility with Python 2, Python 3 and Google App Engine.
 import logging
 import sys
 from typing import TypeVar, Any, Type
+from typing import Any, Callable, Dict, Iterator, Tuple, TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from configparser import ConfigParser as ConfigParserType # noqa: F401Type
+
+    K = TypeVar('K')
+    V = TypeVar('V')
+
 
 # Logging
 log = logging.getLogger("datadog.util")
@@ -27,9 +35,11 @@ if sys.version_info[0] >= 3:
 
     class LazyLoader(object):
         def __init__(self, module_name):
+            # type: (str) -> None
             self.module_name = module_name
 
         def __getattr__(self, name):
+            # type: (str) -> Any
             # defer the importing of the module to when one of its attributes
             # is accessed
             import importlib
@@ -40,6 +50,7 @@ if sys.version_info[0] >= 3:
     configparser = LazyLoader('configparser')
 
     def ConfigParser():
+        # type: () -> ConfigParserType
         return configparser.ConfigParser()
 
     imap = map
@@ -47,9 +58,11 @@ if sys.version_info[0] >= 3:
     text = str
 
     def iteritems(d):
+        # type: (Dict[K, V]) -> Iterator[Tuple[K, V]]
         return iter(d.items())
 
     def iternext(iter):
+        # type: (Iterator[V]) -> V
         return next(iter)
 
 
@@ -68,9 +81,11 @@ else:
     text = unicode
 
     def iteritems(d):
+        # type: (Dict[K, V]) -> Iterator[Tuple[K, V]]
         return d.iteritems()
 
     def iternext(iter):
+        # type: (Iterator[V]) -> V
         return iter.next()
 
 
@@ -95,6 +110,7 @@ else:
 
 
 def _is_py_version_higher_than(major, minor=0):
+    # type: (int, int) -> bool
     """
     Assert that the Python version is higher than `$maj.$min`.
     """
@@ -102,6 +118,7 @@ def _is_py_version_higher_than(major, minor=0):
 
 
 def is_p3k():
+    # type: () -> bool
     """
     Assert that Python is version 3 or higher.
     """
@@ -109,6 +126,7 @@ def is_p3k():
 
 
 def is_higher_py32():
+    # type: () -> bool
     """
     Assert that Python is version 3.2 or higher.
     """
@@ -116,6 +134,7 @@ def is_higher_py32():
 
 
 def is_higher_py35():
+    # type: () -> bool
     """
     Assert that Python is version 3.5 or higher.
     """
@@ -123,6 +142,7 @@ def is_higher_py35():
 
 
 def is_pypy():
+    # type: () -> bool
     """
     Assert that PyPy is being used (regardless of 2 or 3)
     """
@@ -130,6 +150,7 @@ def is_pypy():
 
 
 def conditional_lru_cache(func):
+    # type: (Callable[..., V]) -> Callable[..., V]
     """
     A decorator that conditionally enables a lru_cache of size 512 if
     the version of Python can support it (>3.2) and otherwise returns

--- a/datadog/util/config.py
+++ b/datadog/util/config.py
@@ -2,8 +2,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2015-Present Datadog, Inc
 import os
-import string
 import sys
+from typing import Any, Dict, IO, Optional, List
 
 # datadog
 from datadog.util.compat import configparser, StringIO, is_p3k
@@ -22,6 +22,7 @@ class PathNotFound(Exception):
 
 
 def get_os():
+    # type: () -> str
     "Human-friendly OS name"
     if sys.platform == "darwin":
         return "mac"
@@ -38,20 +39,24 @@ def get_os():
 
 
 def skip_leading_wsp(f):
+    # type: (IO[str]) -> StringIO
     "Works on a file, returns a file-like object"
     if is_p3k():
         return StringIO("\n".join(x.strip(" ") for x in f.readlines()))
     else:
-        return StringIO("\n".join(map(string.strip, f.readlines())))
+        return StringIO("\n".join(map(str.strip, f.readlines())))
 
 
 def _windows_commondata_path():
+    # type: () -> str
     """Return the common appdata path, using ctypes
     From http://stackoverflow.com/questions/626796/\
     how-do-i-find-the-windows-common-application-data-folder-using-python
     """
     import ctypes
-    from ctypes import wintypes, windll
+    from ctypes import wintypes
+    ctypes_any = ctypes  # type: Any
+    windll = ctypes_any.windll
 
     CSIDL_COMMON_APPDATA = 35
 
@@ -64,6 +69,7 @@ def _windows_commondata_path():
 
 
 def _windows_config_path():
+    # type: () -> str
     common_data = _windows_commondata_path()
     path = os.path.join(common_data, "Datadog", DATADOG_CONF)
     if os.path.exists(path):
@@ -72,6 +78,7 @@ def _windows_config_path():
 
 
 def _unix_config_path():
+    # type: () -> str
     path = os.path.join("/etc/dd-agent", DATADOG_CONF)
     if os.path.exists(path):
         return path
@@ -79,6 +86,7 @@ def _unix_config_path():
 
 
 def _mac_config_path():
+    # type: () -> str
     path = os.path.join("~/.datadog-agent/agent", DATADOG_CONF)
     path = os.path.expanduser(path)
     if os.path.exists(path):
@@ -87,6 +95,7 @@ def _mac_config_path():
 
 
 def get_config_path(cfg_path=None, os_name=None):
+    # type: (Optional[str], Optional[str]) -> str
     # Check if there's an override and if it exists
     if cfg_path is not None and os.path.exists(cfg_path):
         return cfg_path
@@ -104,7 +113,8 @@ def get_config_path(cfg_path=None, os_name=None):
 
 
 def get_config(cfg_path=None, options=None):
-    agentConfig = {}
+    # type: (Optional[str], Optional[List[str]]) -> Dict[str, str]
+    agentConfig = {}  # type: Dict[str, str]
 
     # Config handling
     try:
@@ -131,6 +141,7 @@ def get_config(cfg_path=None, options=None):
 
 
 def get_pkg_version():
+    # type: () -> str
     """
     Resolve `datadog` package version.
 
@@ -140,6 +151,7 @@ def get_pkg_version():
 
 
 def get_version():
+    # type: () -> str
     """
     Resolve `datadog` package version.
 

--- a/datadog/util/deprecation.py
+++ b/datadog/util/deprecation.py
@@ -4,12 +4,16 @@
 
 import warnings
 from functools import wraps
+from typing import Any, Callable
 
 
 def deprecated(message):
+    # type: (str) -> Callable[[Callable[..., Any]], Callable[..., Any]]
     def deprecated_decorator(func):
+        # type: (Callable[..., Any]) -> Callable[..., Any]
         @wraps(func)
         def deprecated_func(*args, **kwargs):
+            # type: (*Any, **Any) -> Any
             warnings.warn(
                 "'{0}' is a deprecated function. {1}".format(func.__name__, message),
                 category=DeprecationWarning,

--- a/datadog/util/format.py
+++ b/datadog/util/format.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import logging
 import re
+from typing import Any, List, Optional, Tuple, Union
 
 from datadog.util.compat import conditional_lru_cache
 
@@ -15,18 +16,22 @@ TAG_INVALID_CHARS_SUBS = "_"
 
 
 def pretty_json(obj):
+    # type: (Any) -> str
     return json.dumps(obj, sort_keys=True, indent=2)
 
 
 def construct_url(host, api_version, path):
+    # type: (str, str, str) -> str
     return "{}/api/{}/{}".format(host.strip("/"), api_version.strip("/"), path.strip("/"))
 
 
 def construct_path(api_version, path):
+    # type: (str, str) -> str
     return "{}/{}".format(api_version.strip("/"), path.strip("/"))
 
 
 def force_to_epoch_seconds(epoch_sec_or_dt):
+    # type: (Union[float, int, datetime.datetime]) -> Union[float, int]
     if isinstance(epoch_sec_or_dt, datetime.datetime):
         return calendar.timegm(epoch_sec_or_dt.timetuple())
     return epoch_sec_or_dt
@@ -34,16 +39,19 @@ def force_to_epoch_seconds(epoch_sec_or_dt):
 
 @conditional_lru_cache
 def _normalize_tags_with_cache(tag_list):
+    # type: (Tuple[str, ...]) -> List[str]
     return [TAG_INVALID_CHARS_RE.sub(TAG_INVALID_CHARS_SUBS, tag) for tag in tag_list]
 
 
 def normalize_tags(tag_list):
+    # type: (List[str]) -> List[str]
     # We have to turn our input tag list into a non-mutable tuple for it to
     # be hashable (and thus usable) by the @lru_cache decorator.
     return _normalize_tags_with_cache(tuple(tag_list))
 
 
 def validate_cardinality(cardinality):
+    # type: (Optional[str]) -> Optional[str]
     if cardinality not in (None, "none", "low", "orchestrator", "high"):
         logging.warning(
             "Cardinality must be one of the following: 'none', 'low', 'orchestrator' or 'high'. "

--- a/datadog/util/hostname.py
+++ b/datadog/util/hostname.py
@@ -8,13 +8,12 @@ import re
 import socket
 import subprocess
 import sys
-import types
 
 if sys.version_info[:2] >= (3, 5):
-    from typing import Dict, Optional  # noqa: F401
+    from typing import Dict, Optional, Any, List  # noqa: F401
 
 # datadog
-from datadog.util.compat import url_lib, is_p3k, iteritems
+from datadog.util.compat import url_lib, iteritems
 from datadog.util.config import get_config, get_os, CfgNotFound
 
 VALID_HOSTNAME_RFC_1123_PATTERN = re.compile(
@@ -26,6 +25,7 @@ log = logging.getLogger("datadog.api")
 
 
 def is_valid_hostname(hostname):
+    # type: (str) -> bool
     if hostname.lower() in set(
         [
             "localhost",
@@ -58,8 +58,8 @@ def get_hostname(hostname_from_config):
       * socket.gethostname()
     """
 
-    hostname = None
-    config = None
+    hostname = None  # type: Optional[str]
+    config = None  # type: Optional[Dict[str, str]]
 
     # first, try the config if hostname_from_config is set to True
     try:
@@ -78,7 +78,7 @@ def get_hostname(hostname_from_config):
 
     # Try to get GCE instance name
     if hostname is None:
-        gce_hostname = GCE.get_hostname(config)
+        gce_hostname = GCE.get_hostname(config or {})
         if gce_hostname is not None:
             if is_valid_hostname(gce_hostname):
                 return gce_hostname
@@ -86,17 +86,16 @@ def get_hostname(hostname_from_config):
     if hostname is None:
 
         def _get_hostname_unix():
+            # type: () -> Optional[str]
             try:
                 # try fqdn
                 p = subprocess.Popen(["/bin/hostname", "-f"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
                 out, err = p.communicate()
                 if p.returncode == 0:
-                    if is_p3k():
-                        return out.decode("utf-8").strip()
-                    else:
-                        return out.strip()
+                    return out.decode("utf-8").strip()
             except Exception:
                 return None
+            return None
 
         os_name = get_os()
         if os_name in ["mac", "freebsd", "linux", "solaris"]:
@@ -106,7 +105,7 @@ def get_hostname(hostname_from_config):
 
     # if we have an ec2 default hostname, see if there's an instance-id available
     if hostname is not None and True in [hostname.lower().startswith(p) for p in [u"ip-", u"domu"]]:
-        instanceid = EC2.get_instance_id(config)
+        instanceid = EC2.get_instance_id(config or {})
         if instanceid:
             hostname = instanceid
 
@@ -129,6 +128,7 @@ def get_hostname(hostname_from_config):
 
 
 def get_ec2_instance_id():
+    # type: () -> Optional[str]
     try:
         # Remember the previous default timeout
         old_timeout = socket.getdefaulttimeout()
@@ -149,10 +149,11 @@ class GCE(object):
     URL = "http://169.254.169.254/computeMetadata/v1/?recursive=true"
     TIMEOUT = 0.1  # second
     SOURCE_TYPE_NAME = "google cloud platform"
-    metadata = None
+    metadata = None  # type: Optional[Dict[str, Any]]
 
     @staticmethod
     def _get_metadata(agentConfig):
+        # type: (Dict[str, Any]) -> Dict[str, Any]
         if GCE.metadata is not None:
             return GCE.metadata
 
@@ -186,6 +187,7 @@ class GCE(object):
 
     @staticmethod
     def get_hostname(agentConfig):
+        # type: (Dict[str, Any]) -> Optional[str]
         try:
             host_metadata = GCE._get_metadata(agentConfig)
             return host_metadata["instance"]["hostname"].split(".")[0]
@@ -202,6 +204,7 @@ class EC2(object):
 
     @staticmethod
     def get_tags(agentConfig):
+        # type: (Dict[str, Any]) -> List[str]
         if not agentConfig["collect_instance_metadata"]:
             log.info("Instance metadata collection is disabled. Not collecting it.")
             return []
@@ -244,6 +247,7 @@ class EC2(object):
 
     @staticmethod
     def get_metadata(agentConfig):
+        # type: (Dict[str, Any]) -> Dict[str, str]
         """Use the ec2 http service to introspect the instance. This adds latency \
         if not running on EC2
         """
@@ -286,8 +290,8 @@ class EC2(object):
         ):
             try:
                 v = url_lib.urlopen(EC2.URL + "/" + str(k)).read().strip()
-                assert type(v) in (types.StringType, types.UnicodeType) and len(v) > 0, "%s is not a string" % v
-                EC2.metadata[k] = v
+                assert isinstance(v, (bytes, str)) and len(v) > 0, "%s is not a string" % v
+                EC2.metadata[k] = v.decode("utf-8") if isinstance(v, bytes) else v
             except Exception:
                 pass
 
@@ -302,6 +306,7 @@ class EC2(object):
 
     @staticmethod
     def get_instance_id(agentConfig):
+        # type: (Dict[str, Any]) -> Optional[str]
         try:
             return EC2.get_metadata(agentConfig).get("instance-id", None)
         except Exception:

--- a/mypy.ini
+++ b/mypy.ini
@@ -39,6 +39,3 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-datadog.util.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False

--- a/tests/unit/dogwrap/test_dogwrap.py
+++ b/tests/unit/dogwrap/test_dogwrap.py
@@ -16,7 +16,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 
 class TestDogwrap(unittest.TestCase):
-    def test_output_reader(self):
+    def test_output_reader(self): # type: () -> None
         with open(os.path.join(HERE, "fixtures", "proc_out.txt"), 'rb') as cmd_out:
             content = cmd_out.read()
 
@@ -29,7 +29,7 @@ class TestDogwrap(unittest.TestCase):
             fwd_out.seek(0, 0)
             self.assertEqual(reader.content, fwd_out.read())
 
-    def test_build_event_body(self):
+    def test_build_event_body(self): # type: () -> None
         # Only cmd is already unicode, the rest is decoded in the function
         cmd = u"yö dudes"
         returncode = 0
@@ -48,19 +48,16 @@ class TestDogwrap(unittest.TestCase):
         self.assertEqual(expected_body, event_body)
 
         # notifications can be unicode already in py3, make sure we don't try decoding
-        notifications = notifications.decode("utf-8", "replace")
-        event_body = build_event_body(cmd, returncode, stdout, stderr, notifications)
+        notifications_str = notifications.decode("utf-8", "replace")
+        event_body = build_event_body(cmd, returncode, stdout, stderr, notifications_str)
         self.assertEqual(expected_body, event_body)
 
-    def test_parse_options(self):
+    def test_parse_options(self): # type: () -> None
         options, cmd = parse_options([])
         self.assertEqual(cmd, '')
 
         # The output of parse_args is already unicode in python 3, so don't encode the input
-        if is_p3k():
-            arg = u'helløøééé'
-        else:
-            arg = u'helløøééé'.encode('utf-8')
+        arg = u'helløøééé' if is_p3k() else u'helløøééé'.encode('utf-8')
 
         options, cmd = parse_options(['-n', 'name', '-k', 'key', '-m', 'all', '-p', 'low', '-t', '123',
                                       '--sigterm_timeout', '456', '--sigkill_timeout', '789',
@@ -103,7 +100,7 @@ class TestDogwrap(unittest.TestCase):
             options, _ = parse_options([])
             self.assertEqual(options.api_key, "the_key")
 
-    def test_poll_proc(self):
+    def test_poll_proc(self): # type: () -> None
         mock_proc = mock.Mock()
         mock_proc.poll.side_effect = [None, 0]
 
@@ -111,7 +108,7 @@ class TestDogwrap(unittest.TestCase):
         self.assertEqual(return_value, 0)
         self.assertEqual(mock_proc.poll.call_count, 2)
 
-    def test_poll_timeout(self):
+    def test_poll_timeout(self): # type: () -> None
         mock_proc = mock.Mock()
         mock_proc.poll.side_effect = [None, None, None]
 
@@ -121,6 +118,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('datadog.dogshell.wrap.poll_proc')
     @mock.patch('subprocess.Popen')
     def test_execute(self, mock_popen, mock_poll):
+        # type: (mock.Mock, mock.Mock) -> None
         mock_proc = mock.Mock()
         mock_proc.stdout.readline.side_effect = [b'out1\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
@@ -140,6 +138,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('datadog.dogshell.wrap.poll_proc')
     @mock.patch('subprocess.Popen')
     def test_execute_exit_code(self, mock_popen, mock_poll):
+        # type: (mock.Mock, mock.Mock) -> None
         mock_proc = mock.Mock()
         mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
@@ -159,6 +158,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('datadog.dogshell.wrap.poll_proc')
     @mock.patch('subprocess.Popen')
     def test_execute_cmd_timeout(self, mock_popen, mock_poll):
+        # type: (mock.Mock, mock.Mock) -> None
         mock_proc = mock.Mock()
         mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
@@ -181,6 +181,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('datadog.dogshell.wrap.poll_proc')
     @mock.patch('subprocess.Popen')
     def test_execute_sigterm_timeout(self, mock_popen, mock_poll):
+        # type: (mock.Mock, mock.Mock) -> None
         mock_proc = mock.Mock()
         mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
@@ -204,6 +205,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('datadog.dogshell.wrap.poll_proc')
     @mock.patch('subprocess.Popen')
     def test_execute_sigkill_timeout(self, mock_popen, mock_poll):
+        # type: (mock.Mock, mock.Mock) -> None
         mock_proc = mock.Mock()
         mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
@@ -227,6 +229,7 @@ class TestDogwrap(unittest.TestCase):
     @mock.patch('datadog.dogshell.wrap.poll_proc')
     @mock.patch('subprocess.Popen')
     def test_execute_oserror(self, mock_popen, mock_poll):
+        # type: (mock.Mock, mock.Mock) -> None
         mock_proc = mock.Mock()
         mock_proc.stdout.readline.side_effect = [b'out1\n', b'out2\n', b'']
         mock_proc.stderr.readline.side_effect = [b'err1\n', b'']
@@ -248,6 +251,7 @@ class TestDogwrap(unittest.TestCase):
 
     @mock.patch('subprocess.Popen')
     def test_execute_popen_fail(self, mock_popen):
+        # type: (mock.Mock) -> None
         mock_popen.side_effect = ValueError('Bad things')
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## What is this PR?

This PR adds typing for `util` and fixes inconsistent typing outside `util` that resulted from `util` being properly type annotated. 