### PR TITLE
fix(dogstatsd): push cardinality for sampled metrics

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -961,7 +961,16 @@ class DogStatsd(object):
 
         sampled_metrics = self.aggregator.flush_aggregated_sampled_metrics()
         for m in sampled_metrics:
-            self._report(m.name, m.metric_type, m.value, m.tags, m.rate, m.timestamp, False)
+            self._report(
+                m.name,
+                m.metric_type,
+                m.value,
+                m.tags,
+                m.rate,
+                m.timestamp,
+                False,
+                cardinality=m.cardinality,
+            )
 
     def gauge(
         self,

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -426,6 +426,36 @@ class TestDogStatsd(unittest.TestCase):
         self.statsd.histogram('histo', 123.4, cardinality="low")
         self.assert_equal_telemetry('histo:123.4|h|card:low\n', self.recv(2))
 
+    def test_sampled_metrics_with_cardinality_when_aggregation_enabled(self):
+        statsd = DogStatsd(
+            disable_aggregation=False,
+            disable_telemetry=True,
+            origin_detection_enabled=False,
+            flush_interval=10000,
+            max_metric_samples_per_context=10,
+        )
+        statsd.socket = FakeSocket()
+
+        try:
+            statsd.histogram("histo", 1, cardinality="high")
+            statsd.distribution("dist", 2, cardinality="high")
+            statsd.timing("timer", 3, cardinality="high")
+            statsd.flush_aggregated_metrics()
+
+            packets = [statsd.socket.recv(no_wait=True) for _ in range(3)]
+            self.assertEqual(
+                sorted(
+                    [
+                        "histo:1|h|card:high\n",
+                        "dist:2|d|card:high\n",
+                        "timer:3|ms|card:high\n",
+                    ]
+                ),
+                sorted(packets),
+            )
+        finally:
+            statsd.stop()
+
     def test_pipe_in_tags(self):
         self.statsd.gauge('gt', 123.4, tags=['pipe|in:tag', 'red'])
         self.assert_equal_telemetry('gt:123.4|g|#pipe_in:tag,red\n', self.recv(2))


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f7c39ab8-8802-43dd-9907-ca6522467747","source":"chat","resourceId":"625d1e3c-2606-445a-a59a-53b98b6cc57e","workflowId":"a839a865-fcbf-45e5-910a-ebdcf74c2d39","codeChangeId":"a839a865-fcbf-45e5-910a-ebdcf74c2d39","sourceType":"chat"} -->

## What does this PR do?

This PR updates the `flush_aggregated_metrics` function to properly forward `cardinality`. Previously, this parameter was missing which would always set it to the default value defined in `self._report` (`None`).