### PR TITLE
Retry the connection if a socket error is because the server went away.

### DIFF
--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -183,6 +183,16 @@ DEFAULT_SOCKET_CONNECT_TIMEOUT = 0
 UDS_CONNECT_RETRY_INITIAL_BACKOFF = 0.025
 UDS_CONNECT_RETRY_MAX_BACKOFF = 1.0
 UDS_TRANSIENT_CONNECT_ERRORS = set([errno.ENOENT, errno.ECONNREFUSED])
+# Errors seen while sending on an already-connected socket that indicate the
+# peer went away (e.g. the agent crashed/restarted). These are worth a single
+# reconnect-and-resend attempt instead of dropping the packet outright.
+UDS_TRANSIENT_SEND_ERRORS = set([
+    errno.ECONNREFUSED,
+    errno.ECONNRESET,
+    errno.ENOTCONN,
+    errno.EPIPE,
+    errno.ENOENT,
+])
 
 # Mapping of each "DD_" prefixed environment variable to a specific tag name
 DD_ENV_TAGS_MAPPING = {
@@ -1647,6 +1657,10 @@ class DogStatsd(object):
 
     def _xmit_packet(self, packet, is_telemetry):
         # type: (str, bool) -> bool
+        return self._xmit_packet_attempt(packet, is_telemetry, retry_on_conn_error=True)
+
+    def _xmit_packet_attempt(self, packet, is_telemetry, retry_on_conn_error):
+        # type: (str, bool, bool) -> bool
         socket_kind = None
         try:
             if is_telemetry and self._dedicated_telemetry_destination():
@@ -1689,6 +1703,12 @@ class DogStatsd(object):
                     "Packet size too big (size: %d): %s, dropping the packet",
                     len(packet.encode(self.encoding)),
                     socket_err)
+            elif retry_on_conn_error and socket_err.errno in UDS_TRANSIENT_SEND_ERRORS:
+                log.debug(
+                    "Connection error submitting packet: %s, reconnecting and retrying", socket_err
+                )
+                self.close_socket()
+                return self._xmit_packet_attempt(packet, is_telemetry, retry_on_conn_error=False)
             else:
                 log.warning(
                     "Error submitting packet: %s, dropping the packet and closing the socket",

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1657,11 +1657,44 @@ class DogStatsd(object):
 
     def _xmit_packet(self, packet, is_telemetry):
         # type: (str, bool) -> bool
-        retry_on_conn_error = bool(self.socket_connect_timeout and self.socket_connect_timeout > 0)
-        return self._xmit_packet_attempt(packet, is_telemetry, retry_on_conn_error=retry_on_conn_error)
+        retry_deadline = None
+        if self.socket_connect_timeout and self.socket_connect_timeout > 0:
+            retry_deadline = time.time() + self.socket_connect_timeout
 
-    def _xmit_packet_attempt(self, packet, is_telemetry, retry_on_conn_error):
-        # type: (str, bool, bool) -> bool
+        backoff = UDS_CONNECT_RETRY_INITIAL_BACKOFF
+        while True:
+            sent = self._xmit_packet_attempt(packet, is_telemetry, retry_eligible=retry_deadline is not None)
+            if sent:
+                return True
+            # `sent` is False for a definitive failure (already logged/dropped
+            # above), or None for a transient one that's worth reconnecting
+            # and retrying, bounded by socket_connect_timeout.
+            if sent is not None:
+                break
+            remaining = retry_deadline - time.time()
+            if remaining <= 0:
+                log.warning(
+                    "Gave up reconnecting after socket_connect_timeout (%ss), dropping the packet",
+                    self.socket_connect_timeout,
+                )
+                break
+            time.sleep(min(backoff, remaining))
+            backoff = min(backoff * 2, UDS_CONNECT_RETRY_MAX_BACKOFF)
+
+        if not is_telemetry and self._telemetry:
+            self.bytes_dropped_writer += len(packet)
+            self.packets_dropped_writer += 1
+        return False
+
+    def _xmit_packet_attempt(self, packet, is_telemetry, retry_eligible):
+        # type: (str, bool, bool) -> Optional[bool]
+        """
+        Attempt to send a single packet.
+
+        Returns True if the packet was sent, False if it should be dropped
+        without retrying, or None if the failure is transient (the peer went
+        away), `retry_eligible` is set, and it's worth a reconnect-and-retry.
+        """
         socket_kind = None
         try:
             if is_telemetry and self._dedicated_telemetry_destination():
@@ -1687,13 +1720,14 @@ class DogStatsd(object):
             return True
         except socket.timeout:
             # dogstatsd is overflowing, drop the packets (mimics the UDP behaviour)
-            pass
+            return False
         except (socket.herror, socket.gaierror) as socket_err:
             log.warning(
                 "Error submitting packet: %s, dropping the packet and closing the socket",
                 socket_err,
             )
             self.close_socket()
+            return False
         except socket.error as socket_err:
             if socket_err.errno == errno.EAGAIN:
                 log.debug("Socket send would block: %s, dropping the packet", socket_err)
@@ -1704,24 +1738,22 @@ class DogStatsd(object):
                     "Packet size too big (size: %d): %s, dropping the packet",
                     len(packet.encode(self.encoding)),
                     socket_err)
-            elif retry_on_conn_error and socket_err.errno in UDS_TRANSIENT_SEND_ERRORS:
+            elif retry_eligible and socket_err.errno in UDS_TRANSIENT_SEND_ERRORS:
                 log.debug(
                     "Connection error submitting packet: %s, reconnecting and retrying", socket_err
                 )
                 self.close_socket()
-                return self._xmit_packet_attempt(packet, is_telemetry, retry_on_conn_error=False)
+                return None
             else:
                 log.warning(
                     "Error submitting packet: %s, dropping the packet and closing the socket",
                     socket_err,
                 )
                 self.close_socket()
+            return False
         except Exception as exc:
             log.error("Unexpected error: %s", str(exc))
-
-        if not is_telemetry and self._telemetry:
-            self.bytes_dropped_writer += len(packet)
-            self.packets_dropped_writer += 1
+            return False
 
         # if in stream mode we need to shut down the socket; we can't recover from a
         # partial send

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1680,7 +1680,14 @@ class DogStatsd(object):
             # getting a fresh full socket_connect_timeout allowance each time.
             connect_timeout = self.socket_connect_timeout
             if retry_deadline is not None:
-                connect_timeout = max(0, retry_deadline - time.time())
+                connect_timeout = retry_deadline - time.time()
+                if connect_timeout <= 0:
+                    # The deadline already elapsed.
+                    log.warning(
+                        "Gave up reconnecting after socket_connect_timeout (%ss), dropping the packet",
+                        self.socket_connect_timeout,
+                    )
+                    break
             sent = self._xmit_packet_attempt(
                 packet, is_telemetry, retry_eligible=retry_deadline is not None, connect_timeout=connect_timeout
             )

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -17,7 +17,7 @@ import struct
 import sys
 import threading
 import time
-from threading import Lock, RLock
+from threading import RLock
 import weakref
 
 if sys.version_info[:2] >= (3, 5):
@@ -508,7 +508,9 @@ class DogStatsd(object):
         :type track_instance: boolean
         """
 
-        self._socket_lock = Lock()
+        # RLock: _xmit_packet_attempt holds this across get_socket()/close_socket()
+        # calls, which also take it themselves.
+        self._socket_lock = RLock()
 
         # Check for deprecated option
         if max_buffer_size is not None:
@@ -1697,21 +1699,24 @@ class DogStatsd(object):
         """
         socket_kind = None
         try:
-            if is_telemetry and self._dedicated_telemetry_destination():
-                mysocket = self.telemetry_socket or self.get_socket(telemetry=True)
-                socket_kind = self._telemetry_socket_kind
-            else:
-                # If set, use socket directly
-                mysocket = self.socket or self.get_socket()
-                socket_kind = self._socket_kind
+            # Held across the fetch-and-send so a concurrent close_socket() (e.g.
+            # from another thread's failed send) can't close the fd out from
+            # under a send that's already in flight (which raises EBADF).
+            with self._socket_lock:
+                if is_telemetry and self._dedicated_telemetry_destination():
+                    mysocket = self.telemetry_socket or self.get_socket(telemetry=True)
+                    socket_kind = self._telemetry_socket_kind
+                else:
+                    # If set, use socket directly
+                    mysocket = self.socket or self.get_socket()
+                    socket_kind = self._socket_kind
 
-            encoded_packet = packet.encode(self.encoding)
-            if socket_kind == socket.SOCK_STREAM:
-                with self._socket_lock:
+                encoded_packet = packet.encode(self.encoding)
+                if socket_kind == socket.SOCK_STREAM:
                     mysocket.sendall(struct.pack('<I', len(encoded_packet)))
                     mysocket.sendall(encoded_packet)
-            else:
-                mysocket.send(encoded_packet)
+                else:
+                    mysocket.send(encoded_packet)
 
             if not is_telemetry and self._telemetry:
                 self.packets_sent += 1
@@ -2079,7 +2084,7 @@ class DogStatsd(object):
         # Discard the locks that could have been locked at the time
         # when we forked. This may cause inconsistent internal state,
         # which we will fix in the next steps.
-        self._socket_lock = Lock()
+        self._socket_lock = RLock()
         self._buffer_lock = RLock()
 
         # Reset the buffer so we don't send metrics from the parent

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1668,28 +1668,29 @@ class DogStatsd(object):
 
     def _xmit_packet(self, packet, is_telemetry):
         # type: (str, bool) -> bool
+
+        if is_telemetry and self._dedicated_telemetry_destination():
+            uses_uds = self.telemetry_socket_path is not None
+        else:
+            uses_uds = self.socket_path is not None
+
         retry_deadline = None
-        if self.socket_connect_timeout and self.socket_connect_timeout > 0:
+        if uses_uds and self.socket_connect_timeout and self.socket_connect_timeout > 0:
             retry_deadline = time.time() + self.socket_connect_timeout
 
         backoff = UDS_CONNECT_RETRY_INITIAL_BACKOFF
         while True:
-            # Shrink the connect timeout passed down on every attempt to what's
-            # actually left of retry_deadline, so the UDS connect-retry loop
-            # inside get_socket() shares this loop's overall budget instead of
-            # getting a fresh full socket_connect_timeout allowance each time.
-            connect_timeout = self.socket_connect_timeout
-            if retry_deadline is not None:
-                connect_timeout = retry_deadline - time.time()
-                if connect_timeout <= 0:
-                    # The deadline already elapsed.
-                    log.warning(
-                        "Gave up reconnecting after socket_connect_timeout (%ss), dropping the packet",
-                        self.socket_connect_timeout,
-                    )
-                    break
+            # Cheap fast-path check before even trying to acquire _socket_lock:
+            # if the budget is already spent, don't bother contending for it.
+            if retry_deadline is not None and retry_deadline - time.time() <= 0:
+                log.warning(
+                    "Gave up reconnecting after socket_connect_timeout (%ss), dropping the packet",
+                    self.socket_connect_timeout,
+                )
+                break
+
             sent = self._xmit_packet_attempt(
-                packet, is_telemetry, retry_eligible=retry_deadline is not None, connect_timeout=connect_timeout
+                packet, is_telemetry, retry_eligible=retry_deadline is not None, retry_deadline=retry_deadline
             )
             if sent:
                 return True
@@ -1713,7 +1714,7 @@ class DogStatsd(object):
             self.packets_dropped_writer += 1
         return False
 
-    def _xmit_packet_attempt(self, packet, is_telemetry, retry_eligible, connect_timeout=None):
+    def _xmit_packet_attempt(self, packet, is_telemetry, retry_eligible, retry_deadline=None):
         # type: (str, bool, bool, Optional[float]) -> Optional[bool]
         """
         Attempt to send a single packet.
@@ -1722,12 +1723,31 @@ class DogStatsd(object):
         without retrying, or None if the failure is transient (the peer went
         away), `retry_eligible` is set, and it's worth a reconnect-and-retry.
 
-        :param connect_timeout: Optional override forwarded to get_socket(),
-            see its docstring.
+        :param retry_deadline: Optional absolute time.time()-based deadline
+            for the overall _xmit_packet retry operation. The connect_timeout
+            handed to get_socket() is computed from this only after
+            _socket_lock is actually acquired (not before), so time spent
+            waiting on a contended lock counts against the budget instead of
+            silently extending it.
         """
         socket_kind = None
         with self._socket_lock:
             try:
+                connect_timeout = self.socket_connect_timeout
+                if retry_deadline is not None:
+                    connect_timeout = retry_deadline - time.time()
+                    if connect_timeout <= 0:
+                        # The deadline elapsed while we were waiting to
+                        # acquire the lock -- give up rather than handing a
+                        # <= 0 connect_timeout to get_socket(), which treats
+                        # 0 as "no timeout configured" (unbounded), not
+                        # "already expired".
+                        log.warning(
+                            "Gave up reconnecting after socket_connect_timeout (%ss), dropping the packet",
+                            self.socket_connect_timeout,
+                        )
+                        return False
+
                 if is_telemetry and self._dedicated_telemetry_destination():
                     mysocket = self.telemetry_socket or self.get_socket(
                         telemetry=True, connect_timeout=connect_timeout

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1666,6 +1666,20 @@ class DogStatsd(object):
                 self.bytes_dropped_writer += len(telemetry)
                 self.packets_dropped_writer += 1
 
+    def _installed_socket(self, is_telemetry):
+        # type: (bool) -> Optional[_Socket]
+        """
+        The socket a send for this packet would use, if one is already installed.
+
+        Returns None when a fresh connection would have to be established, which
+        is the only situation where the socket_connect_timeout budget applies.
+        Callers that mean to gate on "would we have to connect?" must use this
+        rather than the deadline alone.
+        """
+        if is_telemetry and self._dedicated_telemetry_destination():
+            return self.telemetry_socket
+        return self.socket
+
     def _xmit_packet(self, packet, is_telemetry):
         # type: (str, bool) -> bool
 
@@ -1680,9 +1694,12 @@ class DogStatsd(object):
 
         backoff = UDS_CONNECT_RETRY_INITIAL_BACKOFF
         while True:
-            # Cheap fast-path check before even trying to acquire _socket_lock:
-            # if the budget is already spent, don't bother contending for it.
-            if retry_deadline is not None and retry_deadline - time.time() <= 0:
+            # Cheap fast-path check before even trying to acquire _socket_lock.
+            if (
+                retry_deadline is not None
+                and retry_deadline - time.time() <= 0
+                and not self._installed_socket(is_telemetry)
+            ):
                 log.warning(
                     "Gave up reconnecting after socket_connect_timeout (%ss), dropping the packet",
                     self.socket_connect_timeout,
@@ -1697,7 +1714,11 @@ class DogStatsd(object):
             # `sent` is False for a definitive failure (already logged/dropped
             # above), or None for a transient one that's worth reconnecting
             # and retrying, bounded by socket_connect_timeout.
-            if sent is not None:
+            #
+            # A None result implies retry_eligible, which implies a deadline was
+            # set; the explicit check keeps that invariant locally provable
+            # (for readers and for the type checker) instead of implicit.
+            if sent is not None or retry_deadline is None:
                 break
             remaining = retry_deadline - time.time()
             if remaining <= 0:
@@ -1733,15 +1754,15 @@ class DogStatsd(object):
         socket_kind = None
         with self._socket_lock:
             try:
+                # Captured under the lock, before the deadline check: whether a
+                # socket already exists decides whether that deadline is even
+                # relevant to this attempt.
+                existing_socket = self._installed_socket(is_telemetry)
+
                 connect_timeout = self.socket_connect_timeout
                 if retry_deadline is not None:
                     connect_timeout = retry_deadline - time.time()
-                    if connect_timeout <= 0:
-                        # The deadline elapsed while we were waiting to
-                        # acquire the lock -- give up rather than handing a
-                        # <= 0 connect_timeout to get_socket(), which treats
-                        # 0 as "no timeout configured" (unbounded), not
-                        # "already expired".
+                    if connect_timeout <= 0 and not existing_socket:
                         log.warning(
                             "Gave up reconnecting after socket_connect_timeout (%ss), dropping the packet",
                             self.socket_connect_timeout,
@@ -1749,13 +1770,13 @@ class DogStatsd(object):
                         return False
 
                 if is_telemetry and self._dedicated_telemetry_destination():
-                    mysocket = self.telemetry_socket or self.get_socket(
+                    mysocket = existing_socket or self.get_socket(
                         telemetry=True, connect_timeout=connect_timeout
                     )
                     socket_kind = self._telemetry_socket_kind
                 else:
                     # If set, use socket directly
-                    mysocket = self.socket or self.get_socket(connect_timeout=connect_timeout)
+                    mysocket = existing_socket or self.get_socket(connect_timeout=connect_timeout)
                     socket_kind = self._socket_kind
 
                 encoded_packet = packet.encode(self.encoding)

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -1657,7 +1657,8 @@ class DogStatsd(object):
 
     def _xmit_packet(self, packet, is_telemetry):
         # type: (str, bool) -> bool
-        return self._xmit_packet_attempt(packet, is_telemetry, retry_on_conn_error=True)
+        retry_on_conn_error = bool(self.socket_connect_timeout and self.socket_connect_timeout > 0)
+        return self._xmit_packet_attempt(packet, is_telemetry, retry_on_conn_error=retry_on_conn_error)
 
     def _xmit_packet_attempt(self, packet, is_telemetry, retry_on_conn_error):
         # type: (str, bool, bool) -> bool

--- a/datadog/dogstatsd/base.py
+++ b/datadog/dogstatsd/base.py
@@ -959,14 +959,23 @@ class DogStatsd(object):
 
         return get_default_route()
 
-    def get_socket(self, telemetry=False):
-        # type: (bool) -> _Socket
+    def get_socket(self, telemetry=False, connect_timeout=None):
+        # type: (bool, Optional[float]) -> _Socket
         """
         Return a connected socket.
 
         Note: connect the socket before assigning it to the class instance to
         avoid bad thread race conditions.
+
+        :param connect_timeout: Optional override for the UDS connect-retry
+            budget passed to _get_uds_socket, in place of
+            self.socket_connect_timeout. The send-retry loop in _xmit_packet
+            uses this to pass down how much of its overall deadline is left,
+            so a retried attempt doesn't get a brand-new full budget.
         """
+        if connect_timeout is None:
+            connect_timeout = self.socket_connect_timeout
+
         with self._socket_lock:
             if telemetry and self._dedicated_telemetry_destination():
                 if not self.telemetry_socket:
@@ -974,7 +983,7 @@ class DogStatsd(object):
                         self.telemetry_socket = self._get_uds_socket(
                             self.telemetry_socket_path,
                             self.telemetry_socket_timeout,
-                            self.socket_connect_timeout,
+                            connect_timeout,
                         )
                     else:
                         self.telemetry_socket = self._get_udp_socket(
@@ -990,7 +999,7 @@ class DogStatsd(object):
                     self.socket = self._get_uds_socket(
                         self.socket_path,
                         self.socket_timeout,
-                        self.socket_connect_timeout,
+                        connect_timeout,
                     )
                 else:
                     self.socket = self._get_udp_socket(
@@ -1665,7 +1674,16 @@ class DogStatsd(object):
 
         backoff = UDS_CONNECT_RETRY_INITIAL_BACKOFF
         while True:
-            sent = self._xmit_packet_attempt(packet, is_telemetry, retry_eligible=retry_deadline is not None)
+            # Shrink the connect timeout passed down on every attempt to what's
+            # actually left of retry_deadline, so the UDS connect-retry loop
+            # inside get_socket() shares this loop's overall budget instead of
+            # getting a fresh full socket_connect_timeout allowance each time.
+            connect_timeout = self.socket_connect_timeout
+            if retry_deadline is not None:
+                connect_timeout = max(0, retry_deadline - time.time())
+            sent = self._xmit_packet_attempt(
+                packet, is_telemetry, retry_eligible=retry_deadline is not None, connect_timeout=connect_timeout
+            )
             if sent:
                 return True
             # `sent` is False for a definitive failure (already logged/dropped
@@ -1688,27 +1706,29 @@ class DogStatsd(object):
             self.packets_dropped_writer += 1
         return False
 
-    def _xmit_packet_attempt(self, packet, is_telemetry, retry_eligible):
-        # type: (str, bool, bool) -> Optional[bool]
+    def _xmit_packet_attempt(self, packet, is_telemetry, retry_eligible, connect_timeout=None):
+        # type: (str, bool, bool, Optional[float]) -> Optional[bool]
         """
         Attempt to send a single packet.
 
         Returns True if the packet was sent, False if it should be dropped
         without retrying, or None if the failure is transient (the peer went
         away), `retry_eligible` is set, and it's worth a reconnect-and-retry.
+
+        :param connect_timeout: Optional override forwarded to get_socket(),
+            see its docstring.
         """
         socket_kind = None
-        try:
-            # Held across the fetch-and-send so a concurrent close_socket() (e.g.
-            # from another thread's failed send) can't close the fd out from
-            # under a send that's already in flight (which raises EBADF).
-            with self._socket_lock:
+        with self._socket_lock:
+            try:
                 if is_telemetry and self._dedicated_telemetry_destination():
-                    mysocket = self.telemetry_socket or self.get_socket(telemetry=True)
+                    mysocket = self.telemetry_socket or self.get_socket(
+                        telemetry=True, connect_timeout=connect_timeout
+                    )
                     socket_kind = self._telemetry_socket_kind
                 else:
                     # If set, use socket directly
-                    mysocket = self.socket or self.get_socket()
+                    mysocket = self.socket or self.get_socket(connect_timeout=connect_timeout)
                     socket_kind = self._socket_kind
 
                 encoded_packet = packet.encode(self.encoding)
@@ -1718,55 +1738,55 @@ class DogStatsd(object):
                 else:
                     mysocket.send(encoded_packet)
 
-            if not is_telemetry and self._telemetry:
-                self.packets_sent += 1
-                self.bytes_sent += len(packet)
+                if not is_telemetry and self._telemetry:
+                    self.packets_sent += 1
+                    self.bytes_sent += len(packet)
 
-            return True
-        except socket.timeout:
-            # dogstatsd is overflowing, drop the packets (mimics the UDP behaviour)
-            return False
-        except (socket.herror, socket.gaierror) as socket_err:
-            log.warning(
-                "Error submitting packet: %s, dropping the packet and closing the socket",
-                socket_err,
-            )
-            self.close_socket()
-            return False
-        except socket.error as socket_err:
-            if socket_err.errno == errno.EAGAIN:
-                log.debug("Socket send would block: %s, dropping the packet", socket_err)
-            elif socket_err.errno == errno.ENOBUFS:
-                log.debug("Socket buffer full: %s, dropping the packet", socket_err)
-            elif socket_err.errno == errno.EMSGSIZE:
-                log.debug(
-                    "Packet size too big (size: %d): %s, dropping the packet",
-                    len(packet.encode(self.encoding)),
-                    socket_err)
-            elif retry_eligible and socket_err.errno in UDS_TRANSIENT_SEND_ERRORS:
-                log.debug(
-                    "Connection error submitting packet: %s, reconnecting and retrying", socket_err
-                )
-                self.close_socket()
-                return None
-            else:
+                return True
+            except socket.timeout:
+                # dogstatsd is overflowing, drop the packets (mimics the UDP behaviour)
+                pass
+            except (socket.herror, socket.gaierror) as socket_err:
                 log.warning(
                     "Error submitting packet: %s, dropping the packet and closing the socket",
                     socket_err,
                 )
                 self.close_socket()
-            return False
-        except Exception as exc:
-            log.error("Unexpected error: %s", str(exc))
-            return False
+                return False
+            except socket.error as socket_err:
+                if socket_err.errno == errno.EAGAIN:
+                    log.debug("Socket send would block: %s, dropping the packet", socket_err)
+                elif socket_err.errno == errno.ENOBUFS:
+                    log.debug("Socket buffer full: %s, dropping the packet", socket_err)
+                elif socket_err.errno == errno.EMSGSIZE:
+                    log.debug(
+                        "Packet size too big (size: %d): %s, dropping the packet",
+                        len(packet.encode(self.encoding)),
+                        socket_err)
+                elif retry_eligible and socket_err.errno in UDS_TRANSIENT_SEND_ERRORS:
+                    log.debug(
+                        "Connection error submitting packet: %s, reconnecting and retrying", socket_err
+                    )
+                    self.close_socket()
+                    return None
+                else:
+                    log.warning(
+                        "Error submitting packet: %s, dropping the packet and closing the socket",
+                        socket_err,
+                    )
+                    self.close_socket()
+                pass
+            except Exception as exc:
+                log.error("Unexpected error: %s", str(exc))
+                return False
 
-        # if in stream mode we need to shut down the socket; we can't recover from a
-        # partial send
-        if socket_kind == socket.SOCK_STREAM:
-            log.debug("Confirming socket closure after error streaming")
-            self.close_socket()
+            # if in stream mode we need to shut down the socket; we can't recover from a
+            # partial send
+            if socket_kind == socket.SOCK_STREAM:
+                log.debug("Confirming socket closure after error streaming")
+                self.close_socket()
 
-        return False
+            return False
 
     def _send_to_buffer(self, packet):
         # type: (str) -> None

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -920,6 +920,39 @@ class TestDogStatsd(unittest.TestCase):
                 mock.ANY,
             )
 
+    @patch('datadog.dogstatsd.base.DogStatsd._get_udp_socket')
+    def test_socket_connection_error_reconnects_and_resends(self, mock_get_udp_socket):
+        working_socket = FakeSocket()
+        mock_get_udp_socket.return_value = working_socket
+        self.statsd.socket = BrokenSocket(error_number=errno.ECONNREFUSED)
+
+        with mock.patch("datadog.dogstatsd.base.log") as mock_log:
+            self.statsd.gauge('reconnected', 1)
+            self.statsd.flush()
+
+            mock_log.error.assert_not_called()
+            mock_log.warning.assert_not_called()
+
+        # The packet was not dropped: it was resent once a fresh socket was obtained.
+        mock_get_udp_socket.assert_called_once()
+        self.assertEqual(self.statsd.packets_dropped_writer, 0)
+        self.assertEqual(working_socket.payloads[0].decode('utf-8'), 'reconnected:1|g\n')
+
+    def test_socket_connection_error_drops_packet_if_reconnect_also_fails(self):
+        self.statsd.socket = BrokenSocket(error_number=errno.ECONNREFUSED)
+
+        with mock.patch.object(
+            DogStatsd, '_get_udp_socket', side_effect=socket.error(errno.ECONNREFUSED, "still refused")
+        ):
+            with mock.patch("datadog.dogstatsd.base.log") as mock_log:
+                self.statsd.gauge('no error', 1)
+                self.statsd.flush()
+
+                mock_log.error.assert_not_called()
+
+        # Both the metric and the telemetry flush hit the same broken reconnect and get dropped.
+        self.assertEqual(self.statsd.packets_dropped_writer, 2)
+
     def test_socket_overflown(self):
         self.statsd.socket = OverflownSocket()
         with mock.patch("datadog.dogstatsd.base.log") as mock_log:

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -940,7 +940,8 @@ class TestDogStatsd(unittest.TestCase):
         self.assertEqual(working_socket.payloads[0].decode('utf-8'), 'reconnected:1|g\n')
 
     def test_socket_connection_error_drops_packet_if_reconnect_also_fails(self):
-        self.statsd.socket_connect_timeout = 5
+        # Small deadline so the retry loop gives up quickly in the test.
+        self.statsd.socket_connect_timeout = 0.05
         self.statsd.socket = BrokenSocket(error_number=errno.ECONNREFUSED)
 
         with mock.patch.object(
@@ -952,8 +953,31 @@ class TestDogStatsd(unittest.TestCase):
 
                 mock_log.error.assert_not_called()
 
-        # Both the metric and the telemetry flush hit the same broken reconnect and get dropped.
+        # Both the metric and the telemetry flush hit the same broken reconnect and get dropped
+        # once the retry deadline is exhausted.
         self.assertEqual(self.statsd.packets_dropped_writer, 2)
+
+    @patch('datadog.dogstatsd.base.DogStatsd._get_udp_socket')
+    def test_socket_connection_error_retries_multiple_times_before_success(self, mock_get_udp_socket):
+        working_socket = FakeSocket()
+        mock_get_udp_socket.side_effect = [
+            socket.error(errno.ECONNREFUSED, "still refused"),
+            socket.error(errno.ECONNREFUSED, "still refused"),
+            working_socket,
+        ]
+        # Long enough to cover a few backoff sleeps well under a second.
+        self.statsd.socket_connect_timeout = 5
+        self.statsd.socket = BrokenSocket(error_number=errno.ECONNREFUSED)
+
+        with mock.patch("datadog.dogstatsd.base.log") as mock_log:
+            self.statsd.gauge('reconnected after retries', 1)
+
+            mock_log.warning.assert_not_called()
+
+        # Two failed reconnect attempts, then a third that finally succeeds.
+        self.assertEqual(mock_get_udp_socket.call_count, 3)
+        self.assertEqual(self.statsd.packets_dropped_writer, 0)
+        self.assertTrue(working_socket.payloads[0].decode('utf-8').startswith('reconnected after retries:1|g'))
 
     def test_socket_connection_error_does_not_retry_without_connect_timeout(self):
         # socket_connect_timeout defaults to 0 (unset): no reconnect attempt should be made

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -979,6 +979,38 @@ class TestDogStatsd(unittest.TestCase):
         self.assertEqual(self.statsd.packets_dropped_writer, 0)
         self.assertTrue(working_socket.payloads[0].decode('utf-8').startswith('reconnected after retries:1|g'))
 
+    def test_close_socket_waits_for_in_flight_send(self):
+        # A concurrent close_socket() (e.g. triggered by another thread's failed
+        # send) must not be able to close the fd out from under a send that's
+        # already in flight - that races and can raise EBADF.
+        send_started = threading.Event()
+        release_send = threading.Event()
+
+        class SlowSocket(FakeSocket):
+            def send(self, payload):
+                send_started.set()
+                release_send.wait(2)
+
+        self.statsd.socket = SlowSocket()
+
+        sender_thread = Thread(target=lambda: self.statsd.gauge('foo', 1))
+        sender_thread.start()
+        self.assertTrue(send_started.wait(2), "send did not start in time")
+
+        closer_thread = Thread(target=self.statsd.close_socket)
+        closer_thread.start()
+        # Give closer_thread a chance to call close_socket() and block on it.
+        time.sleep(0.1)
+
+        # The in-flight send still holds _socket_lock, so close_socket() must
+        # still be waiting on it here rather than having already closed the socket.
+        self.assertTrue(closer_thread.is_alive())
+
+        release_send.set()
+        sender_thread.join(2)
+        closer_thread.join(2)
+        self.assertFalse(closer_thread.is_alive())
+
     def test_socket_connection_error_does_not_retry_without_connect_timeout(self):
         # socket_connect_timeout defaults to 0 (unset): no reconnect attempt should be made
         # for this packet, it should be dropped immediately instead.

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -924,6 +924,7 @@ class TestDogStatsd(unittest.TestCase):
     def test_socket_connection_error_reconnects_and_resends(self, mock_get_udp_socket):
         working_socket = FakeSocket()
         mock_get_udp_socket.return_value = working_socket
+        self.statsd.socket_connect_timeout = 5
         self.statsd.socket = BrokenSocket(error_number=errno.ECONNREFUSED)
 
         with mock.patch("datadog.dogstatsd.base.log") as mock_log:
@@ -939,6 +940,7 @@ class TestDogStatsd(unittest.TestCase):
         self.assertEqual(working_socket.payloads[0].decode('utf-8'), 'reconnected:1|g\n')
 
     def test_socket_connection_error_drops_packet_if_reconnect_also_fails(self):
+        self.statsd.socket_connect_timeout = 5
         self.statsd.socket = BrokenSocket(error_number=errno.ECONNREFUSED)
 
         with mock.patch.object(
@@ -952,6 +954,25 @@ class TestDogStatsd(unittest.TestCase):
 
         # Both the metric and the telemetry flush hit the same broken reconnect and get dropped.
         self.assertEqual(self.statsd.packets_dropped_writer, 2)
+
+    def test_socket_connection_error_does_not_retry_without_connect_timeout(self):
+        # socket_connect_timeout defaults to 0 (unset): no reconnect attempt should be made
+        # for this packet, it should be dropped immediately instead.
+        self.assertEqual(self.statsd.socket_connect_timeout, 0)
+        broken_socket = BrokenSocket(error_number=errno.ECONNREFUSED)
+        self.statsd.socket = broken_socket
+
+        with mock.patch.object(broken_socket, 'send', wraps=broken_socket.send) as mock_send:
+            with mock.patch("datadog.dogstatsd.base.log") as mock_log:
+                self.statsd.gauge('not reconnected', 1)
+
+                mock_log.warning.assert_called_once_with(
+                    "Error submitting packet: %s, dropping the packet and closing the socket",
+                    mock.ANY,
+                )
+
+            # Only one send attempt was made on the broken socket: no reconnect-and-resend.
+            mock_send.assert_called_once()
 
     def test_socket_overflown(self):
         self.statsd.socket = OverflownSocket()

--- a/tests/unit/dogstatsd/test_statsd.py
+++ b/tests/unit/dogstatsd/test_statsd.py
@@ -920,64 +920,181 @@ class TestDogStatsd(unittest.TestCase):
                 mock.ANY,
             )
 
-    @patch('datadog.dogstatsd.base.DogStatsd._get_udp_socket')
-    def test_socket_connection_error_reconnects_and_resends(self, mock_get_udp_socket):
+    def _uds_statsd(self, connect_timeout):
+        """
+        A UDS-backed client whose current socket is already broken.
+
+        The reconnect-and-retry path in _xmit_packet is deliberately scoped to
+        UDS only, so these tests must not use the default UDP client.
+        """
+        statsd = DogStatsd(socket_path='/tmp/dogstatsd-test.sock', telemetry_min_flush_interval=0)
+        statsd.socket_connect_timeout = connect_timeout
+        statsd.socket = BrokenSocket(error_number=errno.ECONNREFUSED)
+        statsd._reset_telemetry()
+        return statsd
+
+    @patch('datadog.dogstatsd.base.DogStatsd._get_uds_socket')
+    def test_socket_connection_error_reconnects_and_resends(self, mock_get_uds_socket):
         working_socket = FakeSocket()
-        mock_get_udp_socket.return_value = working_socket
-        self.statsd.socket_connect_timeout = 5
-        self.statsd.socket = BrokenSocket(error_number=errno.ECONNREFUSED)
+        mock_get_uds_socket.return_value = working_socket
+        statsd = self._uds_statsd(connect_timeout=5)
 
         with mock.patch("datadog.dogstatsd.base.log") as mock_log:
-            self.statsd.gauge('reconnected', 1)
-            self.statsd.flush()
+            statsd.gauge('reconnected', 1)
+            statsd.flush()
 
             mock_log.error.assert_not_called()
             mock_log.warning.assert_not_called()
 
         # The packet was not dropped: it was resent once a fresh socket was obtained.
-        mock_get_udp_socket.assert_called_once()
-        self.assertEqual(self.statsd.packets_dropped_writer, 0)
+        mock_get_uds_socket.assert_called_once()
+        self.assertEqual(statsd.packets_dropped_writer, 0)
         self.assertEqual(working_socket.payloads[0].decode('utf-8'), 'reconnected:1|g\n')
 
     def test_socket_connection_error_drops_packet_if_reconnect_also_fails(self):
         # Small deadline so the retry loop gives up quickly in the test.
-        self.statsd.socket_connect_timeout = 0.05
-        self.statsd.socket = BrokenSocket(error_number=errno.ECONNREFUSED)
+        statsd = self._uds_statsd(connect_timeout=0.05)
 
         with mock.patch.object(
-            DogStatsd, '_get_udp_socket', side_effect=socket.error(errno.ECONNREFUSED, "still refused")
+            DogStatsd, '_get_uds_socket', side_effect=socket.error(errno.ECONNREFUSED, "still refused")
         ):
             with mock.patch("datadog.dogstatsd.base.log") as mock_log:
-                self.statsd.gauge('no error', 1)
-                self.statsd.flush()
+                statsd.gauge('no error', 1)
+                statsd.flush()
 
                 mock_log.error.assert_not_called()
 
         # Both the metric and the telemetry flush hit the same broken reconnect and get dropped
         # once the retry deadline is exhausted.
-        self.assertEqual(self.statsd.packets_dropped_writer, 2)
+        self.assertEqual(statsd.packets_dropped_writer, 2)
 
-    @patch('datadog.dogstatsd.base.DogStatsd._get_udp_socket')
-    def test_socket_connection_error_retries_multiple_times_before_success(self, mock_get_udp_socket):
+    @patch('datadog.dogstatsd.base.DogStatsd._get_uds_socket')
+    def test_socket_connection_error_retries_multiple_times_before_success(self, mock_get_uds_socket):
         working_socket = FakeSocket()
-        mock_get_udp_socket.side_effect = [
+        mock_get_uds_socket.side_effect = [
             socket.error(errno.ECONNREFUSED, "still refused"),
             socket.error(errno.ECONNREFUSED, "still refused"),
             working_socket,
         ]
         # Long enough to cover a few backoff sleeps well under a second.
-        self.statsd.socket_connect_timeout = 5
-        self.statsd.socket = BrokenSocket(error_number=errno.ECONNREFUSED)
+        statsd = self._uds_statsd(connect_timeout=5)
 
         with mock.patch("datadog.dogstatsd.base.log") as mock_log:
-            self.statsd.gauge('reconnected after retries', 1)
+            statsd.gauge('reconnected after retries', 1)
 
             mock_log.warning.assert_not_called()
 
         # Two failed reconnect attempts, then a third that finally succeeds.
-        self.assertEqual(mock_get_udp_socket.call_count, 3)
-        self.assertEqual(self.statsd.packets_dropped_writer, 0)
+        self.assertEqual(mock_get_uds_socket.call_count, 3)
+        self.assertEqual(statsd.packets_dropped_writer, 0)
         self.assertTrue(working_socket.payloads[0].decode('utf-8').startswith('reconnected after retries:1|g'))
+
+    def test_socket_connection_error_does_not_retry_for_udp(self):
+        # Reconnect-and-retry is UDS-only: a UDP client drops the packet on a
+        # transient connection error even when socket_connect_timeout is set.
+        self.statsd.socket_connect_timeout = 5
+        broken_socket = BrokenSocket(error_number=errno.ECONNREFUSED)
+        self.statsd.socket = broken_socket
+
+        with mock.patch.object(broken_socket, 'send', wraps=broken_socket.send) as mock_send:
+            with mock.patch("datadog.dogstatsd.base.log") as mock_log:
+                self.statsd.gauge('not reconnected', 1)
+
+                mock_log.error.assert_not_called()
+                mock_log.warning.assert_called_once_with(
+                    "Error submitting packet: %s, dropping the packet and closing the socket",
+                    mock.ANY,
+                )
+
+            # No reconnect-and-resend: a single send attempt, then dropped.
+            mock_send.assert_called_once()
+
+    @patch('datadog.dogstatsd.base.DogStatsd._get_uds_socket')
+    def test_expired_deadline_sends_on_socket_installed_by_another_thread(self, mock_get_uds_socket):
+        # socket_connect_timeout budgets *connecting*. If another thread already
+        # installed a healthy socket while this one waited for _socket_lock, the
+        # spent budget is irrelevant: sending on it does no connecting, so the
+        # packet must not be dropped at the moment of recovery.
+        statsd = self._uds_statsd(connect_timeout=5)
+        working_socket = FakeSocket()
+        statsd.socket = working_socket
+
+        with mock.patch("datadog.dogstatsd.base.log") as mock_log:
+            sent = statsd._xmit_packet_attempt(
+                'recovered:1|g\n',
+                is_telemetry=False,
+                retry_eligible=True,
+                retry_deadline=time.time() - 1,  # budget consumed while waiting for the lock
+            )
+
+            self.assertTrue(sent)
+            mock_log.warning.assert_not_called()
+
+        # The installed socket was used as-is; no connect was attempted.
+        mock_get_uds_socket.assert_not_called()
+        self.assertEqual(working_socket.payloads[0].decode('utf-8'), 'recovered:1|g\n')
+
+    @patch('datadog.dogstatsd.base.DogStatsd._get_uds_socket')
+    def test_expired_deadline_drops_when_a_connect_would_be_needed(self, mock_get_uds_socket):
+        # The complement of the case above, and the reason the guard exists at
+        # all: with no socket installed, an expired budget must not reach
+        # get_socket(), which treats a <= 0 connect_timeout as "unbounded".
+        statsd = self._uds_statsd(connect_timeout=5)
+        statsd.socket = None
+
+        with mock.patch("datadog.dogstatsd.base.log") as mock_log:
+            sent = statsd._xmit_packet_attempt(
+                'dropped:1|g\n',
+                is_telemetry=False,
+                retry_eligible=True,
+                retry_deadline=time.time() - 1,
+            )
+
+            self.assertFalse(sent)
+            mock_log.warning.assert_called_once_with(
+                "Gave up reconnecting after socket_connect_timeout (%ss), dropping the packet",
+                5,
+            )
+
+        mock_get_uds_socket.assert_not_called()
+
+    def test_concurrent_reconnect_does_not_drop_backlog_after_recovery(self):
+        # End-to-end ordering: thread A reconnects slowly while holding
+        # _socket_lock; B queues behind it and has its entire connect budget
+        # consumed by the wait. Once A installs a healthy socket, B must send on
+        # it rather than discard its packet.
+        statsd = self._uds_statsd(connect_timeout=0.2)
+        working_socket = FakeSocket()
+
+        a_is_connecting = threading.Event()
+        release_connect = threading.Event()
+
+        def slow_connect(*args, **kwargs):
+            a_is_connecting.set()
+            release_connect.wait(5)
+            return working_socket
+
+        with mock.patch.object(DogStatsd, '_get_uds_socket', side_effect=slow_connect):
+            thread_a = Thread(target=lambda: statsd.gauge('from-a', 1))
+            thread_a.start()
+            self.assertTrue(a_is_connecting.wait(5), "A never reached the connect")
+
+            thread_b = Thread(target=lambda: statsd.gauge('from-b', 1))
+            thread_b.start()
+
+            # Let B's whole 0.2s budget elapse while it blocks on _socket_lock,
+            # then let A's connect succeed and install the socket.
+            time.sleep(0.5)
+            release_connect.set()
+
+            thread_a.join(5)
+            thread_b.join(5)
+            self.assertFalse(thread_a.is_alive())
+            self.assertFalse(thread_b.is_alive())
+
+        payloads = [payload.decode('utf-8') for payload in working_socket.payloads]
+        self.assertTrue(any('from-a' in payload for payload in payloads), payloads)
+        self.assertTrue(any('from-b' in payload for payload in payloads), payloads)
 
     def test_close_socket_waits_for_in_flight_send(self):
         # A concurrent close_socket() (e.g. triggered by another thread's failed


### PR DESCRIPTION
### What does this PR do?

Retries reconnecting and resending a payload on send errors socket error.

### Description of the Change

On transient send errors  - `errno.ECONNREFUSED`, `errno.ECONNRESET`, `errno.ENOTCONN`, `errno.EPIPE`, `errno.ENOENT`, close the socket and attempt  to resend. We only attempt resending once to avoid getting stuck in a loop if the agent doesn't come back beyond the `socket_connect_timeout`. 


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/datadogpy/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

