### PR TITLE
feat: emit start signals for cron job monitoring

### DIFF
--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -20,6 +20,7 @@ And you can give the command a timeout too:
 dogwrap -n test-job -k $API_KEY --timeout=1 "sleep 3"
 
 """
+
 # stdlib
 from __future__ import print_function
 
@@ -109,7 +110,9 @@ def poll_proc(proc, sleep_interval, timeout):
     return returncode
 
 
-def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout, proc_poll_interval, buffer_outs):
+def execute(
+    cmd, cmd_timeout, sigterm_timeout, sigkill_timeout, proc_poll_interval, buffer_outs
+):
     # type: (str, float, float, float, float, bool) -> Tuple[Union[int, Type[Timeout]], bytes, bytes, float]
     """
     Launches the process and monitors its outputs
@@ -119,9 +122,11 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout, proc_poll_interv
     stdout = b""
     stderr = b""
     try:
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+        )
     except Exception:
-        print(u"Failed to execute %s" % (repr(cmd)), file=sys.stderr)
+        print("Failed to execute %s" % (repr(cmd)), file=sys.stderr)
         raise
     try:
         # Let's that the threads collecting the output from the command in the
@@ -130,8 +135,12 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout, proc_poll_interv
         stderr_buffer = sys.stderr.buffer if is_p3k() else sys.stderr
         assert proc.stdout is not None
         assert proc.stderr is not None
-        out_reader = OutputReader(proc.stdout, stdout_buffer if not buffer_outs else None)
-        err_reader = OutputReader(proc.stderr, stderr_buffer if not buffer_outs else None)
+        out_reader = OutputReader(
+            proc.stdout, stdout_buffer if not buffer_outs else None
+        )
+        err_reader = OutputReader(
+            proc.stderr, stderr_buffer if not buffer_outs else None
+        )
         out_reader.start()
         err_reader.start()
 
@@ -141,14 +150,19 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout, proc_poll_interv
     except Timeout:
         returncode = Timeout
         sigterm_start = time.time()
-        print("Command timed out after %.2fs, killing with SIGTERM" % (time.time() - start_time), file=sys.stderr)
+        print(
+            "Command timed out after %.2fs, killing with SIGTERM"
+            % (time.time() - start_time),
+            file=sys.stderr,
+        )
         try:
             proc.terminate()
             try:
                 poll_proc(proc, proc_poll_interval, sigterm_timeout)
             except Timeout:
                 print(
-                    "SIGTERM timeout failed after %.2fs, killing with SIGKILL" % (time.time() - sigterm_start),
+                    "SIGTERM timeout failed after %.2fs, killing with SIGKILL"
+                    % (time.time() - sigterm_start),
                     file=sys.stderr,
                 )
                 sigkill_start = time.time()
@@ -157,7 +171,9 @@ def execute(cmd, cmd_timeout, sigterm_timeout, sigkill_timeout, proc_poll_interv
                     poll_proc(proc, proc_poll_interval, sigkill_timeout)
                 except Timeout:
                     print(
-                        "SIGKILL timeout failed after %.2fs, exiting" % (time.time() - sigkill_start), file=sys.stderr
+                        "SIGKILL timeout failed after %.2fs, exiting"
+                        % (time.time() - sigkill_start),
+                        file=sys.stderr,
                     )
         except OSError as e:
             # Ignore OSError 3: no process found.
@@ -188,12 +204,9 @@ def trim_text(text, max_len):
         return text
 
     trimmed_text = (
-        u"{top_third}\n"
-        u"```\n"
-        u"*...trimmed...*\n"
-        u"```\n"
-        u"{bottom_two_third}\n".format(
-            top_third=text[: max_len // 3], bottom_two_third=text[len(text) - (2 * max_len) // 3 :]
+        "{top_third}\n```\n*...trimmed...*\n```\n{bottom_two_third}\n".format(
+            top_third=text[: max_len // 3],
+            bottom_two_third=text[len(text) - (2 * max_len) // 3 :],
         )
     )
 
@@ -207,34 +220,42 @@ def build_event_body(cmd, returncode, stdout, stderr, notifications):
 
     Note: do not exceed MAX_EVENT_BODY_LENGTH length.
     """
-    fmt_stdout = u""
-    fmt_stderr = u""
-    fmt_notifications = u""
+    fmt_stdout = ""
+    fmt_stderr = ""
+    fmt_notifications = ""
 
-    max_length = MAX_EVENT_BODY_LENGTH // 2 if stdout and stderr else MAX_EVENT_BODY_LENGTH
+    max_length = (
+        MAX_EVENT_BODY_LENGTH // 2 if stdout and stderr else MAX_EVENT_BODY_LENGTH
+    )
 
     if stdout:
-        fmt_stdout = u"**>>>> STDOUT <<<<**\n```\n{stdout} \n```\n".format(
+        fmt_stdout = "**>>>> STDOUT <<<<**\n```\n{stdout} \n```\n".format(
             stdout=trim_text(stdout.decode("utf-8", "replace"), max_length)
         )
 
     if stderr:
-        fmt_stderr = u"**>>>> STDERR <<<<**\n```\n{stderr} \n```\n".format(
+        fmt_stderr = "**>>>> STDERR <<<<**\n```\n{stderr} \n```\n".format(
             stderr=trim_text(stderr.decode("utf-8", "replace"), max_length)
         )
 
     if notifications:
-        notifications = notifications.decode("utf-8", "replace") if isinstance(notifications, bytes) else notifications
-        fmt_notifications = u"**>>>> NOTIFICATIONS <<<<**\n\n {notifications}\n".format(notifications=notifications)
+        notifications = (
+            notifications.decode("utf-8", "replace")
+            if isinstance(notifications, bytes)
+            else notifications
+        )
+        fmt_notifications = "**>>>> NOTIFICATIONS <<<<**\n\n {notifications}\n".format(
+            notifications=notifications
+        )
 
     return (
-        u"%%%\n"
-        u"**>>>> CMD <<<<**\n```\n{command} \n```\n"
-        u"**>>>> EXIT CODE <<<<**\n\n {returncode}\n\n\n"
-        u"{stdout}"
-        u"{stderr}"
-        u"{notifications}"
-        u"%%%\n".format(
+        "%%%\n"
+        "**>>>> CMD <<<<**\n```\n{command} \n```\n"
+        "**>>>> EXIT CODE <<<<**\n\n {returncode}\n\n\n"
+        "{stdout}"
+        "{stderr}"
+        "{notifications}"
+        "%%%\n".format(
             command=cmd,
             returncode=returncode,
             stdout=fmt_stdout,
@@ -252,7 +273,9 @@ def generate_warning_codes(option, opt, options_warning):
         warning_codes = options_warning.split(",")
         return warning_codes
     except ValueError:
-        raise optparse.OptionValueError("option %s: invalid warning codes value(s): %r" % (opt, options_warning))
+        raise optparse.OptionValueError(
+            "option %s: invalid warning codes value(s): %r" % (opt, options_warning)
+        )
 
 
 class DogwrapOption(optparse.Option):
@@ -405,7 +428,12 @@ returned (the command outputs remains buffered in dogwrap meanwhile)",
         help="sends a metric for event duration",
     )
     parser.add_option(
-        "--tags", action="store", type="string", dest="tags", default="", help="comma separated list of tags"
+        "--tags",
+        action="store",
+        type="string",
+        dest="tags",
+        default="",
+        help="comma separated list of tags",
     )
 
     options, args = parser.parse_args(args=raw_args)
@@ -422,18 +450,7 @@ def main():
     # type: () -> None
     options, cmd = parse_options()
 
-    # If silent is checked we force the outputs to be buffered (and therefore
-    # not forwarded to the Terminal streams) and we just avoid printing the
-    # buffers at the end
-    returncode, stdout, stderr, duration = execute(
-        cmd,
-        options.timeout,
-        options.sigterm_timeout,
-        options.sigkill_timeout,
-        options.proc_poll_interval,
-        options.buffer_outs,
-    )
-
+    # Resolve API host from site option
     if options.site in ("datadoghq.com", "us"):
         api_host = "https://api.datadoghq.com"
     elif options.site in ("datadoghq.eu", "eu"):
@@ -452,6 +469,41 @@ def main():
     initialize(api_key=options.api_key, api_host=api_host)
     host = api._host_name
 
+    # Build tags before execute() so start signals can use them
+    if options.tags:
+        tags = [t.strip() for t in options.tags.split(",")]
+    else:
+        tags = None
+
+    # Emit start signals before executing the command
+    if options.send_metric:
+        event_name_tag = "event_name:{}".format(options.name)
+        start_tags = (tags or []) + [event_name_tag]
+        api.Metric.send(
+            metric="dogwrap.started", points=1, tags=start_tags, type="gauge"
+        )
+
+    if options.submit_mode == "all":
+        api.Event.create(
+            title="[%s] %s started" % (host, options.name),
+            text="Job triggered",
+            alert_type="info",
+            aggregation_key=options.name,
+            tags=tags,
+        )
+
+    # If silent is checked we force the outputs to be buffered (and therefore
+    # not forwarded to the Terminal streams) and we just avoid printing the
+    # buffers at the end
+    returncode, stdout, stderr, duration = execute(
+        cmd,
+        options.timeout,
+        options.sigterm_timeout,
+        options.sigkill_timeout,
+        options.proc_poll_interval,
+        options.buffer_outs,
+    )
+
     warning_codes = None
 
     if options.warning_codes:
@@ -461,7 +513,7 @@ def main():
     if returncode == 0:
         alert_type = SUCCESS
         event_priority = "low"
-        event_title = u"[%s] %s succeeded in %.2fs" % (host, options.name, duration)
+        event_title = "[%s] %s succeeded in %.2fs" % (host, options.name, duration)
     elif returncode != 0 and options.submit_mode == "warnings":
         if not warning_codes:
             # the list of warning codes is empty - the option was not specified
@@ -470,7 +522,7 @@ def main():
         elif returncode in warning_codes:
             alert_type = WARNING
             event_priority = "normal"
-            event_title = u"[%s] %s failed in %.2fs" % (host, options.name, duration)
+            event_title = "[%s] %s failed in %.2fs" % (host, options.name, duration)
         else:
             print("Command exited with a different exit code that the one(s) provided")
             sys.exit()
@@ -479,10 +531,14 @@ def main():
         event_priority = "normal"
 
         if returncode is Timeout:
-            event_title = u"[%s] %s timed out after %.2fs" % (host, options.name, duration)
+            event_title = "[%s] %s timed out after %.2fs" % (
+                host,
+                options.name,
+                duration,
+            )
             returncode = -1
         else:
-            event_title = u"[%s] %s failed in %.2fs" % (host, options.name, duration)
+            event_title = "[%s] %s failed in %.2fs" % (host, options.name, duration)
 
     notifications = ""
 
@@ -492,11 +548,6 @@ def main():
         notifications = options.notify_error
     elif alert_type == WARNING and options.notify_warning:
         notifications = options.notify_warning
-
-    if options.tags:
-        tags = [t.strip() for t in options.tags.split(",")]
-    else:
-        tags = None
 
     event_body = build_event_body(cmd, returncode, stdout, stderr, notifications)
 
@@ -522,7 +573,12 @@ def main():
                 duration_tags = tags + [event_name_tag]
             else:
                 duration_tags = [event_name_tag]
-            api.Metric.send(metric="dogwrap.duration", points=duration, tags=duration_tags, type="gauge")
+            api.Metric.send(
+                metric="dogwrap.duration",
+                points=duration,
+                tags=duration_tags,
+                type="gauge",
+            )
         api.Event.create(title=event_title, text=event_body, **event)
 
     assert isinstance(returncode, int)
@@ -531,5 +587,8 @@ def main():
 
 if __name__ == "__main__":
     if sys.argv[0].endswith("dogwrap"):
-        warnings.warn("dogwrap is pending deprecation. Please use dogshellwrap instead.", PendingDeprecationWarning)
+        warnings.warn(
+            "dogwrap is pending deprecation. Please use dogshellwrap instead.",
+            PendingDeprecationWarning,
+        )
     main()

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -475,21 +475,28 @@ def main():
     else:
         tags = None
 
-    # Emit start signals before executing the command
-    if options.send_metric:
-        event_name_tag = "event_name:{}".format(options.name)
-        start_tags = (tags or []) + [event_name_tag]
-        api.Metric.send(
-            metric="dogwrap.started", points=1, tags=start_tags, type="gauge"
-        )
+    # Emit start signals before executing the command.
+    # Wrapped in try/except so API failures never block command execution.
+    try:
+        if options.send_metric:
+            event_name_tag = "event_name:{}".format(options.name)
+            start_tags = (tags or []) + [event_name_tag]
+            api.Metric.send(
+                metric="dogwrap.started", points=1, tags=start_tags, type="gauge"
+            )
 
-    if options.submit_mode == "all":
-        api.Event.create(
-            title="[%s] %s started" % (host, options.name),
-            text="Job triggered",
-            alert_type="info",
-            aggregation_key=options.name,
-            tags=tags,
+        if options.submit_mode == "all":
+            api.Event.create(
+                title="[%s] %s started" % (host, options.name),
+                text="Job triggered",
+                alert_type="info",
+                aggregation_key=options.name,
+                tags=tags,
+            )
+    except Exception as e:
+        print(
+            "Failed to send start signals, proceeding with command execution: %s" % e,
+            file=sys.stderr,
         )
 
     # If silent is checked we force the outputs to be buffered (and therefore

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -469,23 +469,28 @@ def main():
     initialize(api_key=options.api_key, api_host=api_host)
     host = api._host_name
 
-    # Build tags before execute() so start signals can use them
+    # Build tags early so start signals can reuse them
     if options.tags:
         tags = [t.strip() for t in options.tags.split(",")]
     else:
         tags = None
 
-    # Emit start signals before executing the command.
-    # Wrapped in try/except so API failures never block command execution.
-    try:
-        if options.send_metric:
+    # Start signals — failures must not block command execution.
+    if options.send_metric:
+        try:
             event_name_tag = "event_name:{}".format(options.name)
             start_tags = (tags or []) + [event_name_tag]
             api.Metric.send(
                 metric="dogwrap.started", points=1, tags=start_tags, type="gauge"
             )
+        except Exception as e:
+            print(
+                "Failed to send start metric: %s" % e,
+                file=sys.stderr,
+            )
 
-        if options.submit_mode == "all":
+    if options.submit_mode == "all":
+        try:
             api.Event.create(
                 title="[%s] %s started" % (host, options.name),
                 text="Job triggered",
@@ -493,11 +498,11 @@ def main():
                 aggregation_key=options.name,
                 tags=tags,
             )
-    except Exception as e:
-        print(
-            "Failed to send start signals, proceeding with command execution: %s" % e,
-            file=sys.stderr,
-        )
+        except Exception as e:
+            print(
+                "Failed to send start event: %s" % e,
+                file=sys.stderr,
+            )
 
     # If silent is checked we force the outputs to be buffered (and therefore
     # not forwarded to the Terminal streams) and we just avoid printing the

--- a/tests/unit/dogshell/test_wrap.py
+++ b/tests/unit/dogshell/test_wrap.py
@@ -1,0 +1,234 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the BSD-3-Clause License.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2015-Present Datadog, Inc
+"""
+Tests for dogwrap start signals (dogwrap.started metric and start event).
+"""
+
+import unittest
+
+import mock
+
+from datadog.dogshell.wrap import main
+
+
+class TestDogwrapStartSignals(unittest.TestCase):
+    @mock.patch("sys.exit")
+    @mock.patch("datadog.dogshell.wrap.execute", return_value=(0, b"", b"", 1.0))
+    @mock.patch("datadog.dogshell.wrap.api.Event.create")
+    @mock.patch("datadog.dogshell.wrap.api.Metric.send")
+    @mock.patch("datadog.dogshell.wrap.initialize")
+    @mock.patch("datadog.dogshell.wrap.parse_options")
+    def test_start_metric_fires_before_duration_metric(
+        self,
+        mock_parse,
+        mock_init,
+        mock_metric_send,
+        mock_event_create,
+        mock_execute,
+        mock_exit,
+    ):
+        """Start metric fires before execute when --send_metric is set."""
+        opts = mock.Mock()
+        opts.name = "test-job"
+        opts.api_key = "fake-key"
+        opts.site = "datadoghq.com"
+        opts.submit_mode = "all"
+        opts.send_metric = True
+        opts.tags = ""
+        opts.timeout = 60
+        opts.sigterm_timeout = 120
+        opts.sigkill_timeout = 60
+        opts.proc_poll_interval = 0.5
+        opts.buffer_outs = False
+        opts.priority = None
+        opts.warning_codes = None
+        opts.notify_success = ""
+        opts.notify_error = ""
+        opts.notify_warning = ""
+        mock_parse.return_value = (opts, "echo hi")
+
+        main()
+
+        # Should have exactly 2 Metric.send calls: started then duration
+        self.assertEqual(mock_metric_send.call_count, 2)
+        first_call = mock_metric_send.call_args_list[0]
+        second_call = mock_metric_send.call_args_list[1]
+        self.assertEqual(first_call[1]["metric"], "dogwrap.started")
+        self.assertEqual(second_call[1]["metric"], "dogwrap.duration")
+
+    @mock.patch("sys.exit")
+    @mock.patch("datadog.dogshell.wrap.execute", return_value=(0, b"", b"", 1.0))
+    @mock.patch("datadog.dogshell.wrap.api.Event.create")
+    @mock.patch("datadog.dogshell.wrap.api.Metric.send")
+    @mock.patch("datadog.dogshell.wrap.initialize")
+    @mock.patch("datadog.dogshell.wrap.parse_options")
+    def test_no_start_metric_without_flag(
+        self,
+        mock_parse,
+        mock_init,
+        mock_metric_send,
+        mock_event_create,
+        mock_execute,
+        mock_exit,
+    ):
+        """Start metric does NOT fire when --send_metric is not set."""
+        opts = mock.Mock()
+        opts.name = "test-job"
+        opts.api_key = "fake-key"
+        opts.site = "datadoghq.com"
+        opts.submit_mode = "errors"
+        opts.send_metric = False
+        opts.tags = ""
+        opts.timeout = 60
+        opts.sigterm_timeout = 120
+        opts.sigkill_timeout = 60
+        opts.proc_poll_interval = 0.5
+        opts.buffer_outs = False
+        opts.priority = None
+        opts.warning_codes = None
+        opts.notify_success = ""
+        opts.notify_error = ""
+        opts.notify_warning = ""
+        mock_parse.return_value = (opts, "echo hi")
+
+        main()
+
+        # Success + errors mode = no end event/metric either, so 0 calls total
+        mock_metric_send.assert_not_called()
+
+    @mock.patch("sys.exit")
+    @mock.patch("datadog.dogshell.wrap.execute", return_value=(0, b"", b"", 1.0))
+    @mock.patch("datadog.dogshell.wrap.api.Metric.send")
+    @mock.patch("datadog.dogshell.wrap.api.Event.create")
+    @mock.patch("datadog.dogshell.wrap.initialize")
+    @mock.patch("datadog.dogshell.wrap.parse_options")
+    def test_start_event_fires_with_submit_mode_all(
+        self,
+        mock_parse,
+        mock_init,
+        mock_event_create,
+        mock_metric_send,
+        mock_execute,
+        mock_exit,
+    ):
+        """Start event fires when --submit_mode all."""
+        opts = mock.Mock()
+        opts.name = "test-job"
+        opts.api_key = "fake-key"
+        opts.site = "datadoghq.com"
+        opts.submit_mode = "all"
+        opts.send_metric = False
+        opts.tags = ""
+        opts.timeout = 60
+        opts.sigterm_timeout = 120
+        opts.sigkill_timeout = 60
+        opts.proc_poll_interval = 0.5
+        opts.buffer_outs = False
+        opts.priority = None
+        opts.warning_codes = None
+        opts.notify_success = ""
+        opts.notify_error = ""
+        opts.notify_warning = ""
+        mock_parse.return_value = (opts, "echo hi")
+
+        main()
+
+        # Should have exactly 2 Event.create calls: start event then end event
+        self.assertEqual(mock_event_create.call_count, 2)
+        first_call = mock_event_create.call_args_list[0]
+        self.assertEqual(first_call[1]["alert_type"], "info")
+        self.assertIn("started", first_call[1]["title"])
+
+        # Second call is the end/success event
+        second_call = mock_event_create.call_args_list[1]
+        self.assertIn("succeeded", second_call[1]["title"])
+
+    @mock.patch("sys.exit")
+    @mock.patch("datadog.dogshell.wrap.execute", return_value=(0, b"", b"", 1.0))
+    @mock.patch("datadog.dogshell.wrap.api.Metric.send")
+    @mock.patch("datadog.dogshell.wrap.api.Event.create")
+    @mock.patch("datadog.dogshell.wrap.initialize")
+    @mock.patch("datadog.dogshell.wrap.parse_options")
+    def test_no_start_event_with_submit_mode_errors(
+        self,
+        mock_parse,
+        mock_init,
+        mock_event_create,
+        mock_metric_send,
+        mock_execute,
+        mock_exit,
+    ):
+        """Start event does NOT fire when --submit_mode errors."""
+        opts = mock.Mock()
+        opts.name = "test-job"
+        opts.api_key = "fake-key"
+        opts.site = "datadoghq.com"
+        opts.submit_mode = "errors"
+        opts.send_metric = False
+        opts.tags = ""
+        opts.timeout = 60
+        opts.sigterm_timeout = 120
+        opts.sigkill_timeout = 60
+        opts.proc_poll_interval = 0.5
+        opts.buffer_outs = False
+        opts.priority = None
+        opts.warning_codes = None
+        opts.notify_success = ""
+        opts.notify_error = ""
+        opts.notify_warning = ""
+        mock_parse.return_value = (opts, "echo hi")
+
+        main()
+
+        # Success + errors mode = no events at all
+        mock_event_create.assert_not_called()
+
+    @mock.patch("sys.exit")
+    @mock.patch("datadog.dogshell.wrap.execute", return_value=(0, b"", b"", 1.0))
+    @mock.patch("datadog.dogshell.wrap.api.Event.create")
+    @mock.patch("datadog.dogshell.wrap.api.Metric.send")
+    @mock.patch("datadog.dogshell.wrap.initialize")
+    @mock.patch("datadog.dogshell.wrap.parse_options")
+    def test_start_metric_tags_include_event_name(
+        self,
+        mock_parse,
+        mock_init,
+        mock_metric_send,
+        mock_event_create,
+        mock_execute,
+        mock_exit,
+    ):
+        """Start metric tags include event_name tag and custom tags."""
+        opts = mock.Mock()
+        opts.name = "test-job"
+        opts.api_key = "fake-key"
+        opts.site = "datadoghq.com"
+        opts.submit_mode = "errors"
+        opts.send_metric = True
+        opts.tags = "env:prod"
+        opts.timeout = 60
+        opts.sigterm_timeout = 120
+        opts.sigkill_timeout = 60
+        opts.proc_poll_interval = 0.5
+        opts.buffer_outs = False
+        opts.priority = None
+        opts.warning_codes = None
+        opts.notify_success = ""
+        opts.notify_error = ""
+        opts.notify_warning = ""
+        mock_parse.return_value = (opts, "echo hi")
+
+        main()
+
+        # Find the dogwrap.started call
+        started_call = None
+        for call in mock_metric_send.call_args_list:
+            if call[1].get("metric") == "dogwrap.started":
+                started_call = call
+                break
+
+        self.assertIsNotNone(started_call, "dogwrap.started metric was not sent")
+        sent_tags = started_call[1]["tags"]
+        self.assertIn("env:prod", sent_tags)
+        self.assertIn("event_name:test-job", sent_tags)

--- a/tests/unit/dogshell/test_wrap.py
+++ b/tests/unit/dogshell/test_wrap.py
@@ -239,7 +239,7 @@ class TestDogwrapStartSignals(unittest.TestCase):
     @mock.patch("datadog.dogshell.wrap.api.Metric.send")
     @mock.patch("datadog.dogshell.wrap.initialize")
     @mock.patch("datadog.dogshell.wrap.parse_options")
-    def test_start_signal_failure_does_not_block_execute(
+    def test_start_metric_failure_does_not_block_start_event(
         self,
         mock_parse,
         mock_init,
@@ -248,7 +248,7 @@ class TestDogwrapStartSignals(unittest.TestCase):
         mock_execute,
         mock_exit,
     ):
-        """API failure on start signals must not prevent command execution."""
+        """Start metric failure must not prevent start event or command execution."""
         opts = mock.Mock()
         opts.name = "test-job"
         opts.api_key = "fake-key"
@@ -273,8 +273,13 @@ class TestDogwrapStartSignals(unittest.TestCase):
 
         main()
 
-        # execute() must still have been called despite the API failure
+        # execute() must still have been called despite the metric failure
         mock_execute.assert_called_once()
+
+        # Start event must still have fired despite the metric failure
+        first_event_call = mock_event_create.call_args_list[0]
+        self.assertEqual(first_event_call[1]["alert_type"], "info")
+        self.assertIn("started", first_event_call[1]["title"])
 
     @mock.patch("sys.exit")
     @mock.patch("datadog.dogshell.wrap.execute", return_value=(0, b"", b"", 1.0))
@@ -282,7 +287,7 @@ class TestDogwrapStartSignals(unittest.TestCase):
     @mock.patch("datadog.dogshell.wrap.api.Event.create")
     @mock.patch("datadog.dogshell.wrap.initialize")
     @mock.patch("datadog.dogshell.wrap.parse_options")
-    def test_start_event_failure_does_not_block_execute(
+    def test_start_event_failure_does_not_block_start_metric(
         self,
         mock_parse,
         mock_init,
@@ -291,13 +296,13 @@ class TestDogwrapStartSignals(unittest.TestCase):
         mock_execute,
         mock_exit,
     ):
-        """API failure on start event must not prevent command execution."""
+        """Start event failure must not prevent start metric or command execution."""
         opts = mock.Mock()
         opts.name = "test-job"
         opts.api_key = "fake-key"
         opts.site = "datadoghq.com"
         opts.submit_mode = "all"
-        opts.send_metric = False
+        opts.send_metric = True
         opts.tags = ""
         opts.timeout = 60
         opts.sigterm_timeout = 120
@@ -311,10 +316,14 @@ class TestDogwrapStartSignals(unittest.TestCase):
         opts.notify_warning = ""
         mock_parse.return_value = (opts, "echo hi")
 
-        # Simulate API failure on the start event call
+        # Simulate API failure on the start event call (first Event.create)
         mock_event_create.side_effect = [Exception("Connection refused"), mock.DEFAULT]
 
         main()
 
-        # execute() must still have been called despite the API failure
+        # execute() must still have been called despite the event failure
         mock_execute.assert_called_once()
+
+        # Start metric must still have fired despite the event failure
+        first_metric_call = mock_metric_send.call_args_list[0]
+        self.assertEqual(first_metric_call[1]["metric"], "dogwrap.started")

--- a/tests/unit/dogshell/test_wrap.py
+++ b/tests/unit/dogshell/test_wrap.py
@@ -232,3 +232,89 @@ class TestDogwrapStartSignals(unittest.TestCase):
         sent_tags = started_call[1]["tags"]
         self.assertIn("env:prod", sent_tags)
         self.assertIn("event_name:test-job", sent_tags)
+
+    @mock.patch("sys.exit")
+    @mock.patch("datadog.dogshell.wrap.execute", return_value=(0, b"", b"", 1.0))
+    @mock.patch("datadog.dogshell.wrap.api.Event.create")
+    @mock.patch("datadog.dogshell.wrap.api.Metric.send")
+    @mock.patch("datadog.dogshell.wrap.initialize")
+    @mock.patch("datadog.dogshell.wrap.parse_options")
+    def test_start_signal_failure_does_not_block_execute(
+        self,
+        mock_parse,
+        mock_init,
+        mock_metric_send,
+        mock_event_create,
+        mock_execute,
+        mock_exit,
+    ):
+        """API failure on start signals must not prevent command execution."""
+        opts = mock.Mock()
+        opts.name = "test-job"
+        opts.api_key = "fake-key"
+        opts.site = "datadoghq.com"
+        opts.submit_mode = "all"
+        opts.send_metric = True
+        opts.tags = ""
+        opts.timeout = 60
+        opts.sigterm_timeout = 120
+        opts.sigkill_timeout = 60
+        opts.proc_poll_interval = 0.5
+        opts.buffer_outs = False
+        opts.priority = None
+        opts.warning_codes = None
+        opts.notify_success = ""
+        opts.notify_error = ""
+        opts.notify_warning = ""
+        mock_parse.return_value = (opts, "echo hi")
+
+        # Simulate API failure on the start metric call
+        mock_metric_send.side_effect = [Exception("API timeout"), mock.DEFAULT]
+
+        main()
+
+        # execute() must still have been called despite the API failure
+        mock_execute.assert_called_once()
+
+    @mock.patch("sys.exit")
+    @mock.patch("datadog.dogshell.wrap.execute", return_value=(0, b"", b"", 1.0))
+    @mock.patch("datadog.dogshell.wrap.api.Metric.send")
+    @mock.patch("datadog.dogshell.wrap.api.Event.create")
+    @mock.patch("datadog.dogshell.wrap.initialize")
+    @mock.patch("datadog.dogshell.wrap.parse_options")
+    def test_start_event_failure_does_not_block_execute(
+        self,
+        mock_parse,
+        mock_init,
+        mock_event_create,
+        mock_metric_send,
+        mock_execute,
+        mock_exit,
+    ):
+        """API failure on start event must not prevent command execution."""
+        opts = mock.Mock()
+        opts.name = "test-job"
+        opts.api_key = "fake-key"
+        opts.site = "datadoghq.com"
+        opts.submit_mode = "all"
+        opts.send_metric = False
+        opts.tags = ""
+        opts.timeout = 60
+        opts.sigterm_timeout = 120
+        opts.sigkill_timeout = 60
+        opts.proc_poll_interval = 0.5
+        opts.buffer_outs = False
+        opts.priority = None
+        opts.warning_codes = None
+        opts.notify_success = ""
+        opts.notify_error = ""
+        opts.notify_warning = ""
+        mock_parse.return_value = (opts, "echo hi")
+
+        # Simulate API failure on the start event call
+        mock_event_create.side_effect = [Exception("Connection refused"), mock.DEFAULT]
+
+        main()
+
+        # execute() must still have been called despite the API failure
+        mock_execute.assert_called_once()


### PR DESCRIPTION
### What does this PR do?

Adds start signals to dogwrap so users can monitor cron jobs that were never triggered or failed to run — enabling proper cron monitoring like established tools such as [Dead Man's Snitch](https://deadmanssnitch.com/) and [Cronitor](https://cronitor.io) do, natively within Datadog.

Fixes #933

### Description of the Change

Two start signals are emitted **before** `execute()`, gated on existing flags (no new CLI surface):

1. **`dogwrap.started` gauge metric** (value=1) — fires when `--send_metric` is set
2. **Info start event** — fires when `--submit_mode all` is set

A minor refactor moves `initialize()`, host/site resolution, and tag construction before `execute()` since start signals need the API client ready. These blocks don't depend on execution results.

**Behavior matrix:**

| `--submit_mode` | `--send_metric` | start metric | start event |
|---|---|---|---|
| errors | False | no | no |
| errors | True | yes | no |
| all | False | no | yes |
| all | True | yes | yes |

### Alternate Designs

- **New CLI flag** (e.g. `--emit_start`): Rejected — reusing existing flags keeps the CLI surface unchanged.
- **Single start event only**: A metric is more useful for "no data" monitors, so both are provided.

### Possible Drawbacks

- One extra API call before `execute()` when start signals are enabled. Negligible latency for cron job use cases.

### Verification Process

- 5 new unit tests in `tests/unit/dogshell/test_wrap.py` covering all behavior matrix combinations
- All 12 existing `tests/unit/dogwrap/test_dogwrap.py` tests pass unchanged
- Live-tested all 4 matrix combinations against a Datadog US5 account, confirmed metrics and events arrived correctly

### Additional Notes

No changes to `execute()`, `poll_proc()`, `OutputReader`, `build_event_body()`, `trim_text()`, or `parse_options()`.

### Release Notes

dogwrap now emits a `dogwrap.started` metric and an info start event before command execution, enabling monitoring for cron jobs that fail to start.