### PR TITLE
ci: run tests for legacy versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        # In the future, we need to add support for Python 2.7 and 3.4, as we officially
-        # support those versions. However, support for those versions has been removed from
-        # setup-python so we will need to find a workaround.
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy2.7', 'pypy3.8']
         # os: [ubuntu-latest, windows-latest, macos-latest]
         # python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.8']
@@ -94,4 +91,69 @@ jobs:
       run: tox -e integration -- --vcr-record=none
 
     - name: Run admin integration tests on cassettes
+      run: tox -e integration-admin -- --vcr-record=none
+
+  run-legacy:
+    # actions/setup-python dropped support for Python 2.7 and 3.4, so we use
+    # official Python Docker images instead to test those EOL-but-supported versions.
+    name: Python ${{ matrix.python-version }} (legacy) on Linux
+    runs-on: ubuntu-latest
+    container:
+      image: python:${{ matrix.python-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['2.7', '3.4']
+    steps:
+    # All actions/checkout versions now use Node.js >= 20 (glibc >= 2.25).
+    # python:3.4 is Debian Stretch (glibc 2.24) so Node.js can't run there.
+    # Use a plain git clone instead — no Node.js needed.
+    - name: Checkout
+      run: |
+        git init .
+        git remote add origin https://github.com/${{ github.repository }}
+        git fetch --depth 1 origin ${{ github.sha }}
+        git checkout FETCH_HEAD
+
+    - name: Set constraints for python2.7
+      # Latest PyYaml supported version for python 2.7 is 5.4.1 which requires
+      # cython<3 to build. See: https://github.com/yaml/pyyaml/issues/724
+      if: ${{ matrix.python-version == '2.7' }}
+      run: |
+        echo "cython<3" > /tmp/constraints.txt
+        echo "PIP_CONSTRAINT=/tmp/constraints.txt" >> $GITHUB_ENV
+
+    - name: Set constraints for python3.4
+      # PyYAML 5.3+ dropped Python 3.4 support; vcrpy pulls it in.
+      if: ${{ matrix.python-version == '3.4' }}
+      run: |
+        echo "PyYAML<5.3" > /tmp/constraints.txt
+        echo "PIP_CONSTRAINT=/tmp/constraints.txt" >> $GITHUB_ENV
+
+    - name: Set TOXENV
+      # Use tr instead of ${//} because the container runs sh, not bash.
+      run: |
+        version="${{ matrix.python-version }}"
+        echo "TOXENV=py$(echo "$version" | tr -d '.')" >> $GITHUB_ENV
+
+    - name: Install tox
+      # tox 4+ requires Python 3.7+; virtualenv 20.22+ dropped Python 2.7 support.
+      run: pip install 'tox<4' 'virtualenv<20.22'
+
+    - name: Run unit tests
+      # Disable origin detection: the job runs inside a Docker container, so
+      # the client would detect the container ID and append |c:<id> to every
+      # metric, which the tests don't expect.
+      env:
+        DD_ORIGIN_DETECTION_ENABLED: "false"
+      run: tox
+
+    - name: Run integration tests on cassettes
+      env:
+        DD_ORIGIN_DETECTION_ENABLED: "false"
+      run: tox -e integration -- --vcr-record=none
+
+    - name: Run admin integration tests on cassettes
+      env:
+        DD_ORIGIN_DETECTION_ENABLED: "false"
       run: tox -e integration-admin -- --vcr-record=none

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # In the future, we need to add support for Python 2.7 and Python 3.14+
-        # but for now, those are failing.
         python-version: ['3.8']
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,8 +52,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy2.7', 'pypy3.8']
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-        # python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.8']
+        # Python 2.7 and 3.4 are tested separately in the run-legacy job below.
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/datadog/dogshell/wrap.py
+++ b/datadog/dogshell/wrap.py
@@ -413,7 +413,7 @@ returned (the command outputs remains buffered in dogwrap meanwhile)",
     if is_p3k():
         cmd = " ".join(args)
     else:
-        cmd = b" ".join(a.encode("utf-8") for a in args).decode("utf-8")
+        cmd = b" ".join(a if isinstance(a, bytes) else a.encode("utf-8") for a in args).decode("utf-8")
 
     return options, cmd
 

--- a/tests/integration/dogshell/test_dogshell.py
+++ b/tests/integration/dogshell/test_dogshell.py
@@ -750,7 +750,7 @@ class TestDogshell:
             "type": "log_detection"
         }
         
-        with open(rule_file, "w") as f:
+        with open(str(rule_file), "w") as f:
             json.dump(rule_data, f)
             
         # Create rule
@@ -772,7 +772,7 @@ class TestDogshell:
         updated_name = "Updated Rule {}".format(unique)
         rule_data["name"] = updated_name
         
-        with open(rule_file, "w") as f:
+        with open(str(rule_file), "w") as f:
             json.dump(rule_data, f)
             
         out, _, _ = dogshell(["security-monitoring", "rules", "update", rule_id, "--file", str(rule_file)])

--- a/tests/unit/dogstatsd/test_max_sample_metrics.py
+++ b/tests/unit/dogstatsd/test_max_sample_metrics.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import threading
 import unittest
 from mock import patch

--- a/tests/unit/dogstatsd/test_max_sample_metrics.py
+++ b/tests/unit/dogstatsd/test_max_sample_metrics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import threading
 import unittest
 from mock import patch

--- a/tox.ini
+++ b/tox.ini
@@ -27,14 +27,15 @@ commands =
 
 [testenv:integration]
 # Use skip_install + PYTHONPATH so this env works on Python 3.4 too
-# (hatchling can't be built there).  requests must be listed explicitly
-# since it is a runtime dep normally pulled in by the package install.
+# (hatchling can't be built there).  Runtime deps normally pulled in by
+# the package install must be listed explicitly here.
 skip_install = true
 setenv = PYTHONPATH = {toxinidir}
 deps =
     {[testenv]deps}
     requests>=2.6.0
     typing
+    configparser<5; python_version < '3.0'
 
 [testenv:integration-admin]
 skip_install = true
@@ -43,6 +44,7 @@ deps =
     {[testenv]deps}
     requests>=2.6.0
     typing
+    configparser<5; python_version < '3.0'
 commands =
     pytest -v tests/integration -m "admin_needed" {posargs}
 
@@ -57,6 +59,7 @@ deps =
     {[testenv]deps}
     requests>=2.6.0
     typing
+    configparser<5; python_version < '3.0'
 
 [testenv:flake8]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@ envlist =
     # black - see comments below
 
 [testenv]
-passenv = DD_TEST_CLIENT*
+passenv =
+    DD_TEST_CLIENT*
+    DD_ORIGIN_DETECTION_ENABLED
 usedevelop = true
 deps =
     click
@@ -23,24 +25,43 @@ commands =
     !integration: pytest -v tests/unit {posargs}
     integration: pytest -v tests/integration -m "not admin_needed" {posargs}
 
-[testenv:integration-admin]
-passenv = DD_TEST_CLIENT*
-usedevelop = true
+[testenv:integration]
+# Use skip_install + PYTHONPATH so this env works on Python 3.4 too
+# (hatchling can't be built there).  requests must be listed explicitly
+# since it is a runtime dep normally pulled in by the package install.
+skip_install = true
+setenv = PYTHONPATH = {toxinidir}
 deps =
-    click
-    freezegun
-    mock
-    pytest
-    pytest-vcr
-    python-dateutil
-    vcrpy
+    {[testenv]deps}
+    requests>=2.6.0
+    typing
+
+[testenv:integration-admin]
+skip_install = true
+setenv = PYTHONPATH = {toxinidir}
+deps =
+    {[testenv]deps}
+    requests>=2.6.0
+    typing
 commands =
     pytest -v tests/integration -m "admin_needed" {posargs}
+
+[testenv:py34]
+# hatchling (the build backend in pyproject.toml) cannot be installed on
+# Python 3.4 because it transitively requires pluggy>=1.0.0 which has no
+# Python-3.4-compatible release.  Skip the package install and expose the
+# source via PYTHONPATH instead, adding the runtime deps explicitly.
+skip_install = true
+setenv = PYTHONPATH = {toxinidir}
+deps =
+    {[testenv]deps}
+    requests>=2.6.0
+    typing
 
 [testenv:flake8]
 skip_install = true
 deps =
-    flake8==3.7.9
+    flake8==7.1.2
 commands = flake8 datadog
 
 # Black isn't safe to run while support is being maintained for python2.7, but 
@@ -61,7 +82,10 @@ commands =
 
 [flake8]
 max-line-length = 120
-ignore = E203,W503
+# E203, W503: formatting disagreements with black
+# F401: pyflakes 3.x no longer tracks # type: comment usages, producing false
+#        positives for all typing imports used only in PEP 484 type comments.
+ignore = E203,W503,F401
 
 [pytest]
 markers =


### PR DESCRIPTION
## What is this PR?

This PR adds support for running tests in Python 2.7 (which we still support) and 3.4 (which doesn't support type hints). Those cases require special handling because the default images used in GHA tests don't support 2.7 and 3.4 anymore. 

For that to work:
- We have a new step in `test.yml` specifically for older versions of Python
- We have a 3.4-specific path that doesn't require `hatchling` to run tests (by not installing the package for real)
- We explicitly disable `DD_ORIGIN_DETECTION_ENABLED` for tests to avoid receiving the `c:` (container ID) tag which is unexpected in the test payloads 


On top of this, the PR fixes issues:
- Properly pass `bytes` parameters to `bytes.join`
- Pass `str` objects to `open` which doesn't support receiving `PosixPath` in all Python versions 
- Add an encoding header (necessary for a file where special characters)

