### PR TITLE
fix(dogstatsd): normalize tags in event() and service_check()

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1687,7 +1687,7 @@ class DogStatsd(object):
         if alert_type:
             string = "%s|t:%s" % (string, alert_type)
         if tags:
-            string = "%s|#%s" % (string, ",".join(tags))
+            string = "%s|#%s" % (string, ",".join(normalize_tags(tags)))
         if self._container_id:
             string = "%s|c:%s" % (string, self._container_id)
         if cardinality:
@@ -1738,7 +1738,7 @@ class DogStatsd(object):
         if hostname:
             string = u"{0}|h:{1}".format(string, hostname)
         if tags:
-            string = u"{0}|#{1}".format(string, ",".join(tags))
+            string = u"{0}|#{1}".format(string, ",".join(normalize_tags(tags)))
         if message:
             string = u"{0}|m:{1}".format(string, message)
         if self._container_id:

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -463,26 +463,26 @@ class TestDogStatsd(unittest.TestCase):
     def test_pipe_in_event_tags(self):
         self.statsd.event('Title', 'msg', tags=['env:prod', 'key:val|injected_field'])
         raw = self.recv(2)
-        assert '|injected_field' not in raw, "pipe in event tag must be replaced with '_'"
-        assert 'key:val_injected_field' in raw
+        self.assertNotIn('|injected_field', raw, "pipe in event tag must be replaced with '_'")
+        self.assertIn('key:val_injected_field', raw)
 
     def test_newline_in_event_tags(self):
         self.statsd.event('Title', 'msg', tags=['env:prod', 'key:val\nfake_metric:1|g'])
         raw = self.recv(2)
-        assert '\nfake_metric:1' not in raw, "newline in event tag must be replaced with '_'"
-        assert 'key:val_fake_metric:1_g' in raw
+        self.assertNotIn('\nfake_metric:1', raw, "newline in event tag must be replaced with '_'")
+        self.assertIn('key:val_fake_metric:1_g', raw)
 
     def test_pipe_in_service_check_tags(self):
         self.statsd.service_check('my.check', self.statsd.OK, tags=['env:prod', 'key:val|h:fake_host'])
         raw = self.recv(2)
-        assert '|h:fake_host' not in raw, "pipe in service_check tag must be replaced with '_'"
-        assert 'key:val_h:fake_host' in raw
+        self.assertNotIn('|h:fake_host', raw, "pipe in service_check tag must be replaced with '_'")
+        self.assertIn('key:val_h:fake_host', raw)
 
     def test_newline_in_service_check_tags(self):
         self.statsd.service_check('my.check', self.statsd.OK, tags=['env:prod', 'key:val\nfake_metric:1|g'])
         raw = self.recv(2)
-        assert '\nfake_metric:1' not in raw, "newline in service_check tag must be replaced with '_'"
-        assert 'key:val_fake_metric:1_g' in raw
+        self.assertNotIn('\nfake_metric:1', raw, "newline in service_check tag must be replaced with '_'")
+        self.assertIn('key:val_fake_metric:1_g', raw)
 
     def test_tagged_gauge(self):
         self.statsd.gauge('gt', 123.4, tags=['country:china', 'age:45', 'blue'])

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -460,6 +460,30 @@ class TestDogStatsd(unittest.TestCase):
         self.statsd.gauge('gt', 123.4, tags=['pipe|in:tag', 'red'])
         self.assert_equal_telemetry('gt:123.4|g|#pipe_in:tag,red\n', self.recv(2))
 
+    def test_pipe_in_event_tags(self):
+        self.statsd.event('Title', 'msg', tags=['env:prod', 'key:val|injected_field'])
+        raw = self.recv(2)
+        assert '|injected_field' not in raw, "pipe in event tag must be replaced with '_'"
+        assert 'key:val_injected_field' in raw
+
+    def test_newline_in_event_tags(self):
+        self.statsd.event('Title', 'msg', tags=['env:prod', 'key:val\nfake_metric:1|g'])
+        raw = self.recv(2)
+        assert '\nfake_metric:1' not in raw, "newline in event tag must be replaced with '_'"
+        assert 'key:val_fake_metric:1_g' in raw
+
+    def test_pipe_in_service_check_tags(self):
+        self.statsd.service_check('my.check', self.statsd.OK, tags=['env:prod', 'key:val|h:fake_host'])
+        raw = self.recv(2)
+        assert '|h:fake_host' not in raw, "pipe in service_check tag must be replaced with '_'"
+        assert 'key:val_h:fake_host' in raw
+
+    def test_newline_in_service_check_tags(self):
+        self.statsd.service_check('my.check', self.statsd.OK, tags=['env:prod', 'key:val\nfake_metric:1|g'])
+        raw = self.recv(2)
+        assert '\nfake_metric:1' not in raw, "newline in service_check tag must be replaced with '_'"
+        assert 'key:val_fake_metric:1_g' in raw
+
     def test_tagged_gauge(self):
         self.statsd.gauge('gt', 123.4, tags=['country:china', 'age:45', 'blue'])
         self.assert_equal_telemetry('gt:123.4|g|#country:china,age:45,blue\n', self.recv(2))


### PR DESCRIPTION
### What does this PR do?

Tags passed to `event()` and `service_check()` were serialized into the DogStatsD wire protocol without calling `normalize_tags()`, leaving `\n` (newline) and `|` (pipe) characters unfiltered. Both are protocol delimiters used by the DogStatsD agent to split packets and fields, so a tag value containing either character can inject additional protocol tokens.

The same issue was already fixed for `_serialize_metric()` in 2020 (commit `11fe1d8`, "Remove illegal characters from tags", relates to #19). This PR extends that fix to the two code paths that were missed.

There is no pre-existing GitHub issue for this specific gap; it was identified during a security review.

### Description of the Change

`normalize_tags()` (already imported in the file) is now called on the user-supplied tag list before joining in both `event()` and `service_check()`, exactly as `_serialize_metric()` already does.

```diff
# event()
- string = "%s|#%s" % (string, ",".join(tags))
+ string = "%s|#%s" % (string, ",".join(normalize_tags(tags)))

# service_check()
- string = u"{0}|#{1}".format(string, ",".join(tags))
+ string = u"{0}|#{1}".format(string, ",".join(normalize_tags(tags)))
```

`normalize_tags` replaces any character outside `[word chars, digits, _, -, :, /, .]` with `_`, so `\n` → `_` and `|` → `_`.

### Alternate Designs

- **Raise an exception on invalid characters** — rejected; would be a breaking change for callers that currently pass tags with spaces or other non-ASCII characters that are silently normalised today.
- **Strip the offending characters entirely** — the existing `normalize_tags` replaces with `_` to preserve tag structure; changing that would be a separate, larger decision.

### Possible Drawbacks

- Tag values that previously contained `|` or `\n` will now appear with `_` in those positions inside Datadog. This is a correctness fix: the previous behaviour was silently malformed on the wire. Any dashboard/alert that matched on a tag containing a literal `|` or `\n` would have been matching against accidental protocol injection rather than a real tag value.

### Verification Process

Ran the new regression tests and the full existing `event` / `service_check` test suite locally:

```
pytest tests/unit/dogstatsd/test_statsd.py -k "event or service_check" -v
# 13 passed, 0 failed
```

Four new tests were added alongside the existing `test_pipe_in_tags` (which covers `_serialize_metric`):

| Test | What it checks |
|---|---|
| `test_pipe_in_event_tags` | `\|` in event tag → replaced with `_`, not treated as field delimiter |
| `test_newline_in_event_tags` | `\n` in event tag → replaced with `_`, not treated as packet delimiter |
| `test_pipe_in_service_check_tags` | `\|` in service_check tag → replaced with `_` |
| `test_newline_in_service_check_tags` | `\n` in service_check tag → replaced with `_` |

### Additional Notes

The `hostname`, `aggregation_key`, `source_type_name`, `priority`, and `alert_type` parameters of `event()`, and `check_name` / `hostname` of `service_check()`, are also currently unsanitized. A newline in any of those would similarly inject content. Those fields are far less commonly populated from external input than tags, and fixing them is a slightly larger change; left for a follow-up if desired.

### Release Notes

Tags containing `|` or `\n` passed to `statsd.event()` and `statsd.service_check()` are now sanitized (special characters replaced with `_`), consistent with the existing behaviour of all metric methods.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.