### PR TITLE
Fix AttributeError in dogshell SLO show command

### DIFF
--- a/datadog/dogshell/service_level_objective.py
+++ b/datadog/dogshell/service_level_objective.py
@@ -326,9 +326,6 @@ class ServiceLevelObjectiveClient(object):
         report_warnings(res)
         report_errors(res)
 
-        if args.string_ids:
-            res["id"] = str(res["id"])
-
         if format == "pretty":
             print(pretty_json(res))
         else:


### PR DESCRIPTION
## Summary

- Fix `AttributeError: 'Namespace' object has no attribute 'string_ids'` when running `dogshell service_level_objective show <slo_id>`
- The `_show` method referenced `args.string_ids` which was never registered on the `show` subparser
- SLO IDs are already strings, so the `string_ids` conversion is unnecessary — removed the dead code

Fixes #875

## Test plan

- Verified all existing dogshell unit tests pass (8/8)
- Confirmed `string_ids` is properly registered in other subcommands (monitor, timeboard, screenboard, downtime) but was missing from the SLO `show` subparser