### PR TITLE
ci: add dependabot configuration for pip and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- Schedules weekly Dependabot version-update PRs for the Python project (`pip`, via `pyproject.toml`) and for the pinned actions in `.github/workflows/`
- Remediates GHS3 finding `dependency_version_updates_enabled`
- `open-pull-requests-limit: 10` per ecosystem to avoid PR floods on the first run; can be tuned later

Jira: [AAWF-979](https://datadoghq.atlassian.net/browse/AAWF-979)

## Context

Pairs with enabling **Dependabot security updates** in repo security settings (https://github.com/DataDog/datadogpy/settings/security_analysis), which addresses GHS3 finding `dependabot_security_updates_enabled`. Both are required to fully close the dependabot-related findings from the security baseline scan.

`actions_pinned` already passes (all `uses:` lines pinned to commit SHAs); Dependabot will bump those SHAs while preserving the `# vX.Y.Z` comments.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, confirm Dependabot picks up the config (~10 min) and starts opening update PRs
- [ ] Re-run `github-security-settings-scanner run-checks --repository DataDog/datadogpy --checks dependency-version-updates` and confirm PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)