### PR TITLE
Add DD_DOGSTATSD_URL support for unix and udp urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ options = {
 initialize(**options)
 ```
 
+Alternatively, the environment variable `DD_DOGSTATSD_URL` can be used to define a UDP connection:
+`DD_DOGSTATSD_URL=udp://localhost:8125`
+
+Manually supplying a host/port takes precedence over this environment variable.
+
 See the full list of available [DogStatsD client instantiation parameters](https://docs.datadoghq.com/developers/dogstatsd/?code-lang=python#client-instantiation-parameters).
 
 #### Instantiate the DogStatsd client with UDS
@@ -109,6 +114,11 @@ options = {
 
 initialize(**options)
 ```
+
+Alternatively, the environment variable `DD_DOGSTATSD_URL` can be used to define a UDS connection:
+`DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket`
+
+As with the UDP variant, manually supplying a `statsd_socket_path` takes precedence over this environment variable.
 
 #### Origin detection over UDP and UDS
 

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -21,6 +21,7 @@ if sys.version_info[0] >= 3:
 # datadog
 from datadog import api
 from datadog.dogstatsd import DogStatsd, statsd  # noqa
+from datadog.dogstatsd.base import DEFAULT_HOST, DEFAULT_PORT
 from datadog.threadstats import ThreadStats, datadog_lambda_wrapper, lambda_metric  # noqa
 from datadog.util.compat import iteritems, NullHandler, text
 from datadog.util.hostname import get_hostname
@@ -152,6 +153,12 @@ def initialize(
         # UDS and the manual host/port override is silently ignored.
         if statsd_host or statsd_use_default_route or statsd_port:
             statsd.socket_path = None
+            # The client may have been UDS-configured (host/port None). Backfill any
+            # side not supplied here so the UDP socket has a valid host and port.
+            if statsd.host is None:
+                statsd.host = DEFAULT_HOST
+            if statsd.port is None:
+                statsd.port = DEFAULT_PORT
     statsd.close_socket()
     if statsd_namespace:
         statsd.namespace = text(statsd_namespace)

--- a/datadog/__init__.py
+++ b/datadog/__init__.py
@@ -147,6 +147,11 @@ def initialize(
             statsd.host = statsd.resolve_host(statsd_host, statsd_use_default_route)
         if statsd_port:
             statsd.port = int(statsd_port)
+        # Selecting a UDP destination must clear any socket path (e.g. one inherited
+        # from DD_DOGSTATSD_URL=unix://...), otherwise get_socket() keeps using the
+        # UDS and the manual host/port override is silently ignored.
+        if statsd_host or statsd_use_default_route or statsd_port:
+            statsd.socket_path = None
     statsd.close_socket()
     if statsd_namespace:
         statsd.namespace = text(statsd_namespace)

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -32,7 +32,7 @@ except ImportError:
 
 # pylint: disable=unused-import
 if sys.version_info[:2] >= (3, 5):
-    from typing import Any, Optional, List, Text, Type, Union, Iterable, Callable, overload  # noqa: F401
+    from typing import Any, Optional, List, Text, Tuple, Type, Union, Iterable, Callable, overload  # noqa: F401
 
 try:
     from typing import SupportsIndex
@@ -49,7 +49,7 @@ from datadog.dogstatsd.context import (
 )
 from datadog.dogstatsd.route import get_default_route
 from datadog.dogstatsd.container import Cgroup
-from datadog.util.compat import text
+from datadog.util.compat import text, urlparse
 from datadog.util.format import normalize_tags, validate_cardinality
 from datadog.version import __version__
 
@@ -265,8 +265,8 @@ class DogStatsd(object):
 
     def __init__(
         self,
-        host=DEFAULT_HOST,                      # type: Text
-        port=DEFAULT_PORT,                      # type: int
+        host=None,                              # type: Optional[Text]
+        port=None,                              # type: Optional[int]
         max_buffer_size=None,                   # type: Optional[int]
         flush_interval=DEFAULT_BUFFERING_FLUSH_INTERVAL,  # type: float
         disable_aggregation=True,               # type: bool
@@ -299,12 +299,20 @@ class DogStatsd(object):
 
         >>> statsd = DogStatsd()
 
+        :envvar DD_DOGSTATSD_URL: the connection information for the DogStatsd server.
+        If set, and no connection was provided explicitly, it takes precedence over
+        DD_AGENT_HOST / DD_DOGSTATSD_PORT.
+        Example for a UDP url: `DD_DOGSTATSD_URL=udp://localhost:8125`
+        Example for a UDS url: `DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket`
+        Windows named pipes are currently unsupported.
+        :type DD_DOGSTATSD_URL: string
+
         :envvar DD_AGENT_HOST: the host of the DogStatsd server.
-        If set, it overrides default value.
+        If set, it overrides default value. DD_DOGSTATSD_URL takes precedence over this value.
         :type DD_AGENT_HOST: string
 
         :envvar DD_DOGSTATSD_PORT: the port of the DogStatsd server.
-        If set, it overrides default value.
+        If set, it overrides default value. DD_DOGSTATSD_URL takes precedence over this value.
         :type DD_DOGSTATSD_PORT: integer
 
         :envvar DATADOG_TAGS: Tags to attach to every metric reported by dogstatsd client.
@@ -485,22 +493,17 @@ class DogStatsd(object):
         # Check for deprecated option
         if max_buffer_size is not None:
             log.warning("The parameter max_buffer_size is now deprecated and is not used anymore")
-        # Check host and port env vars
-        agent_host = os.environ.get("DD_AGENT_HOST")
-        if agent_host and host == DEFAULT_HOST:
-            host = agent_host
+        # Resolve host/port/socket from env vars when not set explicitly. An
+        # explicit constructor argument always wins over any environment variable.
+        host, port, socket_path = self._parse_env_connection_overrides(host, port, socket_path)
 
-        dogstatsd_port = os.environ.get("DD_DOGSTATSD_PORT")
-        if dogstatsd_port and port == DEFAULT_PORT:
-            try:
-                port = int(dogstatsd_port)
-            except ValueError:
-                log.warning(
-                    "Port number provided in DD_DOGSTATSD_PORT env var is not an integer: \
-                %s, using %s as port number",
-                    dogstatsd_port,
-                    port,
-                )
+        # Apply the hard-coded defaults last, once env resolution is done. When a
+        # socket transport is selected these are ignored (host/port become None
+        # below), but resolving them keeps `port` a concrete int for telemetry.
+        if host is None:
+            host = DEFAULT_HOST
+        if port is None:
+            port = DEFAULT_PORT
 
         # Assuming environment variables always override
         telemetry_host = os.environ.get("DD_TELEMETRY_HOST", telemetry_host)
@@ -729,6 +732,65 @@ class DogStatsd(object):
     def enable_telemetry(self):
         # type: () -> None
         self._telemetry = True
+
+    @staticmethod
+    def _parse_env_connection_overrides(host, port, socket_path):
+        # type: (Optional[Text], Optional[int], Optional[Text]) -> Tuple[Optional[Text], Optional[int], Optional[Text]]
+        """
+        Resolve the connection host/port/socket_path from environment variables,
+        without overriding values already provided explicitly to the constructor.
+
+        DD_DOGSTATSD_URL takes precedence over DD_AGENT_HOST / DD_DOGSTATSD_PORT and
+        is only honored when no connection information was passed explicitly. It
+        supports 'udp://host:port' and 'unix:///path/to/socket' URLs.
+        """
+        dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL")
+        if host is None and port is None and socket_path is None and dogstatsd_url is not None:
+            parsed = urlparse(dogstatsd_url)
+            if parsed.scheme == "unix":
+                # The scheme is stripped later by _get_uds_socket, so the full URL
+                # is stored as the socket path (this also preserves unixgram/unixstream).
+                log.debug("DD_DOGSTATSD_URL %r resolved to a unix socket path.", dogstatsd_url)
+                return None, None, dogstatsd_url
+            elif parsed.scheme == "udp":
+                try:
+                    url_port = parsed.port
+                    # Python 2's urlparse does not bounds-check the port.
+                    if url_port is None or url_port < 0 or url_port > 65535:
+                        log.warning(
+                            "DD_DOGSTATSD_URL %r had no or invalid port number, reverting to default %s",
+                            dogstatsd_url, DEFAULT_PORT,
+                        )
+                        url_port = DEFAULT_PORT
+                except ValueError as e:
+                    log.warning(
+                        "DD_DOGSTATSD_URL %r contained an invalid port number, falling back to %d: %s",
+                        dogstatsd_url, DEFAULT_PORT, e,
+                    )
+                    url_port = DEFAULT_PORT
+                return parsed.hostname, url_port, socket_path
+            else:
+                log.warning(
+                    "DD_DOGSTATSD_URL %r had unsupported scheme %r, must be one of 'unix://', 'udp://'",
+                    dogstatsd_url, parsed.scheme,
+                )
+
+        # Fall back to the legacy per-field env vars (only when the arg is unset).
+        agent_host = os.environ.get("DD_AGENT_HOST")
+        if agent_host and host is None:
+            host = agent_host
+
+        dogstatsd_port = os.environ.get("DD_DOGSTATSD_PORT")
+        if dogstatsd_port and port is None:
+            try:
+                port = int(dogstatsd_port)
+            except ValueError:
+                log.warning(
+                    "DD_DOGSTATSD_PORT value %r is not an integer, falling back to default",
+                    dogstatsd_port,
+                )
+
+        return host, port, socket_path
 
     # Note: Invocations of this method should be thread-safe
     def _start_flush_thread(self):

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -747,9 +747,10 @@ class DogStatsd(object):
         dogstatsd_url = os.environ.get("DD_DOGSTATSD_URL")
         if host is None and port is None and socket_path is None and dogstatsd_url is not None:
             parsed = urlparse(dogstatsd_url)
-            if parsed.scheme == "unix":
-                # The scheme is stripped later by _get_uds_socket, so the full URL
-                # is stored as the socket path (this also preserves unixgram/unixstream).
+            if parsed.scheme in ("unix", "unixstream", "unixgram"):
+                # The scheme is stripped later by _get_uds_socket (which also uses it
+                # to pick the SOCK_STREAM/SOCK_DGRAM kind), so the full URL is stored
+                # as the socket path.
                 log.debug("DD_DOGSTATSD_URL %r resolved to a unix socket path.", dogstatsd_url)
                 return None, None, dogstatsd_url
             elif parsed.scheme == "udp":
@@ -771,7 +772,8 @@ class DogStatsd(object):
                 return parsed.hostname, url_port, socket_path
             else:
                 log.warning(
-                    "DD_DOGSTATSD_URL %r had unsupported scheme %r, must be one of 'unix://', 'udp://'",
+                    "DD_DOGSTATSD_URL %r had unsupported scheme %r, must be one of "
+                    "'udp://', 'unix://', 'unixstream://', 'unixgram://'",
                     dogstatsd_url, parsed.scheme,
                 )
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -40,6 +40,16 @@ Here's an example where the statsd host and port are configured as well::
     )
 
 
+If ``statsd_host`` and ``statsd_port`` are left at their default values and no
+``statsd_socket_path`` is supplied, the ``DD_DOGSTATSD_URL`` environment variable,
+if set, is used to determine the connection information. It must be a URL starting
+with either ``udp://`` (to connect over UDP) or ``unix://`` (to use a Unix Domain
+Socket).
+
+* Example for a UDP url: ``DD_DOGSTATSD_URL=udp://localhost:8125``
+* Example for a UDS url: ``DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket``
+
+
 .. autofunction:: datadog.initialize
 
 

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -30,7 +30,7 @@ import pytest
 # Datadog libraries
 from datadog import initialize, statsd
 from datadog import __version__ as version
-from datadog.dogstatsd.base import DEFAULT_BUFFERING_FLUSH_INTERVAL, DogStatsd, MIN_SEND_BUFFER_SIZE, UDP_OPTIMAL_PAYLOAD_LENGTH, UDS_OPTIMAL_PAYLOAD_LENGTH
+from datadog.dogstatsd.base import DEFAULT_BUFFERING_FLUSH_INTERVAL, DEFAULT_HOST, DEFAULT_PORT, DogStatsd, MIN_SEND_BUFFER_SIZE, UDP_OPTIMAL_PAYLOAD_LENGTH, UDS_OPTIMAL_PAYLOAD_LENGTH
 from datadog.dogstatsd.context import TimedContextManagerDecorator
 from datadog.util.compat import is_higher_py35, is_p3k
 from tests.util.contextmanagers import preserve_environment_variable, EnvVars
@@ -296,21 +296,86 @@ class TestDogStatsd(unittest.TestCase):
         initialize(**options)
         self.assertEqual(statsd.cardinality, 'none')
 
-    def test_dogstatsd_initialization_with_env_vars(self):
+    def test_dogstatsd_initialization_with_env_vars_agent_host(self):
         """
-        Dogstatsd can retrieve its config from env vars when
-        not provided in constructor.
+        Dogstatsd can retrieve its config from DD_AGENT_HOST / DD_DOGSTATSD_PORT
+        env vars when not provided in the constructor.
         """
-        # Setup
-        with preserve_environment_variable('DD_AGENT_HOST'):
-            os.environ['DD_AGENT_HOST'] = 'myenvvarhost'
-            with preserve_environment_variable('DD_DOGSTATSD_PORT'):
-                os.environ['DD_DOGSTATSD_PORT'] = '4321'
-                dogstatsd = DogStatsd()
-
-        # Assert
+        with EnvVars(env_vars={'DD_AGENT_HOST': 'myenvvarhost', 'DD_DOGSTATSD_PORT': '4321'}):
+            dogstatsd = DogStatsd()
         self.assertEqual(dogstatsd.host, "myenvvarhost")
         self.assertEqual(dogstatsd.port, 4321)
+
+    def test_dogstatsd_initialization_with_env_vars_dogstatsd_url(self):
+        """
+        Dogstatsd can retrieve its config from the DD_DOGSTATSD_URL env var, but
+        an explicit constructor argument always takes precedence over it.
+        """
+        # UDP url
+        with EnvVars(env_vars={'DD_DOGSTATSD_URL': 'udp://myenvvarhost:4321'}):
+            dogstatsd = DogStatsd()
+        self.assertEqual(dogstatsd.host, "myenvvarhost")
+        self.assertEqual(dogstatsd.port, 4321)
+        self.assertIsNone(dogstatsd.socket_path)
+
+        # UDS url: the full url is stored as the socket path
+        with EnvVars(env_vars={'DD_DOGSTATSD_URL': 'unix:///hello/world.sock'}):
+            dogstatsd = DogStatsd()
+        self.assertEqual(dogstatsd.socket_path, 'unix:///hello/world.sock')
+        self.assertIsNone(dogstatsd.host)
+        self.assertIsNone(dogstatsd.port)
+
+        # Explicit host wins over the url
+        with EnvVars(env_vars={'DD_DOGSTATSD_URL': 'unix:///hello/world.sock'}):
+            dogstatsd = DogStatsd(host="myhost")
+        self.assertIsNone(dogstatsd.socket_path)
+        self.assertEqual(dogstatsd.host, 'myhost')
+        self.assertEqual(dogstatsd.port, DEFAULT_PORT)
+
+        # Explicit port wins over the url
+        with EnvVars(env_vars={'DD_DOGSTATSD_URL': 'unix:///hello/world.sock'}):
+            dogstatsd = DogStatsd(port=8240)
+        self.assertIsNone(dogstatsd.socket_path)
+        self.assertEqual(dogstatsd.host, DEFAULT_HOST)
+        self.assertEqual(dogstatsd.port, 8240)
+
+        # Explicit socket_path wins over the url
+        with EnvVars(env_vars={'DD_DOGSTATSD_URL': 'unix:///hello/world.sock'}):
+            dogstatsd = DogStatsd(socket_path='/var/run/datadog/dsd.sock')
+        self.assertEqual(dogstatsd.socket_path, '/var/run/datadog/dsd.sock')
+        self.assertIsNone(dogstatsd.host)
+        self.assertIsNone(dogstatsd.port)
+
+        # An explicit default host is NOT clobbered by the url
+        with EnvVars(env_vars={'DD_DOGSTATSD_URL': 'udp://other:9999'}):
+            dogstatsd = DogStatsd(host=DEFAULT_HOST)
+        self.assertEqual(dogstatsd.host, DEFAULT_HOST)
+        self.assertEqual(dogstatsd.port, DEFAULT_PORT)
+        self.assertIsNone(dogstatsd.socket_path)
+
+        # Unsupported scheme falls back to defaults without raising
+        with EnvVars(env_vars={'DD_DOGSTATSD_URL': 'http://myenvvarhost:4321'}):
+            dogstatsd = DogStatsd()
+        self.assertEqual(dogstatsd.host, DEFAULT_HOST)
+        self.assertEqual(dogstatsd.port, DEFAULT_PORT)
+        self.assertIsNone(dogstatsd.socket_path)
+
+        # A UDP url without a port falls back to the default port
+        with EnvVars(env_vars={'DD_DOGSTATSD_URL': 'udp://myenvvarhost'}):
+            dogstatsd = DogStatsd()
+        self.assertEqual(dogstatsd.host, "myenvvarhost")
+        self.assertEqual(dogstatsd.port, DEFAULT_PORT)
+        self.assertIsNone(dogstatsd.socket_path)
+
+        # DD_DOGSTATSD_URL takes precedence over DD_AGENT_HOST / DD_DOGSTATSD_PORT
+        with EnvVars(env_vars={
+            'DD_DOGSTATSD_URL': 'udp://urlhost:1111',
+            'DD_AGENT_HOST': 'legacyhost',
+            'DD_DOGSTATSD_PORT': '2222',
+        }):
+            dogstatsd = DogStatsd()
+        self.assertEqual(dogstatsd.host, "urlhost")
+        self.assertEqual(dogstatsd.port, 1111)
 
     def test_initialization_closes_socket(self):
         statsd.socket = FakeSocket()

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -296,6 +296,26 @@ class TestDogStatsd(unittest.TestCase):
         initialize(**options)
         self.assertEqual(statsd.cardinality, 'none')
 
+    def test_initialization_udp_clears_socket_path(self):
+        """
+        Selecting a UDP destination via `initialize` clears a previously set
+        socket_path (e.g. one inherited from DD_DOGSTATSD_URL=unix://...), so the
+        manual host/port override is not silently ignored by get_socket().
+        """
+        original_socket_path = statsd.socket_path
+        try:
+            # Simulate a client that picked up a UDS from DD_DOGSTATSD_URL.
+            initialize(statsd_socket_path='/var/run/datadog/dsd.socket')
+            self.assertEqual(statsd.socket_path, '/var/run/datadog/dsd.socket')
+
+            # A manual UDP override must win: socket_path cleared, host/port set.
+            initialize(statsd_host='myhost', statsd_port=1234)
+            self.assertIsNone(statsd.socket_path)
+            self.assertEqual(statsd.host, 'myhost')
+            self.assertEqual(statsd.port, 1234)
+        finally:
+            statsd.socket_path = original_socket_path
+
     def test_dogstatsd_initialization_with_env_vars_agent_host(self):
         """
         Dogstatsd can retrieve its config from DD_AGENT_HOST / DD_DOGSTATSD_PORT
@@ -324,6 +344,14 @@ class TestDogStatsd(unittest.TestCase):
         self.assertEqual(dogstatsd.socket_path, 'unix:///hello/world.sock')
         self.assertIsNone(dogstatsd.host)
         self.assertIsNone(dogstatsd.port)
+
+        # The unixstream:// and unixgram:// schemes are UDS too
+        for uds_url in ('unixstream:///hello/world.sock', 'unixgram:///hello/world.sock'):
+            with EnvVars(env_vars={'DD_DOGSTATSD_URL': uds_url}):
+                dogstatsd = DogStatsd()
+            self.assertEqual(dogstatsd.socket_path, uds_url)
+            self.assertIsNone(dogstatsd.host)
+            self.assertIsNone(dogstatsd.port)
 
         # Explicit host wins over the url
         with EnvVars(env_vars={'DD_DOGSTATSD_URL': 'unix:///hello/world.sock'}):

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -313,6 +313,21 @@ class TestDogStatsd(unittest.TestCase):
             self.assertIsNone(statsd.socket_path)
             self.assertEqual(statsd.host, 'myhost')
             self.assertEqual(statsd.port, 1234)
+
+            # host-only override on a UDS-configured client backfills the default port
+            # (the client had port=None), so the UDP socket is valid.
+            initialize(statsd_socket_path='/var/run/datadog/dsd.socket')
+            initialize(statsd_host='hostonly')
+            self.assertIsNone(statsd.socket_path)
+            self.assertEqual(statsd.host, 'hostonly')
+            self.assertEqual(statsd.port, DEFAULT_PORT)
+
+            # port-only override likewise backfills the default host
+            initialize(statsd_socket_path='/var/run/datadog/dsd.socket')
+            initialize(statsd_port=9999)
+            self.assertIsNone(statsd.socket_path)
+            self.assertEqual(statsd.host, DEFAULT_HOST)
+            self.assertEqual(statsd.port, 9999)
         finally:
             statsd.socket_path = original_socket_path
 


### PR DESCRIPTION
### Description of the Change

Reads the standard `DD_DOGSTATSD_URL` environment variable to configure the DogStatsd connection, matching the other Datadog dogstatsd libraries and the Datadog Kubernetes operator (which mounts a UDS and sets `DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket`).

Supported schemes:
- `udp://host:port` → resolves to host/port
- `unix:///path/to/socket` → resolves to `socket_path` (the full url is stored; `_get_uds_socket` already strips the scheme, so `unixgram://`/`unixstream://` distinctions are preserved). Windows named pipes are not supported.

`host`/`port` are now `Optional` (`None` sentinels). This makes an explicit connection argument (e.g. `DogStatsd(host="localhost")`) distinguishable from the default, so it is never silently overridden by an environment variable. Precedence: **explicit arg > `DD_DOGSTATSD_URL` > `DD_AGENT_HOST`/`DD_DOGSTATSD_PORT` > hard-coded default.**

This revives #870 with the review feedback applied: reuses the existing `datadog.util.compat.urlparse` (py2/py3) shim instead of a duplicate import, drops the unused Windows-named-pipe constant, upgrades the unsupported-scheme / invalid-port messages to `warning` with the offending value, and uses `None` sentinels to fix the explicit-default-precedence concern.

### Verification Process

New unit tests in `tests/unit/dogstatsd/test_statsd.py` cover udp and unix urls, explicit-arg precedence (including the `DogStatsd(host="localhost")` regression case), unsupported schemes, a portless udp url, and url-vs-legacy-env precedence. `pytest tests/unit/dogstatsd/test_statsd.py`, `flake8`, and `mypy` all pass.

### Release Notes

`DogStatsd` now honors the standard `DD_DOGSTATSD_URL` environment variable (`udp://` and `unix://`).

Fixes #805
