### PR TITLE
ci: remove setup-python action blocked by enterprise policy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,8 @@ jobs:
 
       - name: Install datadog_checks_dev
         run: |
-          python -m pip install datadog_checks_dev[cli]==20.0.1
+          python3 -m venv .venv
+          .venv/bin/pip install datadog_checks_dev[cli]==20.0.1
 
       # Publish wheels to PyPI using Trusted Publishers.
       # https://docs.pypi.org/trusted-publishers/using-a-publisher/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,11 +24,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install datadog_checks_dev
-        run: |
-          python3 -m venv .venv
-          .venv/bin/pip install datadog_checks_dev[cli]==20.0.1
-
       # Publish wheels to PyPI using Trusted Publishers.
       # https://docs.pypi.org/trusted-publishers/using-a-publisher/
       # This job needs to run from within the pypi-datadog-checks-base environment. PyPi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Build distributions
+        run: |
+          python3 -m venv .venv
+          .venv/bin/pip install build
+          .venv/bin/python -m build
+
       # Publish wheels to PyPI using Trusted Publishers.
       # https://docs.pypi.org/trusted-publishers/using-a-publisher/
       # This job needs to run from within the pypi-datadog-checks-base environment. PyPi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,11 +24,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
-        name: Install Python
-        with:
-          python-version: '3.9'
-
       - name: Install datadog_checks_dev
         run: |
           python -m pip install datadog_checks_dev[cli]==20.0.1


### PR DESCRIPTION
## Problem

The `v0.52.2` release CI job was failing with:

> The action `actions/setup-python@v5` is not allowed in DataDog/datadogpy because all actions must be from a repository owned by your enterprise, created by GitHub, or match the pattern: `pypa/gh-action-pypi-publish@*`.

The workflow's pinned SHA (`e9aba2c848f5ebd159c070c61ea2c4e2b122355e`) has a stale comment of `# v2.3.4` but actually resolves to `setup-python@v5`, which is blocked by the enterprise action policy.


## Fix

Remove the `setup-python` step entirely. Ubuntu runners already ship with Python, so this step is unnecessary.

A couple of extra fixes from #912 which changed the release to use the `gh-action-pypi-publish` action are needed:
1. We don't need to install `datadog_checks_dev`. That job is removed. 
2. We need to build the package prior to release first.


## Test plan

- [ ] Merge and re-publish the `v0.52.2` release to confirm the Build job passes